### PR TITLE
Audit and correct the safety proof

### DIFF
--- a/linera-chain/src/data_types/proof/objects.rs
+++ b/linera-chain/src/data_types/proof/objects.rs
@@ -89,6 +89,11 @@ pub trait SignedProposal {}
 /// the [`JustificationChain`] its wrapper carries. The three instantiations are
 /// [`ValidatedBlockCertificate`], [`ConfirmedBlockCertificate`] and [`TimeoutCertificate`].
 ///
+/// The names invite a conflation worth pre-empting: [`ConfirmedBlock`] and [`ValidatedBlock`] are
+/// the certified *values*, wrappers around a [`Block`] carrying no signatures. Their names record
+/// the role the value plays — the thing `Confirmed` or `Validated` votes are cast on — not a
+/// property the value can attest to. Confirmation lives in the certificate.
+///
 /// A certificate is **valid for a committee** when [`LiteCertificate::check`] returns `Ok` for
 /// it. Both block certificate types delegate their `check` to that one function, so it is the
 /// single place where a certificate's signatures, its justification chain, and the binding
@@ -100,6 +105,9 @@ pub trait SignedProposal {}
 /// [`JustificationChain`]: crate::justification::JustificationChain
 /// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
 /// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
+/// [`ConfirmedBlock`]: crate::block::ConfirmedBlock
+/// [`ValidatedBlock`]: crate::block::ValidatedBlock
+/// [`Block`]: crate::block::Block
 /// [`TimeoutCertificate`]: crate::types::TimeoutCertificate
 /// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
 /// [`CertificateEmbedsQuorum`]: super::quorum::CertificateEmbedsQuorum

--- a/linera-chain/src/data_types/proof/objects.rs
+++ b/linera-chain/src/data_types/proof/objects.rs
@@ -89,27 +89,24 @@ pub trait SignedProposal {}
 /// the [`JustificationChain`] its wrapper carries. The three instantiations are
 /// [`ValidatedBlockCertificate`], [`ConfirmedBlockCertificate`] and [`TimeoutCertificate`].
 ///
-/// The names invite a conflation worth pre-empting: [`ConfirmedBlock`] and [`ValidatedBlock`] are
-/// the certified *values*, wrappers around a [`Block`] carrying no signatures. Their names record
-/// the role the value plays — the thing `Confirmed` or `Validated` votes are cast on — not a
-/// property the value can attest to. Confirmation lives in the certificate.
-///
-/// A certificate is **valid for a committee** when [`LiteCertificate::check`] returns `Ok` for
-/// it. Both block certificate types delegate their `check` to that one function, so it is the
-/// single place where a certificate's signatures, its justification chain, and the binding
-/// between the two are verified. Unless said otherwise, "certificate" in this specification
+/// A certificate is **valid for a committee** when its `check` returns `Ok`. Both block
+/// certificate types delegate to [`LiteCertificate::check`], which verifies the signatures, the
+/// justification chain, and the binding between the two; [`TimeoutCertificate`], being a
+/// [`GenericCertificate`] alias, uses [`GenericCertificate::check`], which verifies the
+/// signatures and carries no chain. Unless said otherwise, "certificate" in this specification
 /// means one that is valid for the committee of its epoch; what that buys us is
-/// [`CertificateEmbedsQuorum`] and [`CertificateCarriesCorrectVote`].
+/// [`CertificateEmbedsQuorum`], [`CertificateSignaturesVerify`] and
+/// [`CertificateCarriesCorrectVote`].
 ///
 /// [`GenericCertificate<T>`]: crate::types::GenericCertificate
 /// [`JustificationChain`]: crate::justification::JustificationChain
 /// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
 /// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
-/// [`ConfirmedBlock`]: crate::block::ConfirmedBlock
-/// [`ValidatedBlock`]: crate::block::ValidatedBlock
-/// [`Block`]: crate::block::Block
 /// [`TimeoutCertificate`]: crate::types::TimeoutCertificate
 /// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
+/// [`GenericCertificate`]: crate::types::GenericCertificate
+/// [`GenericCertificate::check`]: crate::types::GenericCertificate::check
+/// [`CertificateSignaturesVerify`]: super::quorum::CertificateSignaturesVerify
 /// [`CertificateEmbedsQuorum`]: super::quorum::CertificateEmbedsQuorum
 /// [`CertificateCarriesCorrectVote`]: super::quorum::CertificateCarriesCorrectVote
 pub trait Certificate {}

--- a/linera-chain/src/data_types/proof/quorum.rs
+++ b/linera-chain/src/data_types/proof/quorum.rs
@@ -72,21 +72,30 @@ pub trait Intersection: ThresholdArithmetic {}
 /// intersection cannot consist of faulty validators alone. ∎
 pub trait CorrectValidatorInIntersection: Intersection + MaxByzantineWeight {}
 
-/// **Lemma (A valid certificate embeds a quorum).** If [`LiteCertificate::check`] returns `Ok`
-/// for a certificate `c` against a committee, then the signers of `c.signatures` form a
-/// [`Quorum`] of that committee.
+/// **Lemma (A valid certificate embeds a quorum).** If a certificate `c` verifies against a
+/// committee, then the signers of `c.signatures` form a [`Quorum`] of that committee.
 ///
-/// *Proof.* [`LiteCertificate::check`] passes `c.signatures` to the crate-private helper
-/// `check_signatures`, which (1) rejects a repeated signer with
+/// *Proof.* There are two verification entry points, and both funnel into the crate-private
+/// helper `check_signatures`: [`LiteCertificate::check`], which the two block certificate types
+/// delegate to, and [`GenericCertificate::check`], which is what a
+/// [`TimeoutCertificate`] — a type alias for `GenericCertificate<Timeout>` — resolves to. Each
+/// builds the same [`SignedVotePayload`] and passes it with `c.signatures` to that helper, which
+/// (1) rejects a repeated signer with
 /// [`ChainError::CertificateValidatorReuse`], establishing pairwise distinctness; (2) rejects any
 /// signer whose [`Committee::weight`] is `0` with [`ChainError::InvalidSigner`], establishing
 /// committee membership; and (3) accumulates the signers' weights and rejects a total below
 /// [`Committee::quorum_threshold`] with [`ChainError::CertificateRequiresQuorum`], establishing
-/// `w(S) ≥ q`. Those three are precisely [`Quorum`]. ∎
+/// `w(S) ≥ q`. Those three are precisely [`Quorum`]. The accumulation cannot overflow: step (1)
+/// establishes distinctness before step (3) adds, so the total is bounded by the committee's own
+/// `total_votes`, which [`Committee::new`] rejects on overflow. ∎
 ///
 /// The signatures themselves are [`CertificateSignaturesVerify`].
 ///
 /// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
+/// [`GenericCertificate::check`]: crate::types::GenericCertificate::check
+/// [`TimeoutCertificate`]: crate::types::TimeoutCertificate
+/// [`SignedVotePayload`]: super::objects::SignedVotePayload
+/// [`Committee::new`]: linera_execution::committee::Committee::new
 /// [`ChainError::CertificateValidatorReuse`]: crate::ChainError::CertificateValidatorReuse
 /// [`ChainError::InvalidSigner`]: crate::ChainError::InvalidSigner
 /// [`ChainError::CertificateRequiresQuorum`]: crate::ChainError::CertificateRequiresQuorum
@@ -94,17 +103,18 @@ pub trait CorrectValidatorInIntersection: Intersection + MaxByzantineWeight {}
 /// [`Committee::quorum_threshold`]: linera_execution::committee::Committee::quorum_threshold
 pub trait CertificateEmbedsQuorum {}
 
-/// **Lemma (Every signature on a valid certificate verifies).** If [`LiteCertificate::check`]
-/// returns `Ok` for a certificate `c`, then *each individual* signer of `c.signatures` holds a
-/// signature that verifies over the single [`SignedVotePayload`]
+/// **Lemma (Every signature on a valid certificate verifies).** If a certificate `c` verifies
+/// against a committee — through either entry point named in [`CertificateEmbedsQuorum`] — then
+/// *each individual* signer of `c.signatures` holds a signature that verifies over the single
+/// [`SignedVotePayload`]
 ///
 /// ```text
 /// (c.value.value_hash, c.round, c.value.kind, c.unlocking_round, c.first_round,
 ///  c.justification_commitment)
 /// ```
 ///
-/// *Proof.* [`LiteCertificate::check`] constructs exactly that
-/// [`VoteValue`](crate::data_types::VoteValue) and passes it, with `c.signatures`, to
+/// *Proof.* Both entry points construct exactly that
+/// [`VoteValue`](crate::data_types::VoteValue) and pass it, with `c.signatures`, to
 /// `check_signatures`, whose final step calls `ValidatorSignature::verify_batch` and propagates
 /// any failure. For [`ValidatorSignature`] — an alias of `Secp256k1Signature` — that function is
 /// a loop of individual verifications returning on the first failure:

--- a/linera-chain/src/manager/proof/commit.rs
+++ b/linera-chain/src/manager/proof/commit.rs
@@ -60,13 +60,20 @@ pub trait CommitRestsOnValidation:
 /// epoch.
 ///
 /// *Proof.* The tip register is advanced in one place in `linera_chain::chain`, at the end of
-/// the private `ChainStateView::apply_confirmed_block` (`tip.next_block_height.
-/// try_add_assign_one()`), reached only from `ChainWorkerState::execute_contiguous_block` and
-/// `execute_block_with_checkpoint_restore`. Both are reached only through
+/// [`ChainStateView::apply_confirmed_block`] (`tip.next_block_height.try_add_assign_one()`).
+/// That method has a single call site in the workspace outside tests, in
+/// `ChainWorkerState::execute_contiguous_block`; `execute_block_with_checkpoint_restore` reaches
+/// it by delegating there after installing the snapshot. Both are reached only through
 /// `ChainWorkerState::process_confirmed_block`, whose every non-early-return path first
 /// evaluates `certificate.check(&committee)?` with `committee` fetched for `block.header.epoch`.
 /// The early returns — the `tip.next_block_height > height` skip and the `Preprocess` dispatch —
 /// do not advance the tip. ∎
+///
+/// **Where this is fragile.** [`ChainStateView::apply_confirmed_block`] is `pub`, on a type this
+/// crate re-exports, and it takes a [`ConfirmedBlock`] and no [`Committee`] — so it cannot verify
+/// anything, and nothing about its signature confines it to verified callers. The enumeration
+/// above holds by current usage, not by visibility. A new caller must perform the certificate
+/// check itself.
 ///
 /// Two paths deserve explicit mention because they weaken the *precondition* without weakening
 /// this lemma. `pre_checkpoint_block_trust` lets a hash recorded by an earlier checkpoint
@@ -77,6 +84,9 @@ pub trait CommitRestsOnValidation:
 ///
 /// [`ChainTipState::next_block_height`]: crate::ChainTipState::next_block_height
 /// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
+/// [`ConfirmedBlock`]: crate::block::ConfirmedBlock
+/// [`ChainStateView::apply_confirmed_block`]: crate::ChainStateView::apply_confirmed_block
+/// [`Committee`]: linera_execution::committee::Committee
 /// [`check`]: crate::types::ConfirmedBlockCertificate::check
 pub trait TipAdvancesOnlyOnValidCertificate {}
 

--- a/linera-chain/src/manager/proof/locking.rs
+++ b/linera-chain/src/manager/proof/locking.rs
@@ -46,7 +46,7 @@ use crate::{
         CorrectValidatorInIntersection,
     },
     manager::proof::{
-        model::{ConsensusInstance, DurablePersistence, EpochAgreement},
+        model::{ConsensusInstance, DurablePersistence, EpochAgreement, SerializedChainState},
         rounds::{CurrentRoundMonotone, RoundFloor, VoteRoundBelowCurrentRound},
         voting::{
             ConfirmationNeedsValidatedCertificate, ConfirmationOnlyInCurrentRound,
@@ -208,7 +208,11 @@ pub trait CastValidationRoundFloor:
 /// [`Outcome::Skip`]: crate::manager::Outcome::Skip
 /// [`SerializedChainState`]: crate::manager::proof::model::SerializedChainState
 pub trait OneValidationVotePerRound:
-    ProposalGate + CastValidationRoundFloor + ValidationRoundStrictlyIncreases + DurablePersistence
+    ProposalGate
+    + CastValidationRoundFloor
+    + ValidationRoundStrictlyIncreases
+    + DurablePersistence
+    + SerializedChainState
 {
 }
 
@@ -264,6 +268,7 @@ pub trait OneConfirmationVotePerRound:
     + LockRoundMonotone
     + RoundFloor
     + DurablePersistence
+    + SerializedChainState
 {
 }
 

--- a/linera-chain/src/manager/proof/model.rs
+++ b/linera-chain/src/manager/proof/model.rs
@@ -118,11 +118,24 @@ pub trait MaxByzantineWeight {}
 ///
 /// This is what makes [`Intersection`] applicable to two certificates for the same height: two
 /// quorums of *different* committees need not intersect at all. It is close to enforced rather
-/// than assumed. A proposal is rejected unless `check_block_epoch` finds
-/// [`ProposedBlock::epoch`] equal to the chain's current epoch, and
-/// `ChainWorkerState::process_validated_block` and `process_confirmed_block` apply the same
-/// check to the certified block before verifying signatures against that epoch's committee. The
-/// chain's current epoch at height `h` is a function of the committed blocks below `h`, which
+/// than assumed, by two different mechanisms.
+///
+/// *Which committee judges a certificate* is a function of the block's own declared epoch, not of
+/// the judging node's state: `ChainWorkerState::process_confirmed_block` fetches
+/// `committee_for_epoch(block.header.epoch)` and verifies the certificate against that committee.
+/// Since [`ProposedBlock::epoch`] is covered by the block hash, two correct validators never
+/// disagree about which committee a given certificate is judged by. This is what the assumption
+/// needs, and it is unconditional.
+///
+/// *That the epoch is also the chain's current one* is enforced separately, by `check_block_epoch`,
+/// at three sites: `try_handle_block_proposal` before voting, `process_validated_block` before
+/// verifying the certificate, and `execute_contiguous_block` before applying a confirmed block.
+/// Note it is **not** applied in `process_confirmed_block` itself — deliberately, since a node
+/// catching up must accept certificates from earlier epochs — so a merely *preprocessed* block is
+/// never epoch-checked in this sense, which is consistent with preprocessing not advancing the tip
+/// ([`TipAdvancesOnlyOnValidCertificate`]).
+///
+/// The chain's current epoch at height `h` is a function of the committed blocks below `h`, which
 /// [`UniqueChain`] shows is unique — so the assumption is discharged for height `h` by the
 /// agreement result at heights below `h`, and the induction in [`UniqueChain`] is what makes
 /// that non-circular.
@@ -134,6 +147,7 @@ pub trait MaxByzantineWeight {}
 /// [`ProposedBlock::epoch`]: crate::data_types::ProposedBlock::epoch
 /// [`Intersection`]: crate::data_types::proof::quorum::Intersection
 /// [`UniqueChain`]: crate::manager::proof::safety::UniqueChain
+/// [`TipAdvancesOnlyOnValidCertificate`]: crate::manager::proof::commit::TipAdvancesOnlyOnValidCertificate
 pub trait EpochAgreement {}
 
 /// **Assumption (Cryptographic soundness).** [`ValidatorSignature`] is existentially unforgeable:

--- a/linera-chain/src/manager/proof/rounds.rs
+++ b/linera-chain/src/manager/proof/rounds.rs
@@ -115,6 +115,10 @@ pub trait CurrentRoundMonotone: RoundFloor + ConsensusInstance {}
 /// [`RoundOrder`]: crate::manager::proof::model::RoundOrder
 /// [`ConfirmationOnlyInCurrentRound`]: crate::manager::proof::voting::ConfirmationOnlyInCurrentRound
 pub trait VoteRoundBelowCurrentRound:
-    VoteConstructionSites + ProposalGate + RoundFloor + CurrentRoundMonotone
+    VoteConstructionSites
+    + ProposalGate
+    + RoundFloor
+    + CurrentRoundMonotone
+    + crate::manager::proof::voting::ConfirmationOnlyInCurrentRound
 {
 }

--- a/linera-chain/src/manager/proof/safety.rs
+++ b/linera-chain/src/manager/proof/safety.rs
@@ -27,8 +27,8 @@ use crate::{
         model::{ConflictingBlocks, DeterministicExecution, EpochAgreement},
         rounds::{CurrentRoundMonotone, VoteRoundBelowCurrentRound},
         voting::{
-            ConfirmationNeedsValidatedCertificate, FastConfirmationNeedsEmptyLock,
-            UnlockingRequiresHigherCertificate,
+            ConfirmationNeedsValidatedCertificate, ConfirmationOnlyInCurrentRound,
+            FastConfirmationNeedsEmptyLock, UnlockingRequiresHigherCertificate,
         },
     },
 };
@@ -168,6 +168,8 @@ pub trait LockPreservation:
     + CastValidationRoundFloor
     + FastConfirmationNeedsEmptyLock
     + ConfirmationNeedsValidatedCertificate
+    + ConfirmationOnlyInCurrentRound
+    + UnlockingRequiresHigherCertificate
     + VoteRoundBelowCurrentRound
     + CurrentRoundMonotone
     + CorrectValidatorInIntersection


### PR DESCRIPTION
## Motivation

A systematic audit of the safety proof, and the corrections it turned up.

`CommitAgreement`'s transitive dependency closure is **41 of the 98 statements**, in 8 layers, 15 of them leaves — computed from the DAG rather than guessed, which makes the scope finite and orderable. Every statement in that closure was audited, in dependency order, against the code it claims about.

**Eight findings. None is a soundness hole**; every conclusion in the proof still stands. All eight are the same underlying thing — a statement that does not quite say what its users need — which is the failure mode this scheme is meant to make impossible and does not.

## Findings and fixes

**1. Two certificate lemmas were scoped to the wrong entry point.** `CertificateEmbedsQuorum` and `CertificateSignaturesVerify` both said *"If `LiteCertificate::check` returns `Ok`…"*. But `TimeoutCertificate` is a type alias for `GenericCertificate<Timeout>`, so its `check` resolves to `GenericCertificate::check`, which calls `check_signatures` directly and never goes through `LiteCertificate::check`. `pacemaker::TimeoutCertificateProvesRoundReached` and `SingleLeaderRoundsNeedTimeout` were applying both lemmas outside their stated scope. Restated to name both entry points.

**2. The same error in `objects::Certificate`,** which called `LiteCertificate::check` *"the single place where a certificate's signatures … are verified"*. Corrected to name both paths and what each covers.

**3. `apply_confirmed_block` is not private.** `TipAdvancesOnlyOnValidCertificate` called it *"the private `ChainStateView::apply_confirmed_block`"*. It is `pub`, on a type this crate re-exports, and takes a `&ConfirmedBlock` and no `Committee` — so it cannot verify anything, and nothing in its signature confines it to verified callers. Added a fragility note; tracked for a code fix in #6686.

**4. Its call graph was off by one hop.** The proof claimed the tip register is *"reached only from `execute_contiguous_block` and `execute_block_with_checkpoint_restore`"*. There is one direct call site, in `execute_contiguous_block`; the checkpoint path reaches it by delegating there after installing the snapshot.

**5. `EpochAgreement`'s discharge story was wrong, and the truth is a better argument.** It claimed `process_confirmed_block` applies `check_block_epoch` to the certified block. It does not — it fetches `committee_for_epoch(block.header.epoch)` and verifies against *that* committee. `check_block_epoch` runs at three other sites: `try_handle_block_proposal`, `process_validated_block`, `execute_contiguous_block`.

The distinction strengthens the assumption. *Which committee judges a certificate* is a function of the block's **declared** epoch, which is covered by the block hash — so two correct validators can never disagree about it, unconditionally, which is exactly what the assumption needs. Requiring the epoch to *also* be the chain's current one is a separate, later check, deliberately absent from `process_confirmed_block` so a node catching up can accept certificates from earlier epochs. Consequence now recorded: a merely *preprocessed* block is never epoch-checked in that second sense, consistent with preprocessing not advancing the tip.

**6–8. Four proofs consumed dependencies they did not declare.** Found by cross-checking each statement's prose citations against its supertrait list:

- `LockPreservation` → `ConfirmationOnlyInCurrentRound`, `UnlockingRequiresHigherCertificate`
- `OneValidationVotePerRound`, `OneConfirmationVotePerRound` → `SerializedChainState` (both proofs say in words that they consume it)
- `VoteRoundBelowCurrentRound` → `ConfirmationOnlyInCurrentRound`

All were present transitively, so the graph was not unsound — but the declared lists understated what the proofs use, which is the one property the supertrait scheme exists to make reliable. Now declared; `rustc` confirms no cycles.

**Two smaller additions.** `CertificateEmbedsQuorum` notes why its weight accumulation cannot overflow (distinctness is established before the sum, so the total is bounded by `total_votes`, which `Committee::new` rejects on overflow). `objects::Certificate` now lists `CertificateSignaturesVerify` alongside the other two consequences of validity.

## What passed

Everything else in the closure, with every enumeration claim re-derived against the code: the five `Vote::new*` signing sites; the single caller each of `create_vote` and `create_final_vote`; the four `update_locking` sites; the complete ten-field writer table in `locking.rs`; the two `manager.reset` sites; `save()` after each of the four vote-producing calls; `chain_write` holding a per-chain write lock across the transition; and the verbatim guard quotes in `check_proposed_block`, `check_validated_block` and `create_final_vote`.

## Test Plan

Documentation-only.

- `cargo doc --no-deps -p linera-chain -p linera-core -p linera-spec` with `RUSTDOCFLAGS="-A rustdoc::redundant_explicit_links -D warnings"` — clean.
- `cargo check -p linera-chain` — clean; a supertrait cycle from the newly declared dependencies would fail here with `E0391`.
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo test -p linera-chain --lib` — 80 passed, 0 failed.
- Five separation invariants checked mechanically against the DAG extracted from `rustdoc --output-format json`, all holding: safety uses no liveness assumption; accountability soundness, conflict completeness and chain auditability all avoid `MaxByzantineWeight`; `CorrectSignerCastItsVote` avoids the weight machinery entirely. These are claims `linera_spec` makes in prose that nothing enforced — worth turning into a test in a follow-up.

Two notes on the auditing itself, for whoever repeats it on the progress and liveness closures:

- The prose-citation-vs-supertrait check has a high false-positive rate — 27 of 41 flagged, of which roughly 85% are forward references or definition citations, both of which our convention deliberately puts in prose. It is still worth running: the four real findings above came from it, after filtering.
- Enumeration checks need multi-line-aware searching. A first pass over the writer table missed setters split as `self.timeout_vote` / `.set(…)` and wrongly reported two fields as having no writer.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6674 — the specification. #6684 — the previous round of citation fixes.
- #6686 — code fix for finding 3, filed from this audit.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
