### PR TITLE
Retry the playground wasm-split download on TLS failures

### DIFF
--- a/docker/Dockerfile.playground
+++ b/docker/Dockerfile.playground
@@ -43,13 +43,17 @@ RUN rustup show
 
 # build.bash strips the WASM with wasm-split when it is on PATH; without it the
 # `--keep-debug` build ships unstripped (~10x larger). Same version as CI.
+# `--retry-all-errors` is required rather than plain `--retry`: curl counts only
+# timeouts and some HTTP/FTP status codes as transient, so a TLS handshake
+# failure (exit 35) against github.com is otherwise never retried.
 ARG TARGETARCH
 RUN case "${TARGETARCH}" in \
       arm64) arch=aarch64 ;; \
       amd64) arch=x86_64 ;; \
       *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac && \
-    curl -fsSL -o /usr/local/bin/wasm-split \
+    curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+      -o /usr/local/bin/wasm-split \
       "https://github.com/getsentry/symbolicator/releases/download/26.3.0/wasm-split-Linux-${arch}" && \
     chmod +x /usr/local/bin/wasm-split
 


### PR DESCRIPTION
## Motivation

The `Docker Image` workflow failed on `main` at `d6e9062d` ([run 31431142019](https://github.com/linera-io/linera-protocol/actions/runs/31431142019)) and fired `CIWorkflowFailingCluster`. Only the Playground image failed, on the `wasm-split` download:

```
#16 ERROR: process "/bin/sh -c case \"${TARGETARCH}\" in ... curl -fsSL -o /usr/local/bin/wasm-split ..." did not complete successfully: exit code: 35
```

`curl` exit 35 is `CURLE_SSL_CONNECT_ERROR` — a TLS handshake failure reaching `github.com`, not a build error. The commit was docs-only (#6680), and the same workflow passed on the two preceding commits and on `testnet_conway` afterwards. A plain re-run went green.

This is the only network fetch in the file with no retry, so it converts any momentary TLS blip into a red `main`.

## Proposal

Add `--retry 5 --retry-delay 3 --retry-all-errors` to the download.

`--retry-all-errors` is the load-bearing flag, and the reason this is not simply the repo's usual `--retry 10 --retry-connrefused`: curl retries only *transient* errors by default, defined as "a timeout, an FTP 4xx response code or an HTTP 408, 429, 500, 502, 503 or 504 response code" ([everything.curl.dev](https://everything.curl.dev/usingcurl/downloads/retry.html)). A TLS handshake failure is not in that set, so plain `--retry` would not have retried this failure at all. `--retry-all-errors` "makes curl treat all transfers failures as reason for retry" (same source).

The flag needs curl ≥ 7.71.0; the builder stage is `rust:1.86-bookworm`, and Debian bookworm ships [curl 7.88.1](https://packages.debian.org/bookworm/curl).

`-f` is retained, so an HTTP error status still fails the build rather than writing an error page to `/usr/local/bin/wasm-split`.

## Test Plan

- Ran the exact post-change invocation and confirmed it succeeds and yields a valid binary:
  ```
  $ curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors -o wasm-split \
      "https://github.com/getsentry/symbolicator/releases/download/26.3.0/wasm-split-Linux-aarch64"; echo $?
  0
  $ file wasm-split
  wasm-split: ELF 64-bit LSB pie executable, ARM aarch64, ..., stripped
  ```
- Confirmed `--retry-all-errors` is accepted by the flag parser (`curl --help all | grep retry`).
- CI builds the Playground image on this PR, exercising the changed layer on both `amd64` and `arm64`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Failing run: https://github.com/linera-io/linera-protocol/actions/runs/31431142019
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
