### PR TITLE
Stop reporting an always-empty stderr capture in command errors

### DIFF
--- a/linera-base/src/command.rs
+++ b/linera-base/src/command.rs
@@ -161,12 +161,9 @@ impl CommandExt for tokio::process::Command {
             .wait_with_output()
             .await
             .with_context(|| self.description())?;
-        // `stderr` is inherited, so `output.stderr` is always empty here: report where the
-        // child's diagnostics actually went instead of an empty capture.
         ensure!(
             output.status.success(),
-            "{}: got non-zero error code {}. The command's stderr was inherited by this \
-             process; see the output above for its diagnostics.",
+            "{}: got non-zero error code {}",
             self.description(),
             output.status,
         );

--- a/linera-base/src/command.rs
+++ b/linera-base/src/command.rs
@@ -161,12 +161,14 @@ impl CommandExt for tokio::process::Command {
             .wait_with_output()
             .await
             .with_context(|| self.description())?;
+        // `stderr` is inherited, so `output.stderr` is always empty here: report where the
+        // child's diagnostics actually went instead of an empty capture.
         ensure!(
             output.status.success(),
-            "{}: got non-zero error code {}. Stderr: \n{:?}\n",
+            "{}: got non-zero error code {}. The command's stderr was inherited by this \
+             process; see the output above for its diagnostics.",
             self.description(),
             output.status,
-            String::from_utf8(output.stderr),
         );
         String::from_utf8(output.stdout).with_context(|| self.description())
     }


### PR DESCRIPTION
## Motivation

The error reports a `Stderr:` field that is always empty: the same function sets `self.stderr(Stdio::inherit())`, so `output.stderr` is never populated. `Stderr:` followed by `Ok("")` reads as "the child died silently" and sends the reader looking in the wrong place — the child's real error is already in the log, inherited, a few lines above.

## Proposal

Delete the empty capture. `Stdio::inherit()` is left alone: it streams a long-running child's stderr live, which the e2e tests want.

## Test Plan

- `cargo clippy -p linera-base --all-targets --all-features` — clean.
- `cargo +nightly fmt -p linera-base --check` — clean.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- A run this message obstructed: https://github.com/linera-io/linera-protocol/actions/runs/31436934424
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
