### PR TITLE
Audit and correct the accountability proof

### DIFF
--- a/linera-chain/src/justification/proof.rs
+++ b/linera-chain/src/justification/proof.rs
@@ -57,17 +57,31 @@ use crate::{
 /// committee. There are four shapes, and each exhibits a pair of `v`'s own signatures — or, for
 /// [`InvalidJustification`], a single signature plus the opening it commits to.
 ///
-/// **The committee matters.** [`EquivocationProof::check`] judges the exhibited signatures against
-/// whatever [`Committee`] the auditor supplies, and [`InvalidJustification`] in particular asks
-/// whether an opening was a quorum *of that committee*. A vote is honest relative to the committee
-/// of the epoch it was cast in, so throughout this module a proof is understood to be adjudicated
-/// against that committee. Judging a vote against a different epoch's committee could convict a
-/// correct validator, and nothing in [`EquivocationProof::check`] prevents an auditor from doing
-/// so — the epoch is not carried in the proof.
+/// **What `check` establishes, and what it does not.** Signatures are verified against the
+/// [`ValidatorPublicKey`] carried *in the proof*, not against anything looked up in the committee.
+/// Of the four arms, only [`InvalidJustification`] consults the `committee` argument at all — to
+/// judge whether the opening was a quorum of it. So [`LockViolation`], [`DoubleVote`] and
+/// [`FirstRoundViolation`] are committee-independent: their verdicts hold whatever committee is
+/// supplied, and indeed whether or not the named validator belongs to one.
+///
+/// For [`InvalidJustification`] the committee does matter, and a vote is honest only relative to
+/// the committee of the epoch it was cast in; that epoch is not carried in the proof, so an
+/// auditor supplying a different epoch's committee could convict a correct validator. Throughout
+/// this module such a proof is understood to be adjudicated against the right one.
+///
+/// No arm checks committee membership or weight. An accepted proof therefore says "this key
+/// equivocated", not "this committee member equivocated": turning a set of proofs into a weight
+/// is the consumer's job, and [`ConflictCompleteness`] states its threshold about the set
+/// [`extract_equivocations`] returns, whose members are committee signers by construction.
 ///
 /// [`EquivocationProof`]: crate::justification::EquivocationProof
 /// [`EquivocationProof::check`]: crate::justification::EquivocationProof::check
 /// [`InvalidJustification`]: crate::justification::EquivocationProof::InvalidJustification
+/// [`LockViolation`]: crate::justification::EquivocationProof::LockViolation
+/// [`DoubleVote`]: crate::justification::EquivocationProof::DoubleVote
+/// [`FirstRoundViolation`]: crate::justification::EquivocationProof::FirstRoundViolation
+/// [`ValidatorPublicKey`]: linera_base::crypto::ValidatorPublicKey
+/// [`extract_equivocations`]: crate::justification::extract_equivocations
 /// [`Committee`]: linera_execution::committee::Committee
 pub trait MisbehaviourProof {}
 
@@ -259,7 +273,11 @@ pub trait InvalidJustificationSoundness:
 /// Note what this does *not* assume: no [`MaxByzantineWeight`], no synchrony, no bound on how many
 /// other validators misbehaved. Soundness is a statement about one validator's own signatures, so
 /// it survives arbitrary corruption of everyone else — which is what makes a conviction meaningful
-/// in the regime where accountability is invoked.
+/// in the regime where accountability is invoked. For three of the four variants it does not even
+/// depend on the committee ([`MisbehaviourProof`]); only the [`InvalidJustification`] case needs
+/// the right one.
+///
+/// [`InvalidJustification`]: crate::justification::EquivocationProof::InvalidJustification
 ///
 /// [`EquivocationProof::check`]: crate::justification::EquivocationProof::check
 /// [`CorrectValidator`]: crate::manager::proof::model::CorrectValidator
@@ -342,7 +360,11 @@ pub trait ChainTilesRounds {}
 ///   the intersection of the two confirmation quorums — weight at least `f⁺` — emitting a
 ///   [`FirstRoundViolation`] for each, accepted since `earlier_round = r < s = attested_round`.
 ///
-/// In every case the blamed set is a full quorum intersection. ∎
+/// In every case the blamed set is a full quorum intersection — which is where the weight claim
+/// comes from: its members are signers of a verified certificate, hence committee members of
+/// nonzero weight by [`CertificateEmbedsQuorum`]. [`EquivocationProof::check`] itself establishes
+/// no membership or weight ([`MisbehaviourProof`]), so a consumer tallying the threshold must read
+/// the weights from the committee. ∎
 ///
 /// *Depends on the shared-committee hypothesis.* [`Intersection`] compares quorums of one
 /// committee; [`extract_equivocations`] checks only the chain and height, not the epoch, so two


### PR DESCRIPTION
## Motivation

The accountability proof, audited the same way as the safety proof (#6685).

`AccountabilityScope`'s transitive closure is 58 statements, of which 41 are shared with `CommitAgreement` and already audited; **17 are new**. Those were audited in dependency order against the code they claim about, leaves first.

**Two findings, both about what `EquivocationProof::check` does not do.** Neither is a soundness hole — in fact the first makes soundness *stronger* than documented.

## Findings

**1. `MisbehaviourProof` misstated the committee's role.** It said `check` *"judges the exhibited signatures against whatever `Committee` the auditor supplies"*. It does not. Signatures are verified against the `ValidatorPublicKey` carried **in the proof**:

```rust
confirmed_signature.check(&confirmed, *validator)?;
```

Of the four arms, only `InvalidJustification` consults the `committee` argument at all — to judge whether the opening was a quorum of it. `LockViolation`, `DoubleVote` and `FirstRoundViolation` never touch it.

That is a *better* property than was claimed: three quarters of the scheme is committee-independent, so those verdicts hold whatever committee is supplied, and whether or not the named validator belongs to one. The caveat about adjudicating against the wrong epoch's committee — which the proof did state — is real but applies only to `InvalidJustification`.

**2. No arm checks committee membership or weight.** An accepted proof says "this key equivocated", not "this committee member equivocated". `ConflictCompleteness` asserts that the returned proofs name validators of total weight at least `validity_threshold`, which is true of the set `extract_equivocations` returns — its members are signers of verified certificates, hence committee members of nonzero weight by `CertificateEmbedsQuorum` — but nothing in `check` establishes it, and a consumer tallying the threshold has to read the weights from the committee itself. Both statements now say so.

## What passed

The other 15, with every code claim re-derived:

- `ChainTilesRounds` — `JustificationChain::verify`'s `windows(2)` strict-increase check, `commitment()`'s fold setting each link's unlocking round to the one below, and `LiteCertificate::check`'s `Confirmed` arm requiring `top == self.round` unless the first-round attestation is set.
- `ConflictCompleteness` — `extract_equivocations` calls `walk_chain` both ways, `double_confirm`, and `first_round_violation` both ways; `walk_chain`'s window guard is verbatim `link.round > confirmer.round && unlocking_round.is_none_or(|u| u <= confirmer.round)`.
- `DoubleValidationCompleteness` — `extract_double_validations` acts only under `a.round == b.round`.
- `LockViolationSoundness` — the window guard `*confirmed_round < *validated_round && validated_unlocking_round.is_none_or(|u| *confirmed_round >= u)` is verbatim.
- `FirstRoundSoundness` — `check` requires chain and height equality and `earlier_round < attested_round`, and deliberately does *not* require different blocks, matching the lemma.
- `LeaderEligibility` — `can_propose`'s dispatch, including super owners returning `!round.is_validator()`.
- `SoundChain`, `ChainAuditability`, `DoubleVoteSoundness`, `InvalidJustificationSoundness`, `CertifiedBlockWasExecuted`, `IncomingBundlesAreSelfDerived`, `SafetyStateRecovery`, `ProofSoundness`, `AccountableSafety`.

## Test Plan

Documentation-only. Each command run unpiped with its exit status checked, per linera-io/linera-infra#1703:

- `cargo doc --no-deps -p linera-chain -p linera-core -p linera-spec` with `RUSTDOCFLAGS="-A rustdoc::redundant_explicit_links -D warnings"` — exit 0.
- `cargo check -p linera-chain` — exit 0.
- `cargo +nightly fmt --all -- --check` — exit 0.
- `cargo test -p linera-chain --lib` — exit 0, 80 passed.

Independent of #6685: that PR touches `objects.rs`, `quorum.rs`, `commit.rs`, `locking.rs`, `model.rs`, `rounds.rs` and `safety.rs`; this one touches only `justification/proof.rs`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6685 — the safety audit, same method.
- #6674 — the specification.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
