### PR TITLE
Label statements by what they are, not by what they follow from

### DIFF
--- a/linera-chain/src/data_types/proof/quorum.rs
+++ b/linera-chain/src/data_types/proof/quorum.rs
@@ -64,7 +64,7 @@ pub trait ThresholdArithmetic {}
 /// [`ThresholdArithmetic`]. ∎
 pub trait Intersection: ThresholdArithmetic {}
 
-/// **Corollary (A correct validator lies in every quorum intersection).** Any two quorums of the
+/// **Lemma (A correct validator lies in every quorum intersection).** Any two quorums of the
 /// same committee share at least one correct validator.
 ///
 /// *Proof.* By [`Intersection`] the intersection has weight at least `f⁺`. By
@@ -178,7 +178,7 @@ pub trait CorrectSignerCastItsVote:
 {
 }
 
-/// **Corollary (Every valid certificate carries a correct validator's vote).** For every
+/// **Lemma (Every valid certificate carries a correct validator's vote).** For every
 /// certificate valid for its committee there is at least one *correct* validator that itself cast
 /// a vote with that certificate's exact signed payload.
 ///

--- a/linera-chain/src/manager/proof/locking.rs
+++ b/linera-chain/src/manager/proof/locking.rs
@@ -272,7 +272,7 @@ pub trait OneConfirmationVotePerRound:
 {
 }
 
-/// **Corollary (At most one validated block per round).** For a given chain and height, all
+/// **Lemma (At most one validated block per round).** For a given chain and height, all
 /// valid [`ValidatedBlockCertificate`]s certified in the same round certify the same block.
 ///
 /// *Proof.* Let two such certificates certify `B₁` and `B₂` in round `s`. By

--- a/linera-chain/src/manager/proof/safety.rs
+++ b/linera-chain/src/manager/proof/safety.rs
@@ -217,7 +217,7 @@ pub trait CommitAgreement:
 {
 }
 
-/// **Corollary (The committed chain is unique).** For each chain there is at most one sequence of
+/// **Theorem (The committed chain is unique).** For each chain there is at most one sequence of
 /// committed blocks: the committed blocks at heights `0, 1, 2, …` form a single hash-linked list,
 /// and any two correct validators' [`block_hashes`](crate::ChainStateView) agree wherever both
 /// are defined. In particular the committed prefixes observed by correct validators are always
@@ -245,7 +245,7 @@ pub trait UniqueChain:
 {
 }
 
-/// **Corollary (Agreement failure is attributable).** The converse of [`CommitAgreement`]: when
+/// **Remark (Agreement failure is attributable).** The converse of [`CommitAgreement`]: when
 /// it fails, the failure is not silent. Two conflicting confirmed certificates are self-contained
 /// evidence convicting validators of at least
 /// [`validity_threshold`](linera_execution::committee::Committee::validity_threshold) weight, and

--- a/linera-spec/src/lib.rs
+++ b/linera-spec/src/lib.rs
@@ -74,6 +74,21 @@
 //! above — they are ordered, not numbered, so adding or splitting one renames nothing and
 //! invalidates no reference.
 //!
+//! Each statement opens with one of six labels, all of which mean something on their own:
+//!
+//! | label | carries a proof | meaning |
+//! |---|---|---|
+//! | **Definition** | no | fixes a term, and pins it to the Rust it denotes |
+//! | **Assumption** | no | something the implementation does not establish and a deployment must supply |
+//! | **Invariant** | yes | holds in every reachable state, proved by induction over transitions |
+//! | **Lemma** | yes | a proved statement |
+//! | **Theorem** | yes | one of the results the specification exists to establish |
+//! | **Remark** / **Caveat** | no | an observation or a limitation, asserting nothing new |
+//!
+//! None of them is *relational*: nothing is labelled by what it follows from. These pages are
+//! reached from anywhere by link, so there is no preceding result for a label to refer back to —
+//! and the supertrait list already names what a statement follows from, exactly and checkably.
+//!
 //! # The safety/liveness split
 //!
 //! The two arguments are deliberately disjoint in their assumptions, and the module layout


### PR DESCRIPTION
## Motivation

"Corollary" is a *relational* label: it says a statement follows immediately from the one before
it. That works in a paper read front to back. It does not work here — these pages are reached from
anywhere by link, so there is no preceding result for the label to refer back to, and a reader
cannot tell what a given corollary is supposed to be a corollary *of*.

The information the label was reaching for is already present, and present better: the supertrait
list names exactly what a statement follows from, and `rustc` checks it.

## Proposal

Relabel the five corollaries, choosing by what each statement *is* rather than by what it follows
from:

| statement | was | now |
|---|---|---|
| `quorum::CorrectValidatorInIntersection` | Corollary | **Lemma** |
| `quorum::CertificateCarriesCorrectVote` | Corollary | **Lemma** |
| `locking::UniqueValidatedBlockPerRound` | Corollary | **Lemma** |
| `safety::UniqueChain` | Corollary | **Theorem** — it is one of the results the specification exists to establish |
| `safety::Accountability` | Corollary | **Remark** — it has no supertraits and no proof; it points at [`justification::proof`], where the claim is established |

No prose anywhere referred to a statement as "the corollary", so nothing else changes.

Also records the label vocabulary in `linera-spec`, so this is a rule rather than a one-off
cleanup: six labels, which of them carry a proof, and the constraint that none may be relational.

## Test Plan

Documentation-only. Each command run unpiped with its exit status checked, per
linera-io/linera-infra#1703:

- `cargo doc --no-deps -p linera-chain -p linera-core -p linera-spec` with
  `RUSTDOCFLAGS="-A rustdoc::redundant_explicit_links -D warnings"` — exit 0.
- `cargo check -p linera-chain` — exit 0.
- `cargo +nightly fmt --all -- --check` — exit 0.
- Label census after the change: 48 Lemma, 16 Definition, 13 Assumption, 9 Theorem, 6 Remark,
  5 Invariant, 1 Caveat, 0 Corollary.

Branched after #6685 merged, so it already carries those corrections; no rebase needed.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6674 — the specification. #6685, #6689 — the safety and accountability audits.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
