### PR TITLE
Audit and correct the progress and liveness proofs

### DIFF
--- a/linera-core/src/proof/progress.rs
+++ b/linera-core/src/proof/progress.rs
@@ -267,10 +267,13 @@ pub trait ProposalAccepted:
 /// is the retried certificate's `full_justification`. ∎
 ///
 /// Note the blob preconditions: a validator missing a blob the proposal requires answers
-/// `WorkerError::BlobsNotFound` instead of voting, and the driver uploads the blobs and retries
-/// (`Client::submit_block_proposal`'s retry on `BlobsNotFound`). This is bounded work — the blob
-/// set is fixed by the proposal — so it does not affect the argument beyond a constant number of
-/// extra round trips.
+/// `WorkerError::BlobsNotFound` instead of voting. That does not cost a round. The retry is
+/// *per-validator*, inside `RemoteNodeUpdater::send_block_proposal`'s loop: the arm matching
+/// `BlobsNotFound | InactiveChain` sends the proposal's published blobs with `send_pending_blobs`
+/// and re-submits to that validator alone, so the other validators' votes are unaffected and the
+/// quorum round is not restarted. It terminates because the loop drains its `blob_ids` — the set
+/// is fixed by the proposal and each pass takes it with `mem::take`. So the `2Δ` bound above
+/// absorbs it as a constant factor rather than an extra round of the protocol.
 ///
 /// [`ValidatedBlockCertificate`]: linera_chain::types::ValidatedBlockCertificate
 /// [`ChainManager::create_vote`]: linera_chain::manager::ChainManager::create_vote


### PR DESCRIPTION
## Motivation

The progress and liveness proofs, audited the same way as the safety (#6685) and accountability
(#6689) ones. This completes the specification: 98 statements, all audited.

The remaining region was **40 statements** across 15 layers — the ones most exposed to drift,
since they describe the client driver in `linera-core` rather than the chain manager.

**One finding**, and it makes the lemma stronger rather than weaker.

## Finding

`ValidationQuorumForms` said that a validator missing a blob answers `WorkerError::BlobsNotFound`
instead of voting, *"and the driver uploads the blobs and retries
(`Client::submit_block_proposal`'s retry on `BlobsNotFound`)"*, costing "a constant number of
extra round trips".

`Client::submit_block_proposal` has no such retry. The blob retries live in
`linera_core::updater`, and there are three distinct ones, on three different paths:
`send_confirmed_certificate` (uploads from local storage), `send_validated_certificate` (sends the
locking blobs), and — the one this lemma needs — `send_block_proposal`.

The proposal one is *per-validator*, inside `RemoteNodeUpdater::send_block_proposal`'s loop: the
arm matching `BlobsNotFound | InactiveChain` sends the proposal's published blobs with
`send_pending_blobs` and re-submits to **that validator alone**. The other validators' votes are
unaffected and the quorum round is not restarted — so it is not "extra round trips" at all, and
the `2Δ` bound the lemma claims absorbs it as a constant factor rather than an extra round of the
protocol. Termination is also visible: the loop drains its `blob_ids`, whose set is fixed by the
proposal, taking them with `mem::take` each pass.

## What passed

The other 39, with every code claim re-derived:

- `TimeoutVoteConditions` — the four conditions of `create_timeout_vote`, in order.
- `RoundTimeoutGrowth` / `RoundsWithoutTimeout` — `ChainOwnership::round_timeout`'s full dispatch,
  including all three `None` cases and `fast_round_duration` defaulting to `None`.
- `TimeoutCertificateForms` — `communicate_with_quorum`'s grouping key is the five-field signed
  payload, exactly as the proof relies on for the votes to aggregate.
- `FullReachability` — `DEFAULT_QUORUM_GRACE_PERIOD` is `0.2`, and `sync_remote_if_needed` returns
  `LocalNodeLagging` only for `WrongRound` and `UnexpectedBlockHeight` in the *higher* direction,
  confirming that `HasIncompatibleConfirmedVote` does not trigger a pull. The `TODO(#6453)` the
  statement cites is still there.
- `ClockAccuracy` — the `block_time_grace_period` rejection and the skew warning firing at
  `validity_threshold`.
- `ProposalAccepted` — `round_for_new_proposal`, `already_handled_proposal`,
  `BlockProposal::new_retry_regular`.
- `LeaderEligibility`, `FallbackVote`, `TimeoutCertificateAdvancesRound`,
  `SingleLeaderRoundsNeedTimeout`, `CorrectValidatorsFormQuorum`, `RoundAdvancement`,
  `EventuallyCorrectLeader`, `LockRecovery`, `FinalizationQuorumForms`, `RoundProgress`,
  `HeightProgress`, `UnboundedProgress`, `LivenessScope`, `UniqueChain`, `SafetyScope`, and the
  definitions and remaining assumptions.

## Test Plan

Documentation-only. Each command run unpiped with its exit status checked, per
linera-io/linera-infra#1703:

- `cargo doc --no-deps -p linera-chain -p linera-core -p linera-spec` with
  `RUSTDOCFLAGS="-A rustdoc::redundant_explicit_links -D warnings"` — exit 0.
- `cargo check -p linera-core` — exit 0.
- `cargo +nightly fmt --all -- --check` — exit 0.
- `cargo test -p linera-chain --lib` — exit 0, 80 passed.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6685, #6689 — the safety and accountability audits, same method.
- #6674 — the specification.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
