### PR TITLE
Scope notification soundness to correct validators

### DIFF
--- a/linera-core/src/proof/notifications.rs
+++ b/linera-core/src/proof/notifications.rs
@@ -13,6 +13,8 @@
 
 use linera_chain::manager::proof::model::{CorrectValidator, StorageAtomicity};
 
+use super::availability::{BlockOutputsArePersisted, InboxHoldsOnlySentBundles};
+
 /// **Lemma (A correct validator's notification reports a change that is already persisted).** If a
 /// client receives a [`Notification`] from a correct validator, the state change it names is in
 /// that validator's storage. Nothing is claimed about a faulty validator's notifications, which by
@@ -91,3 +93,49 @@ pub trait NotificationsAreBestEffort {}
 /// [`ActiveCorrectDriver`]: super::assumptions::ActiveCorrectDriver
 /// [`MissingDependenciesAreRecoverable`]: super::availability::MissingDependenciesAreRecoverable
 pub trait NoProofDependsOnNotifications: NotificationsAreBestEffort {}
+
+/// **Lemma (A notification is backed by a certificate the validator can serve — except for a new
+/// round).** For every notification a correct validator emits other than `Reason::NewRound`, that
+/// validator holds a quorum-signed certificate establishing what the notification reports, and
+/// will hand it to anyone who asks. A recipient can therefore not merely learn that something
+/// happened but verify it, and carry the evidence to other validators.
+///
+/// *Proof.* Site by site, for the reasons a validator emits.
+///
+/// * `Reason::NewBlock` and `Reason::NewEvents` are reachable only through
+///   `ChainWorkerState::process_confirmed_block`, which verifies the [`ConfirmedBlockCertificate`]
+///   with `certificate.check` and writes it with `write_blobs_and_certificate` *before* dispatching
+///   to the path that emits them ([`BlockOutputsArePersisted`]). The certificate is in storage
+///   before the notification exists.
+/// * `Reason::NewIncomingBundle` is emitted once `process_cross_chain_update` reports
+///   `CrossChainUpdateResult::Updated`. By [`InboxHoldsOnlySentBundles`] that bundle reached the
+///   inbox from another worker of the *same validator*, built from its persisted outbox for a block
+///   that validator had processed — so the sending block's certificate is in this validator's
+///   storage too. Note it certifies a block of the *sending* chain, not of the chain the
+///   notification names.
+///
+/// Serving them is the ordinary node surface: `download_certificate`, `download_certificates` and
+/// `download_certificates_by_heights`. A node that receives one of these notifications can fetch
+/// the certificate, verify it against the committee, and push it onward — `send_confirmed_certificate`
+/// is exactly that path. ∎
+///
+/// **`Reason::NewRound` has no such backing, and cannot.** `ChainManager::update_current_round`
+/// takes a maximum over four inputs, and only two are certificates: a [`TimeoutCertificate`], or a
+/// locking block, which is a [`ValidatedBlockCertificate`]. The other two are `proposed` and
+/// `signed_proposal` — one owner's signature, not a quorum's. A round raised by a proposal in a
+/// higher multi-leader round therefore has nothing portable behind it, which is
+/// [`MultiLeaderRoundsAreLocal`] seen from the notification side: a recipient that wants to reach
+/// that round must be sent the proposal itself, because no compact proof of it exists to send.
+///
+/// **`Reason::BlockExecuted` is out of scope here.** It is emitted by `linera_core::client`, not by
+/// a validator, so it is a client telling itself something rather than a claim one node makes to
+/// another.
+///
+/// [`ConfirmedBlockCertificate`]: linera_chain::types::ConfirmedBlockCertificate
+/// [`ValidatedBlockCertificate`]: linera_chain::types::ValidatedBlockCertificate
+/// [`TimeoutCertificate`]: linera_chain::types::TimeoutCertificate
+/// [`MultiLeaderRoundsAreLocal`]: linera_chain::manager::proof::timeouts::MultiLeaderRoundsAreLocal
+pub trait NotificationIsCertificateBacked:
+    NotificationImpliesPersistedChange + BlockOutputsArePersisted + InboxHoldsOnlySentBundles
+{
+}

--- a/linera-core/src/proof/notifications.rs
+++ b/linera-core/src/proof/notifications.rs
@@ -41,12 +41,25 @@ use super::availability::{BlockOutputsArePersisted, InboxHoldsOnlySentBundles};
 /// so a client is never told about a half-written change. ∎
 ///
 /// **A notification carries no evidence.** [`Notification`] is a `chain_id` and a [`Reason`]: no
-/// signature, no certificate, not even a field naming the sender. So the qualifier above is not a
-/// technicality a client can discharge by inspection — a fabricated notification is
-/// indistinguishable from a sound one, and the only way to learn whether the change really happened
-/// is to ask. What a client may take from one is that it is worth querying now, and never what the
-/// answer will be. That the named block is *the* block at that height, rather than one validator's
-/// idea of it, is [`CommitAgreement`]'s and not this lemma's.
+/// signature, no certificate, not even a field naming the sender. Validators are not asked to sign
+/// them.
+///
+/// Knowing *who* sent one is a deployment matter rather than a protocol one. Under
+/// `NetworkProtocol::Grpc(TlsConfig::Tls)` the transport authenticates which validator the stream
+/// came from, so a third party cannot inject notifications into it; `TlsConfig::ClearText` is an
+/// equally valid configuration, so the specification cannot assume even that. And where it does
+/// hold it authenticates the *origin*, never the content, and only to the client holding the
+/// connection — a client cannot show anyone else what a validator told it. A notification is
+/// therefore never evidence in the sense the [accountability results] use: none is convictable, and
+/// none can be forwarded as proof of anything.
+///
+/// So the qualifier above is not a technicality a client can discharge by inspection. A fabricated
+/// notification is indistinguishable *by content* from a sound one, and the only way to learn
+/// whether the change happened is to ask. What a client may take from one is that it is worth
+/// querying now, and never what the answer will be. That the named block is *the* block at that
+/// height, rather than one validator's idea of it, is [`CommitAgreement`]'s and not this lemma's.
+///
+/// [accountability results]: linera_chain::justification::proof
 ///
 /// [`Notification`]: crate::worker::Notification
 /// [`NetworkActions`]: crate::worker::NetworkActions
@@ -118,6 +131,11 @@ pub trait NoProofDependsOnNotifications: NotificationsAreBestEffort {}
 /// `download_certificates_by_heights`. A node that receives one of these notifications can fetch
 /// the certificate, verify it against the committee, and push it onward — `send_confirmed_certificate`
 /// is exactly that path. ∎
+///
+/// This is the precise sense in which a notification is worth acting on despite carrying no
+/// evidence itself. The message is unsigned and, at best, authenticated only to its recipient by
+/// the transport; what it points at is quorum-signed and transferable to anyone. The hint is
+/// non-transferable, the thing it hints at is not.
 ///
 /// **`Reason::NewRound` has no such backing, and cannot.** `ChainManager::update_current_round`
 /// takes a maximum over four inputs, and only two are certificates: a [`TimeoutCertificate`], or a

--- a/linera-core/src/proof/notifications.rs
+++ b/linera-core/src/proof/notifications.rs
@@ -4,16 +4,19 @@
 //! What a notification tells a client, and what it does not.
 //!
 //! A [`Notification`] is a hint that shortens the wait between a change and a client noticing it.
-//! It is sound — what it reports really happened — and it is best effort — it may never arrive.
-//! The results here fix both halves, and the second is the reason for the third: nothing in this
-//! specification may depend on a notification.
+//! From a correct validator it is sound — what it reports really happened — and from any validator
+//! it is best effort, since it may never arrive and carries nothing that could be checked if it
+//! did. The results here fix each half, and together they are the reason for the third: nothing in
+//! this specification may depend on a notification.
 //!
 //! [`Notification`]: crate::worker::Notification
 
 use linera_chain::manager::proof::model::{CorrectValidator, StorageAtomicity};
 
-/// **Lemma (A notification reports a change that is already persisted).** If a client receives a
-/// [`Notification`], the state change it names is in the validator's storage.
+/// **Lemma (A correct validator's notification reports a change that is already persisted).** If a
+/// client receives a [`Notification`] from a correct validator, the state change it names is in
+/// that validator's storage. Nothing is claimed about a faulty validator's notifications, which by
+/// [`CorrectValidator`] may report anything at all.
 ///
 /// *Proof.* Notifications are not sent where they are built. Each is pushed onto the
 /// `notifications` field of a [`NetworkActions`] value which the handler *returns*, and every
@@ -35,13 +38,18 @@ use linera_chain::manager::proof::model::{CorrectValidator, StorageAtomicity};
 /// reaches a client without a completed save. By [`StorageAtomicity`] that save is all or nothing,
 /// so a client is never told about a half-written change. ∎
 ///
-/// **Not a claim about interpretation.** The lemma says the named height, hash, round or stream
-/// really was written by the validator that sent it. A client trusting a *single* validator's
-/// notification is trusting that validator; agreement is what makes the report meaningful across
-/// the committee, and that comes from [`CommitAgreement`], not from here.
+/// **A notification carries no evidence.** [`Notification`] is a `chain_id` and a [`Reason`]: no
+/// signature, no certificate, not even a field naming the sender. So the qualifier above is not a
+/// technicality a client can discharge by inspection — a fabricated notification is
+/// indistinguishable from a sound one, and the only way to learn whether the change really happened
+/// is to ask. What a client may take from one is that it is worth querying now, and never what the
+/// answer will be. That the named block is *the* block at that height, rather than one validator's
+/// idea of it, is [`CommitAgreement`]'s and not this lemma's.
 ///
 /// [`Notification`]: crate::worker::Notification
 /// [`NetworkActions`]: crate::worker::NetworkActions
+/// [`Reason`]: crate::worker::Reason
+/// [`CorrectValidator`]: linera_chain::manager::proof::model::CorrectValidator
 /// [`CommitAgreement`]: linera_chain::manager::proof::safety::CommitAgreement
 pub trait NotificationImpliesPersistedChange: CorrectValidator + StorageAtomicity {}
 
@@ -68,8 +76,10 @@ pub trait NotificationsAreBestEffort {}
 /// returns*, never from a notification. [`MissingDependenciesAreRecoverable`] is that argument, and
 /// nothing in it consults a notification. ∎
 ///
-/// This is what makes [`NotificationsAreBestEffort`] harmless: a lost notification costs latency,
-/// never correctness and never progress. It also fixes their role — notifications are an
+/// This is what makes both ways a notification can fail harmless. A lost one costs latency, never
+/// correctness and never progress. A *fabricated* one — which a faulty validator can send freely,
+/// notifications being unauthenticated — costs at most a wasted query, since the client acts on
+/// what it then reads and not on what it was told. It also fixes their role: notifications are an
 /// optimization over polling, and a client that ignores them entirely is slower but no less
 /// correct.
 ///


### PR DESCRIPTION
## Motivation

`NotificationImpliesPersistedChange`, added in #6692, claims that a `Notification` a client receives names a change that is in "the validator's storage" — without saying *which* validator. A faulty validator can send whatever it likes, so the claim as stated is false for exactly the case a Byzantine fault model exists to cover.

`CorrectValidator` was already a supertrait, so the dependency was tracked; the prose simply did not say it. That is the gap this closes.

## Proposal

Scope the lemma to correct validators, and state why the qualifier is not something a client can discharge by inspection.

- **The lemma is now "A correct validator's notification reports a change that is already persisted"**, and says explicitly that nothing is claimed about a faulty validator's notifications.
- **A notification carries no evidence.** `Notification` is a `chain_id` and a `Reason`: no signature, no certificate, not even a field naming the sender — validators are not asked to sign them. Knowing *who* sent one is a deployment matter: `NetworkProtocol::Grpc(TlsConfig::Tls)` authenticates the origin at the transport, but `TlsConfig::ClearText` is an equally valid configuration, and even where TLS holds it authenticates the origin rather than the content, and only to the client holding the connection. So a notification is never evidence in the sense the accountability results use — none is convictable, none can be forwarded as proof. A fabricated notification is therefore indistinguishable from a sound one, and the only way to learn whether the change happened is to ask. What a client may take from one is that it is worth querying now, and never what the answer will be. This replaces a weaker remark that said a client trusting one validator is trusting that validator, which understated the point — there is nothing in the message to trust or check either way.
- **`NoProofDependsOnNotifications` now covers fabrication, not only loss.** A lost notification costs latency; a fabricated one costs at most a wasted query, because the client acts on what it then reads rather than on what it was told. Previously only the loss case was argued, which left a faulty validator's forgeries unaddressed.

- **`NotificationIsCertificateBacked`** (new) — for every reason a validator emits *except* `NewRound`, it holds a quorum-signed certificate for what it reported and will serve it. `NewBlock` and `NewEvents` are reachable only via `process_confirmed_block`, which verifies and writes the certificate before dispatching to the emitting path; `NewIncomingBundle` is backed by the *sending* chain's certificate, which the same validator holds because the bundle came from its own worker. Serving is `download_certificate` / `download_certificates` / `download_certificates_by_heights`, so a recipient can verify the report and push it onward rather than merely believe it.

  **`NewRound` is the exception and cannot be otherwise.** `update_current_round` maxes over four inputs, of which only a `TimeoutCertificate` and a locking block are certificates; `proposed` and `signed_proposal` are one owner's signature. A round raised by a proposal in a higher multi-leader round has nothing portable behind it — `MultiLeaderRoundsAreLocal` seen from the notification side. `BlockExecuted` is emitted by the client, not a validator, so it is out of scope.

## Test Plan

CI. The change is documentation-only: no runtime footprint, no public API change beyond the statement's own doc text. `cargo doc --all-features` with `-D warnings` passes, which is what checks that every cited item resolves, and `cargo +nightly fmt --check` is clean.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6692 — added the statement being corrected.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)