### PR TITLE
[testnet] Let identified task outcomes be submitted independently of failing siblings (#6697)

### DIFF
--- a/examples/task-processor/src/contract.rs
+++ b/examples/task-processor/src/contract.rs
@@ -45,13 +45,10 @@ impl Contract for TaskProcessorContract {
     async fn execute_operation(&mut self, operation: TaskProcessorOperation) {
         match operation {
             TaskProcessorOperation::RequestTask { operator, input } => {
-                self.state
-                    .pending_tasks
-                    .push_back(PendingTask { operator, input });
+                self.add_pending_task(operator, input);
             }
-            TaskProcessorOperation::StoreResult { result } => {
-                // Remove the first pending task (the one that was just processed).
-                self.state.pending_tasks.delete_front();
+            TaskProcessorOperation::StoreResult { id, result } => {
+                self.remove_pending_task(id).await;
                 self.state.results.push_back(result);
                 let count = self.state.task_count.get() + 1;
                 self.state.task_count.set(count);
@@ -68,5 +65,39 @@ impl Contract for TaskProcessorContract {
             .save_and_drop()
             .await
             .expect("Failed to save state");
+    }
+}
+
+impl TaskProcessorContract {
+    /// Queues a task under a fresh identifier.
+    fn add_pending_task(&mut self, operator: String, input: String) {
+        let id = *self.state.next_task_id.get();
+        self.state.next_task_id.set(id + 1);
+        self.state.pending_tasks.push_back(PendingTask {
+            id,
+            operator,
+            input,
+        });
+    }
+
+    /// Removes the pending task with the given identifier.
+    ///
+    /// It is not necessarily the oldest one: the task processor reports the outcome of an
+    /// identified task as soon as it is available, even if a task requested earlier is
+    /// still failing.
+    async fn remove_pending_task(&mut self, id: u64) {
+        let count = self.state.pending_tasks.count();
+        let pending_tasks = self
+            .state
+            .pending_tasks
+            .read_front(count)
+            .await
+            .expect("Failed to read pending tasks");
+        self.state.pending_tasks.clear();
+        for task in pending_tasks {
+            if task.id != id {
+                self.state.pending_tasks.push_back(task);
+            }
+        }
     }
 }

--- a/examples/task-processor/src/lib.rs
+++ b/examples/task-processor/src/lib.rs
@@ -18,8 +18,8 @@ pub struct TaskProcessorAbi;
 pub enum TaskProcessorOperation {
     /// Request a task to be processed by the given operator with the given input.
     RequestTask { operator: String, input: String },
-    /// Store the result of a completed task.
-    StoreResult { result: String },
+    /// Store the result of the completed task with the given identifier.
+    StoreResult { id: u64, result: String },
 }
 
 impl ContractAbi for TaskProcessorAbi {

--- a/examples/task-processor/src/service.rs
+++ b/examples/task-processor/src/service.rs
@@ -89,6 +89,7 @@ impl QueryRoot {
         if let Ok(pending_tasks) = self.state.pending_tasks.read_front(count).await {
             for pending in pending_tasks {
                 actions.execute_tasks.push(Task {
+                    id: Some(pending.id.to_string()),
                     operator: pending.operator,
                     input: pending.input,
                 });
@@ -100,8 +101,14 @@ impl QueryRoot {
 
     /// Processes the outcome of a completed task and schedules operations.
     async fn process_task_outcome(&self, outcome: TaskOutcome) -> bool {
+        // The outcome is matched to its task by identity, so an outcome missing after a
+        // failure does not shift the ones that follow.
+        let Some(id) = outcome.id.and_then(|id| id.parse::<u64>().ok()) else {
+            return false;
+        };
         // Schedule an operation to store the result and remove the pending task.
         let operation = TaskProcessorOperation::StoreResult {
+            id,
             result: outcome.output,
         };
         self.runtime.schedule_operation(&operation);

--- a/examples/task-processor/src/state.rs
+++ b/examples/task-processor/src/state.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 /// A pending task stored in the application state.
 #[derive(Clone, Debug, Serialize, Deserialize, async_graphql::SimpleObject)]
 pub struct PendingTask {
+    /// The identifier under which the task processor reports the outcome.
+    pub id: u64,
     /// The operator to execute the task.
     pub operator: String,
     /// The input to pass to the operator.
@@ -19,6 +21,8 @@ pub struct PendingTask {
 pub struct TaskProcessorState {
     /// Pending tasks to be executed.
     pub pending_tasks: QueueView<PendingTask>,
+    /// The identifier to assign to the next requested task.
+    pub next_task_id: RegisterView<u64>,
     /// Results from completed tasks.
     pub results: QueueView<String>,
     /// Counter for tracking how many tasks have been processed.

--- a/examples/task-processor/tests/snapshots/format__format.snap
+++ b/examples/task-processor/tests/snapshots/format__format.snap
@@ -13,6 +13,7 @@ REGISTRY:
       1:
         StoreResult:
           STRUCT:
+            - id: U64
             - result: STR
 OPERATION:
   TYPENAME: TaskProcessorOperation

--- a/linera-base/src/task_processor.rs
+++ b/linera-base/src/task_processor.rs
@@ -29,6 +29,12 @@ pub struct ProcessorActions {
     /// upon the next query for actions.
     pub set_cursor: Option<String>,
     /// The application is requesting the execution of the given tasks.
+    ///
+    /// If every task carries an [`id`](Task::id), the outcomes are independent: each one is
+    /// submitted as soon as its task succeeds, and a task that fails is retried without
+    /// holding back its siblings. Otherwise the outcomes are submitted in the order of this
+    /// vector and submission stops at the first failure, so that an application matching
+    /// them by position never sees a gap.
     pub execute_tasks: Vec<Task>,
 }
 
@@ -37,6 +43,12 @@ scalar!(ProcessorActions);
 /// An off-chain task requested by an on-chain application.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Task {
+    /// An opaque, application-defined identifier, echoed back in the [`TaskOutcome`].
+    ///
+    /// Applications that set it match outcomes by identity rather than by position; see
+    /// [`ProcessorActions::execute_tasks`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     /// The operator handling the task.
     pub operator: String,
     /// The input argument in JSON.
@@ -46,6 +58,9 @@ pub struct Task {
 /// The result of executing an off-chain operator.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TaskOutcome {
+    /// The identifier of the [`Task`] this outcome belongs to, if it had one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     /// The operator handling the task.
     pub operator: String,
     /// The JSON output.

--- a/linera-base/src/task_processor.rs
+++ b/linera-base/src/task_processor.rs
@@ -30,10 +30,10 @@ pub struct ProcessorActions {
     pub set_cursor: Option<String>,
     /// The application is requesting the execution of the given tasks.
     ///
-    /// If every task carries a distinct [`id`](Task::id), the outcomes are independent: each
-    /// one is submitted as soon as its task succeeds, and a task that fails is retried
-    /// without holding back its siblings. Otherwise - if a task has no id, or if two of them
-    /// share one - the outcomes are submitted in the order of this vector and submission
+    /// Tasks are grouped by [`id`](Task::id), the ones without an id forming a single group.
+    /// The outcomes of distinct groups are independent: each is submitted as soon as its task
+    /// succeeds, and a task that fails is retried without holding back the other groups.
+    /// Within a group the outcomes are submitted in the order of this vector and submission
     /// stops at the first failure, so that an application matching them by position never
     /// sees a gap.
     pub execute_tasks: Vec<Task>,
@@ -46,9 +46,9 @@ scalar!(ProcessorActions);
 pub struct Task {
     /// An opaque, application-defined identifier, echoed back in the [`TaskOutcome`].
     ///
-    /// Applications that set it match outcomes by identity rather than by position. It must
-    /// be distinct from the id of every other task of the same batch; see
-    /// [`ProcessorActions::execute_tasks`].
+    /// Applications that set it match outcomes by identity rather than by position. An id
+    /// distinct from the id of every other task of the batch makes the outcome independent of
+    /// all of them; see [`ProcessorActions::execute_tasks`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// The operator handling the task.

--- a/linera-base/src/task_processor.rs
+++ b/linera-base/src/task_processor.rs
@@ -31,11 +31,11 @@ pub struct ProcessorActions {
     /// The application is requesting the execution of the given tasks.
     ///
     /// Tasks are grouped by [`id`](Task::id), the ones without an id forming a single group.
-    /// The outcomes of distinct groups are independent: each is submitted as soon as its task
-    /// succeeds, and a task that fails is retried without holding back the other groups.
-    /// Within a group the outcomes are submitted in the order of this vector and submission
-    /// stops at the first failure, so that an application matching them by position never
-    /// sees a gap.
+    /// The outcomes of distinct groups commute: each is submitted as soon as its task
+    /// succeeds, in no guaranteed order relative to the other groups, and a task that fails is
+    /// retried without holding the other groups back. Within a group the outcomes are
+    /// submitted in the order of this vector and submission stops at the first failure, so
+    /// that an application matching them by position never sees a gap.
     pub execute_tasks: Vec<Task>,
 }
 

--- a/linera-base/src/task_processor.rs
+++ b/linera-base/src/task_processor.rs
@@ -30,11 +30,12 @@ pub struct ProcessorActions {
     pub set_cursor: Option<String>,
     /// The application is requesting the execution of the given tasks.
     ///
-    /// If every task carries an [`id`](Task::id), the outcomes are independent: each one is
-    /// submitted as soon as its task succeeds, and a task that fails is retried without
-    /// holding back its siblings. Otherwise the outcomes are submitted in the order of this
-    /// vector and submission stops at the first failure, so that an application matching
-    /// them by position never sees a gap.
+    /// If every task carries a distinct [`id`](Task::id), the outcomes are independent: each
+    /// one is submitted as soon as its task succeeds, and a task that fails is retried
+    /// without holding back its siblings. Otherwise - if a task has no id, or if two of them
+    /// share one - the outcomes are submitted in the order of this vector and submission
+    /// stops at the first failure, so that an application matching them by position never
+    /// sees a gap.
     pub execute_tasks: Vec<Task>,
 }
 
@@ -45,7 +46,8 @@ scalar!(ProcessorActions);
 pub struct Task {
     /// An opaque, application-defined identifier, echoed back in the [`TaskOutcome`].
     ///
-    /// Applications that set it match outcomes by identity rather than by position; see
+    /// Applications that set it match outcomes by identity rather than by position. It must
+    /// be distinct from the id of every other task of the same batch; see
     /// [`ProcessorActions::execute_tasks`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -262,10 +262,13 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                     // Tasks are assumed idempotent: whatever is not submitted here is
                     // recomputed by the next call to `nextActions`.
                     let (outcomes, errors) = split_batch_results(results, independent);
+                    // `None` sorts before any timestamp, so keeping the maximum keeps the
+                    // latest retry the batch asked for: a task failing on every attempt
+                    // cannot shorten the delay protecting the operator.
                     let mut retry_at = None;
                     for error in errors {
                         error!(%application_id, %error, "Error executing task");
-                        retry_at = later(retry_at, Timestamp::now().saturating_add(retry_delay));
+                        retry_at = retry_at.max(Some(Timestamp::now().saturating_add(retry_delay)));
                     }
                     for outcome in outcomes {
                         if let Err(timestamp) = Self::submit_task_outcome(
@@ -276,7 +279,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                         )
                         .await
                         {
-                            retry_at = later(retry_at, timestamp);
+                            retry_at = retry_at.max(Some(timestamp));
                             if !independent {
                                 break;
                             }
@@ -451,12 +454,6 @@ fn split_batch_results(
     (outcomes, errors)
 }
 
-/// Returns the latest of the timestamps at which a batch should be retried, so that a task
-/// failing on every attempt cannot shorten the delay protecting the operator.
-fn later(retry_at: Option<Timestamp>, timestamp: Timestamp) -> Option<Timestamp> {
-    Some(retry_at.map_or(timestamp, |retry_at| retry_at.max(timestamp)))
-}
-
 /// Builds the GraphQL query submitting `task_outcome` to its application.
 fn task_outcome_query(task_outcome: &TaskOutcome) -> String {
     format!(
@@ -506,15 +503,6 @@ mod tests {
             vec!["second", "fourth"]
         );
         assert_eq!(errors.len(), 2);
-    }
-
-    #[test]
-    fn test_later() {
-        let early = Timestamp::from(1);
-        let late = Timestamp::from(2);
-        assert_eq!(later(None, early), Some(early));
-        assert_eq!(later(Some(late), early), Some(late));
-        assert_eq!(later(Some(early), late), Some(late));
     }
 
     #[test]

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -237,28 +237,27 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 let retry_delay = self.retry_delay;
                 let operators = self.operators.clone();
                 tokio::spawn(async move {
-                    let independent = outcomes_are_independent(&actions.execute_tasks);
-                    // Spawn all tasks concurrently and join them.
-                    let handles: Vec<_> = actions
-                        .execute_tasks
-                        .into_iter()
-                        .map(|task| {
-                            let operators = operators.clone();
-                            tokio::spawn(Self::execute_task(application_id, task, operators))
-                        })
-                        .collect();
-                    let results = future::join_all(handles)
-                        .await
-                        .into_iter()
-                        .map(|result| {
-                            result.unwrap_or_else(|error| {
-                                Err(anyhow::anyhow!("task panicked: {error}"))
-                            })
-                        })
-                        .collect();
+                    // Run all tasks concurrently, keeping the group each one belongs to.
+                    // Tasks sharing an id, and all the tasks without one, can only be told
+                    // apart by position, so they form a group whose outcomes must stay
+                    // ordered. A distinctly identified task is a group of its own.
+                    let results = future::join_all(actions.execute_tasks.into_iter().map(|task| {
+                        let operators = operators.clone();
+                        let group = task.id.clone();
+                        async move {
+                            let result =
+                                tokio::spawn(Self::execute_task(application_id, task, operators))
+                                    .await
+                                    .unwrap_or_else(|error| {
+                                        Err(anyhow::anyhow!("task panicked: {error}"))
+                                    });
+                            (group, result)
+                        }
+                    }))
+                    .await;
                     // Tasks are assumed idempotent: whatever is not submitted here is
                     // recomputed by the next call to `nextActions`.
-                    let (outcomes, errors) = split_batch_results(results, independent);
+                    let (outcomes, errors) = split_batch_results(results);
                     // `None` sorts before any timestamp, so keeping the maximum keeps the
                     // latest retry the batch asked for: a task failing on every attempt
                     // cannot shorten the delay protecting the operator.
@@ -267,7 +266,11 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                         error!(%application_id, %error, "Error executing task");
                         retry_at = retry_at.max(Some(Timestamp::now().saturating_add(retry_delay)));
                     }
-                    for outcome in outcomes {
+                    let mut failed_groups = BTreeSet::new();
+                    for (group, outcome) in outcomes {
+                        if failed_groups.contains(&group) {
+                            continue;
+                        }
                         if let Err(timestamp) = Self::submit_task_outcome(
                             &chain_client,
                             application_id,
@@ -277,9 +280,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                         .await
                         {
                             retry_at = retry_at.max(Some(timestamp));
-                            if !independent {
-                                break;
-                            }
+                            failed_groups.insert(group);
                         }
                     }
                     if batch_sender
@@ -425,39 +426,28 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
     }
 }
 
-/// Returns whether the outcomes of `tasks` can be submitted independently of each other.
+/// Splits the results of a finished batch into the outcomes to submit, each with the group it
+/// belongs to, and the errors to report.
 ///
-/// They can only if every task carries a distinct id: an application that has to match an
-/// outcome by position - because the task has no id, or because another task shares it -
-/// would pop the wrong entry as soon as one outcome is skipped.
-fn outcomes_are_independent(tasks: &[Task]) -> bool {
-    let ids = tasks
-        .iter()
-        .filter_map(|task| task.id.as_ref())
-        .collect::<BTreeSet<_>>();
-    ids.len() == tasks.len()
-}
-
-/// Splits the results of a finished batch into the outcomes to submit and the errors to
-/// report.
-///
-/// If the outcomes are not `independent`, the ones ordered after the first failure are
-/// dropped and recomputed on the next attempt, so that the application sees no gap in the
-/// sequence it matches them against.
+/// Outcomes of different groups are independent, but within a group the ones ordered after a
+/// failure are dropped and recomputed on the next attempt, so that an application matching
+/// them by position sees no gap in the sequence.
 fn split_batch_results(
-    results: Vec<Result<TaskOutcome, anyhow::Error>>,
-    independent: bool,
-) -> (Vec<TaskOutcome>, Vec<anyhow::Error>) {
+    results: Vec<(Option<String>, Result<TaskOutcome, anyhow::Error>)>,
+) -> (Vec<(Option<String>, TaskOutcome)>, Vec<anyhow::Error>) {
     let mut outcomes = Vec::new();
     let mut errors = Vec::new();
-    for result in results {
+    let mut failed_groups = BTreeSet::new();
+    for (group, result) in results {
         match result {
-            Ok(outcome) => outcomes.push(outcome),
+            Ok(outcome) => {
+                if !failed_groups.contains(&group) {
+                    outcomes.push((group, outcome));
+                }
+            }
             Err(error) => {
                 errors.push(error);
-                if !independent {
-                    break;
-                }
+                failed_groups.insert(group);
             }
         }
     }
@@ -484,56 +474,62 @@ mod tests {
         }
     }
 
-    fn task(id: Option<&str>) -> Task {
-        Task {
-            id: id.map(str::to_string),
-            operator: "echo".to_string(),
-            input: "input".to_string(),
-        }
+    type BatchResult = (Option<String>, Result<TaskOutcome, anyhow::Error>);
+
+    fn success(id: Option<&str>, output: &str) -> BatchResult {
+        (id.map(str::to_string), Ok(outcome(id, output)))
+    }
+
+    fn failure(id: Option<&str>) -> BatchResult {
+        (id.map(str::to_string), Err(anyhow::anyhow!("boom")))
+    }
+
+    fn outputs(outcomes: Vec<(Option<String>, TaskOutcome)>) -> Vec<String> {
+        outcomes
+            .into_iter()
+            .map(|(_, outcome)| outcome.output)
+            .collect()
     }
 
     #[test]
-    fn test_outcomes_are_independent() {
-        assert!(outcomes_are_independent(&[
-            task(Some("1")),
-            task(Some("2"))
-        ]));
-        assert!(!outcomes_are_independent(&[task(Some("1")), task(None)]));
-        assert!(!outcomes_are_independent(&[
-            task(Some("1")),
-            task(Some("1"))
-        ]));
-    }
-
-    #[test]
-    fn test_split_batch_results_stops_at_first_failure_when_ordered() {
+    fn test_split_batch_results_drops_a_failed_group() {
+        // Tasks without an id all belong to the same group.
         let results = vec![
-            Ok(outcome(None, "first")),
-            Err(anyhow::anyhow!("boom")),
-            Ok(outcome(None, "third")),
+            success(None, "first"),
+            failure(None),
+            success(None, "third"),
         ];
-        let (outcomes, errors) = split_batch_results(results, false);
-        assert_eq!(
-            outcomes.into_iter().map(|o| o.output).collect::<Vec<_>>(),
-            vec!["first"]
-        );
+        let (outcomes, errors) = split_batch_results(results);
+        assert_eq!(outputs(outcomes), vec!["first"]);
         assert_eq!(errors.len(), 1);
     }
 
     #[test]
-    fn test_split_batch_results_keeps_siblings_when_independent() {
+    fn test_split_batch_results_keeps_distinctly_identified_siblings() {
         let results = vec![
-            Err(anyhow::anyhow!("boom")),
-            Ok(outcome(Some("2"), "second")),
-            Err(anyhow::anyhow!("bang")),
-            Ok(outcome(Some("4"), "fourth")),
+            failure(Some("1")),
+            success(Some("2"), "second"),
+            failure(Some("3")),
+            success(Some("4"), "fourth"),
         ];
-        let (outcomes, errors) = split_batch_results(results, true);
-        assert_eq!(
-            outcomes.into_iter().map(|o| o.output).collect::<Vec<_>>(),
-            vec!["second", "fourth"]
-        );
+        let (outcomes, errors) = split_batch_results(results);
+        assert_eq!(outputs(outcomes), vec!["second", "fourth"]);
         assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    fn test_split_batch_results_only_drops_the_siblings_sharing_an_id() {
+        // Only what is ordered after the failure *and* shares its id is dropped.
+        let results = vec![
+            success(Some("dup"), "before"),
+            failure(Some("dup")),
+            success(Some("dup"), "after"),
+            success(Some("other"), "other"),
+            success(None, "unidentified"),
+        ];
+        let (outcomes, errors) = split_batch_results(results);
+        assert_eq!(outputs(outcomes), vec!["before", "other", "unidentified"]);
+        assert_eq!(errors.len(), 1);
     }
 
     #[test]

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -18,7 +18,7 @@ use futures::{future, stream::StreamExt, FutureExt};
 use linera_base::{
     data_types::{TimeDelta, Timestamp},
     identifiers::{ApplicationId, ChainId},
-    task_processor::{ProcessorActions, TaskOutcome},
+    task_processor::{ProcessorActions, Task, TaskOutcome},
 };
 use linera_core::{
     client::ChainClient, data_types::ClientOutcome, node::NotificationStream, worker::Reason,
@@ -237,50 +237,47 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 let retry_delay = self.retry_delay;
                 let operators = self.operators.clone();
                 tokio::spawn(async move {
+                    // Outcomes are independent only if every task in the batch is identified:
+                    // an application that has to match an outcome by position would pop the
+                    // wrong entry as soon as one is skipped.
+                    let independent = actions.execute_tasks.iter().all(|task| task.id.is_some());
                     // Spawn all tasks concurrently and join them.
                     let handles: Vec<_> = actions
                         .execute_tasks
                         .into_iter()
                         .map(|task| {
                             let operators = operators.clone();
-                            tokio::spawn(Self::execute_task(
-                                application_id,
-                                task.operator,
-                                task.input,
-                                operators,
-                            ))
+                            tokio::spawn(Self::execute_task(application_id, task, operators))
                         })
                         .collect();
-                    let results = future::join_all(handles).await;
-                    // Submit outcomes in the original order. Stop on any failure to
-                    // preserve ordering: the on-chain queue is FIFO, so skipping a
-                    // failed task and submitting a later one would pop the wrong entry.
-                    // Tasks are assumed idempotent, so on failure the whole batch is
-                    // retried from scratch.
+                    let results = future::join_all(handles)
+                        .await
+                        .into_iter()
+                        .map(|result| {
+                            result.unwrap_or_else(|error| {
+                                Err(anyhow::anyhow!("task panicked: {error}"))
+                            })
+                        })
+                        .collect();
+                    // Tasks are assumed idempotent: whatever is not submitted here is
+                    // recomputed by the next call to `nextActions`.
+                    let (outcomes, errors) = split_batch_results(results, independent);
                     let mut retry_at = None;
-                    for result in results {
-                        match result {
-                            Ok(Ok(outcome)) => {
-                                if let Err(timestamp) = Self::submit_task_outcome(
-                                    &chain_client,
-                                    application_id,
-                                    &outcome,
-                                    retry_delay,
-                                )
-                                .await
-                                {
-                                    retry_at = Some(timestamp);
-                                    break;
-                                }
-                            }
-                            Ok(Err(error)) => {
-                                error!(%application_id, %error, "Error executing task");
-                                retry_at = Some(Timestamp::now().saturating_add(retry_delay));
-                                break;
-                            }
-                            Err(error) => {
-                                error!(%application_id, %error, "Task panicked");
-                                retry_at = Some(Timestamp::now().saturating_add(retry_delay));
+                    for error in errors {
+                        error!(%application_id, %error, "Error executing task");
+                        retry_at = later(retry_at, Timestamp::now().saturating_add(retry_delay));
+                    }
+                    for outcome in outcomes {
+                        if let Err(timestamp) = Self::submit_task_outcome(
+                            &chain_client,
+                            application_id,
+                            &outcome,
+                            retry_delay,
+                        )
+                        .await
+                        {
+                            retry_at = later(retry_at, timestamp);
+                            if !independent {
                                 break;
                             }
                         }
@@ -301,10 +298,14 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
 
     async fn execute_task(
         application_id: ApplicationId,
-        operator: String,
-        input: String,
+        task: Task,
         operators: OperatorMap,
     ) -> Result<TaskOutcome, anyhow::Error> {
+        let Task {
+            id,
+            operator,
+            input,
+        } = task;
         let binary_path = operators
             .get(&operator)
             .ok_or_else(|| anyhow::anyhow!("unsupported operator: {operator}"))?;
@@ -326,6 +327,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
             output.status
         );
         let outcome = TaskOutcome {
+            id,
             operator,
             output: String::from_utf8_lossy(&output.stdout).into(),
         };
@@ -378,11 +380,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
     ) -> Result<(), Timestamp> {
         info!("Submitting task outcome for {application_id}: {task_outcome:?}");
         let retry_with_delay = || Timestamp::now().saturating_add(retry_delay);
-        let query = format!(
-            "query {{ processTaskOutcome(outcome: {{ operator: {}, output: {} }}) }}",
-            task_outcome.operator.to_value(),
-            task_outcome.output.to_value(),
-        );
+        let query = task_outcome_query(task_outcome);
         let bytes = serde_json::to_vec(&json!({"query": query})).map_err(|error| {
             error!(%application_id, %error, "Error serializing task outcome query");
             retry_with_delay()
@@ -424,5 +422,110 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
             }
         }
         Ok(())
+    }
+}
+
+/// Splits the results of a finished batch into the outcomes to submit and the errors to
+/// report.
+///
+/// If the outcomes are not `independent`, the ones ordered after the first failure are
+/// dropped and recomputed on the next attempt, so that the application sees no gap in the
+/// sequence it matches them against.
+fn split_batch_results(
+    results: Vec<Result<TaskOutcome, anyhow::Error>>,
+    independent: bool,
+) -> (Vec<TaskOutcome>, Vec<anyhow::Error>) {
+    let mut outcomes = Vec::new();
+    let mut errors = Vec::new();
+    for result in results {
+        match result {
+            Ok(outcome) => outcomes.push(outcome),
+            Err(error) => {
+                errors.push(error);
+                if !independent {
+                    break;
+                }
+            }
+        }
+    }
+    (outcomes, errors)
+}
+
+/// Returns the latest of the timestamps at which a batch should be retried, so that a task
+/// failing on every attempt cannot shorten the delay protecting the operator.
+fn later(retry_at: Option<Timestamp>, timestamp: Timestamp) -> Option<Timestamp> {
+    Some(retry_at.map_or(timestamp, |retry_at| retry_at.max(timestamp)))
+}
+
+/// Builds the GraphQL query submitting `task_outcome` to its application.
+fn task_outcome_query(task_outcome: &TaskOutcome) -> String {
+    format!(
+        "query {{ processTaskOutcome(outcome: {}) }}",
+        task_outcome.to_value()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn outcome(id: Option<&str>, output: &str) -> TaskOutcome {
+        TaskOutcome {
+            id: id.map(str::to_string),
+            operator: "echo".to_string(),
+            output: output.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_split_batch_results_stops_at_first_failure_when_ordered() {
+        let results = vec![
+            Ok(outcome(None, "first")),
+            Err(anyhow::anyhow!("boom")),
+            Ok(outcome(None, "third")),
+        ];
+        let (outcomes, errors) = split_batch_results(results, false);
+        assert_eq!(
+            outcomes.into_iter().map(|o| o.output).collect::<Vec<_>>(),
+            vec!["first"]
+        );
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    fn test_split_batch_results_keeps_siblings_when_independent() {
+        let results = vec![
+            Err(anyhow::anyhow!("boom")),
+            Ok(outcome(Some("2"), "second")),
+            Err(anyhow::anyhow!("bang")),
+            Ok(outcome(Some("4"), "fourth")),
+        ];
+        let (outcomes, errors) = split_batch_results(results, true);
+        assert_eq!(
+            outcomes.into_iter().map(|o| o.output).collect::<Vec<_>>(),
+            vec!["second", "fourth"]
+        );
+        assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    fn test_later() {
+        let early = Timestamp::from(1);
+        let late = Timestamp::from(2);
+        assert_eq!(later(None, early), Some(early));
+        assert_eq!(later(Some(late), early), Some(late));
+        assert_eq!(later(Some(early), late), Some(late));
+    }
+
+    #[test]
+    fn test_task_outcome_query() {
+        assert_eq!(
+            task_outcome_query(&outcome(None, "hello")),
+            r#"query { processTaskOutcome(outcome: {operator: "echo", output: "hello"}) }"#
+        );
+        assert_eq!(
+            task_outcome_query(&outcome(Some("42"), "hello")),
+            r#"query { processTaskOutcome(outcome: {id: "42", operator: "echo", output: "hello"}) }"#
+        );
     }
 }

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -237,10 +237,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 let retry_delay = self.retry_delay;
                 let operators = self.operators.clone();
                 tokio::spawn(async move {
-                    // Outcomes are independent only if every task in the batch is identified:
-                    // an application that has to match an outcome by position would pop the
-                    // wrong entry as soon as one is skipped.
-                    let independent = actions.execute_tasks.iter().all(|task| task.id.is_some());
+                    let independent = outcomes_are_independent(&actions.execute_tasks);
                     // Spawn all tasks concurrently and join them.
                     let handles: Vec<_> = actions
                         .execute_tasks
@@ -428,6 +425,19 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
     }
 }
 
+/// Returns whether the outcomes of `tasks` can be submitted independently of each other.
+///
+/// They can only if every task carries a distinct id: an application that has to match an
+/// outcome by position - because the task has no id, or because another task shares it -
+/// would pop the wrong entry as soon as one outcome is skipped.
+fn outcomes_are_independent(tasks: &[Task]) -> bool {
+    let ids = tasks
+        .iter()
+        .filter_map(|task| task.id.as_ref())
+        .collect::<BTreeSet<_>>();
+    ids.len() == tasks.len()
+}
+
 /// Splits the results of a finished batch into the outcomes to submit and the errors to
 /// report.
 ///
@@ -472,6 +482,27 @@ mod tests {
             operator: "echo".to_string(),
             output: output.to_string(),
         }
+    }
+
+    fn task(id: Option<&str>) -> Task {
+        Task {
+            id: id.map(str::to_string),
+            operator: "echo".to_string(),
+            input: "input".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_outcomes_are_independent() {
+        assert!(outcomes_are_independent(&[
+            task(Some("1")),
+            task(Some("2"))
+        ]));
+        assert!(!outcomes_are_independent(&[task(Some("1")), task(None)]));
+        assert!(!outcomes_are_independent(&[
+            task(Some("1")),
+            task(Some("1"))
+        ]));
     }
 
     #[test]

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -1536,6 +1536,107 @@ async fn test_task_processor_outcome_ordering() -> Result<()> {
     Ok(())
 }
 
+/// Test that a task failing on every attempt does not hold back the outcomes of the other
+/// tasks in its batch.
+#[cfg(feature = "storage-service")]
+#[test_log::test(tokio::test)]
+async fn test_task_processor_failing_task_does_not_block_siblings() -> Result<()> {
+    use std::{io::Write, os::unix::fs::PermissionsExt};
+
+    use linera_base::{abi::ContractAbi, identifiers::ApplicationId};
+
+    struct TaskProcessorAbi;
+
+    impl ContractAbi for TaskProcessorAbi {
+        type Operation = ();
+        type Response = ();
+    }
+
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let config = LocalNetConfig::new_test(Database::Service, Network::Grpc);
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.load_wallet()?.default_chain().unwrap();
+
+    // Publish and create the task-processor example application.
+    let example_dir = ClientWrapper::example_path("task-processor")?;
+    let app_id_str = client
+        .project_publish(example_dir, vec![], None, &())
+        .await?;
+    let app_id: ApplicationId = app_id_str.trim().parse()?;
+
+    // Create an operator that always fails, and one that echoes its input.
+    let tmp_dir = tempfile::tempdir()?;
+    let failing_path = tmp_dir.path().join("failing-operator");
+    {
+        let mut file = std::fs::File::create(&failing_path)?;
+        writeln!(file, "#!/bin/sh")?;
+        writeln!(file, "exit 1")?;
+    }
+    std::fs::set_permissions(&failing_path, std::fs::Permissions::from_mode(0o755))?;
+
+    let fast_path = tmp_dir.path().join("fast-operator");
+    {
+        let mut file = std::fs::File::create(&fast_path)?;
+        writeln!(file, "#!/bin/sh")?;
+        writeln!(file, "cat")?;
+    }
+    std::fs::set_permissions(&fast_path, std::fs::Permissions::from_mode(0o755))?;
+
+    // Start the node service with both operators.
+    let port = get_node_port().await;
+    let operators = vec![
+        ("failing".to_string(), failing_path),
+        ("fast".to_string(), fast_path),
+    ];
+    let mut node_service = client
+        .run_node_service_with_options(port, ProcessInbox::Skip, &[app_id], &operators, false)
+        .await?;
+
+    node_service.ensure_is_running()?;
+
+    // Subscribe to notifications for the chain.
+    let mut notifications = Box::pin(node_service.notifications(chain).await?);
+
+    let app = node_service.make_application(&chain, &app_id.with_abi::<TaskProcessorAbi>())?;
+
+    // Submit both tasks in a single block, the failing one first.
+    app.multiple_mutate(&[
+        r#"requestTask(operator: "failing", input: "never_stored")"#.to_string(),
+        r#"requestTask(operator: "fast", input: "fast_result")"#.to_string(),
+    ])
+    .await?;
+
+    // Wait for the block containing the RequestTask operations, then for the block
+    // containing the StoreResult operation of the task that succeeded.
+    notifications.wait_for_block(None).await?;
+    notifications.wait_for_block(None).await?;
+
+    let task_count: u64 = app.query_json("taskCount").await?;
+    assert_eq!(task_count, 1);
+    let results: Vec<String> = app.query_json("results").await?;
+    assert_eq!(results, vec!["fast_result"]);
+
+    // The failing task is still pending, and is the only one retried.
+    let response = app.query("nextActions(now: 0)").await?;
+    let tasks = response["nextActions"]["execute_tasks"]
+        .as_array()
+        .expect("expected a list of tasks")
+        .clone();
+    assert_eq!(
+        tasks.len(),
+        1,
+        "Expected only the failing task, got: {tasks:?}"
+    );
+    assert_eq!(tasks[0]["operator"], "failing");
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
+
+    Ok(())
+}
+
 /// Test that the node service read-only mode disables mutations and prevents query-triggered operations.
 #[cfg(feature = "storage-service")]
 #[test_log::test(tokio::test)]


### PR DESCRIPTION
## Motivation

Backport of #6697 to `testnet_conway`.

`TaskProcessor` submitted a batch of task outcomes serially and stopped at the first failure,
discarding every outcome ordered after it. One application whose task failed could therefore
block outcomes that were computed successfully, indefinitely, even when they were entirely
unrelated to the failure — the blast radius being "every task that sorts after the failing one".
This is what took down two healthy oracle markets along with a third one on `oracle-v2-70-1`.

Fixes #6696 on the testnet branch.

## Proposal

Cherry-pick of #6697: `Task` gains an opaque, application-defined `id`, echoed back in the
matching `TaskOutcome`. The processor then groups a batch's tasks by id, the ones without an id
forming a single group, and treats the groups as independent: each outcome is submitted as soon
as its task succeeds, and a task that fails is retried without holding back the other groups.
Within a group, submission keeps stopping at the first failure, since positional matching is
then all the application has left and it must never see a gap.

A batch whose ids are all distinct is therefore a batch of singleton groups (fully independent),
and a batch with no ids at all is a single group (exactly today's behaviour).

Both fields are optional and skipped when unset, so the GraphQL surface is unchanged for
applications that do not opt in.

Note for SDK consumers: `Task` gaining a public field is source-breaking for struct literals,
so an application building tasks by hand needs a one-line change (`id: None` to keep today's
behaviour, or `id: Some(..)` to opt into independent submission).

## Test Plan

Same tests as #6697, adapted to this branch's example application (no `RequestTaskOn` / no
cross-chain message variant, plain-tagged operation enum):

- Unit tests for the grouping rule (a failure drops the rest of its own group, distinctly
  identified siblings survive, a repeated id only holds back the tasks sharing it) and for the
  outcome query rendering.
- End-to-end test `test_task_processor_failing_task_does_not_block_siblings`.
- `test_task_processor_outcome_ordering` still passes.

Locally verified on this branch: `cargo test -p linera-service --lib task_processor`,
`cd examples && cargo test -p task-processor`, `cargo clippy --all-targets --all-features`
under `-D warnings` for the two packages touched, and `cargo fmt --check` in both workspaces.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- Main-branch PR: #6697
- Issue: #6696
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
