### PR TITLE
Stop the event-block walk once a block holds only already-known events

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2054,15 +2054,17 @@ impl<Env: Environment> Client<Env> {
                 if let Some((prev_hash, prev_height)) =
                     block.body.previous_event_blocks.get(stream_id)
                 {
-                    if next_expected_events.get(stream_id).is_some_and(|index| {
-                        block
-                            .body
-                            .events
-                            .iter()
-                            .flatten()
-                            .find(|event| event.stream_id == *stream_id)
-                            .is_some_and(|event| event.index == *index)
-                    }) {
+                    let first_event_index = block
+                        .body
+                        .events
+                        .iter()
+                        .flatten()
+                        .find(|event| event.stream_id == *stream_id)
+                        .map(|event| event.index);
+                    if !event_ancestors_needed(
+                        next_expected_events.get(stream_id).copied(),
+                        first_event_index,
+                    ) {
                         continue;
                     }
                     if !certificates.contains_key(prev_height) {
@@ -2859,6 +2861,52 @@ pub async fn create_bytecode_blobs(
         blobs.push(blob);
     }
     (blobs, module_id)
+}
+
+/// Whether ancestor blocks in a `previous_event_blocks` walk may still hold unseen
+/// events. Ancestors only carry indices strictly below `first_event_index`, so once
+/// that index is at or below the next expected one, everything older is already known.
+/// Unknown stream or a block without the stream's events keeps walking.
+fn event_ancestors_needed(next_expected: Option<u32>, first_event_index: Option<u32>) -> bool {
+    match (next_expected, first_event_index) {
+        (Some(expected), Some(first)) => first > expected,
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod event_walk_tests {
+    use super::event_ancestors_needed;
+
+    /// A stream with no new events since the last sync (every block's first index is
+    /// below the expected one) must stop the walk instead of traversing the entire
+    /// stream history — the regression behind the 2026-08-12 restart storms.
+    #[test]
+    fn already_known_block_stops_the_walk() {
+        assert!(!event_ancestors_needed(Some(10), Some(3)));
+        assert!(!event_ancestors_needed(Some(10), Some(9)));
+    }
+
+    /// The frontier block (first event is exactly the next expected one) ends the walk.
+    #[test]
+    fn frontier_block_stops_the_walk() {
+        assert!(!event_ancestors_needed(Some(10), Some(10)));
+    }
+
+    /// A gap below this block's events means older blocks are still needed.
+    #[test]
+    fn gap_keeps_walking() {
+        assert!(event_ancestors_needed(Some(10), Some(11)));
+        assert!(event_ancestors_needed(Some(0), Some(5)));
+    }
+
+    /// No local knowledge of the stream, or no event for it in this block: keep walking.
+    #[test]
+    fn unknown_state_keeps_walking() {
+        assert!(event_ancestors_needed(None, Some(0)));
+        assert!(event_ancestors_needed(Some(10), None));
+        assert!(event_ancestors_needed(None, None));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Motivation

The backwards walk over `previous_event_blocks` in `download_event_bearing_blocks` stops scheduling ancestors only when a block's first event index is EXACTLY the next expected one — the frontier block. A stream with no new events since the last sync matches no block at all, so the walk traverses the entire stream history back to its first event block, re-verifying signatures, re-writing certificates and events, and re-preprocessing every block under the publisher chain worker's lock — on every restart, every notification race, for every subscriber. On testnet-conway (2026-08-12 restart storm) this was the single largest validator cost: PreviousEventBlocks server time rose x1053 over baseline (45,262s in 80 minutes), and the walk's one-certificate-per-request fetches fed a x24 rise in DownloadRawCertificatesByHeights. Present since #5588/#5653.

## Proposal

Stop scheduling ancestors as soon as a block's first event index for the stream is at or below the next expected index: ancestors can only hold strictly lower indices, so everything older is already known. The decision is extracted into a pure function (`event_ancestors_needed`) with unit tests covering the idle-stream regression, the frontier case, gaps, and unknown-stream cases (the latter unchanged: a new subscriber still walks to the stream start — whether that is itself desirable is left as a design question).

Soundness rests on per-stream event indices being contiguous and ascending across blocks (counter in `stream_event_counts`, incremented per emission, never reset — checkpoints included) and on `previous_event_blocks` linking exactly the previous event-bearing block per stream.

## Test Plan

- New `event_walk_tests` (4 cases) plus the pre-existing event-sync tests; full `cargo test -p linera-core --lib` 169/169.
- Clippy (all targets/features, no-default-features, wasm32/web-default) and fmt clean.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- Measured decomposition of the 2026-08-12 storm and the walk trace: internal incident notes; companion PRs address the download-dedup and resubscribe legs.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)