### PR TITLE
Raise RequestsScheduler dedup windows so load cannot disable deduplication

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -232,13 +232,13 @@ Client implementation and command-line tool for the Linera blockchain
   Default value: `5000`
 * `--cache-ttl-ms <CACHE_TTL_MS>` — Time-to-live for cached responses in milliseconds
 
-  Default value: `2000`
+  Default value: `30000`
 * `--cache-max-size <CACHE_MAX_SIZE>` — Maximum number of entries in the cache
 
   Default value: `1000`
 * `--max-request-ttl-ms <MAX_REQUEST_TTL_MS>` — Maximum latency for an in-flight request before we stop deduplicating it (in milliseconds)
 
-  Default value: `200`
+  Default value: `5000`
 * `--alpha <ALPHA>` — Smoothing factor for Exponential Moving Averages (0 < alpha < 1). Higher values give more weight to recent observations. Typical values are between 0.01 and 0.5. A value of 0.1 means that 10% of the new observation is considered and 90% of the previous average is retained
 
   Default value: `0.1`

--- a/linera-core/src/client/requests_scheduler/cache.rs
+++ b/linera-core/src/client/requests_scheduler/cache.rs
@@ -15,13 +15,13 @@ pub(super) struct CacheEntry<R> {
     cached_at: Timestamp,
 }
 
-/// Cache for request results with TTL-based expiration and LRU eviction.
+/// Cache for request results with TTL-based expiration and oldest-first eviction.
 ///
 /// This cache supports:
 /// - Exact match lookups
 /// - Subsumption-based lookups (larger requests can satisfy smaller ones)
 /// - TTL-based expiration
-/// - LRU eviction
+/// - Oldest-first eviction when full
 #[derive(Debug, Clone)]
 pub(super) struct RequestsCache<K, R> {
     /// Cache of recently completed requests with their results and timestamps.
@@ -29,7 +29,7 @@ pub(super) struct RequestsCache<K, R> {
     cache: Arc<tokio::sync::RwLock<HashMap<K, CacheEntry<R>>>>,
     /// Time-to-live for cached entries. Entries older than this duration are considered expired.
     cache_ttl: Duration,
-    /// Maximum number of entries to store in the cache. When exceeded, oldest entries are evicted (LRU).
+    /// Maximum number of entries to store in the cache. When exceeded, oldest entries are evicted.
     max_cache_size: usize,
 }
 
@@ -60,25 +60,33 @@ where
     /// # Returns
     /// - `Some(T)` if a cached result is found (either exact or subsumed)
     /// - `None` if no suitable cached result exists
-    pub(super) async fn get<T>(&self, key: &K) -> Option<T>
+    pub(super) async fn get<T>(&self, key: &K, now: Timestamp) -> Option<T>
     where
         T: TryFrom<R>,
     {
         let cache = self.cache.read().await;
 
-        // Check cache for exact match first
+        // Check cache for exact match first. Expired entries are skipped here rather
+        // than only during store-time eviction: eviction only runs when the cache is
+        // at capacity, so without this check a quiet client would serve stale entries
+        // indefinitely.
         if let Some(entry) = cache.get(key) {
-            tracing::trace!(
-                key = ?key,
-                "cache hit (exact match) - returning cached result"
-            );
-            #[cfg(with_metrics)]
-            metrics::REQUEST_CACHE_HIT.inc();
-            return T::try_from((*entry.result).clone()).ok();
+            if now.duration_since(entry.cached_at) <= self.cache_ttl {
+                tracing::trace!(
+                    key = ?key,
+                    "cache hit (exact match) - returning cached result"
+                );
+                #[cfg(with_metrics)]
+                metrics::REQUEST_CACHE_HIT.inc();
+                return T::try_from((*entry.result).clone()).ok();
+            }
         }
 
         // Check cache for subsuming requests
         for (cached_key, entry) in cache.iter() {
+            if now.duration_since(entry.cached_at) > self.cache_ttl {
+                continue;
+            }
             if cached_key.subsumes(key) {
                 if let Some(extracted) = key.try_extract_result(cached_key, &entry.result) {
                     tracing::trace!(
@@ -95,10 +103,7 @@ where
         None
     }
 
-    /// Stores a result in the cache with LRU eviction if cache is full.
-    ///
-    /// If the cache is at capacity, this method removes the oldest expired entries first.
-    /// Entries are considered "oldest" based on their cached_at timestamp.
+    /// Stores a result in the cache, evicting expired and then oldest entries when full.
     ///
     /// # Arguments
     /// - `key`: The request key to cache
@@ -106,6 +111,18 @@ where
     pub(super) async fn store(&self, key: K, result: Arc<R>, now: Timestamp) {
         self.evict_expired_entries(now).await; // Clean up expired entries first
         let mut cache = self.cache.write().await;
+        // TTL eviction alone does not bound the cache: when every entry is still
+        // fresh, evict the oldest so the size cap holds.
+        while cache.len() >= self.max_cache_size {
+            let Some(oldest_key) = cache
+                .iter()
+                .min_by_key(|(_, entry)| entry.cached_at)
+                .map(|(key, _)| key.clone())
+            else {
+                break;
+            };
+            cache.remove(&oldest_key);
+        }
         // Insert new entry
         cache.insert(
             key.clone(),
@@ -222,7 +239,7 @@ mod tests {
         let cache: RequestsCache<RangeKey, RangeResult> =
             RequestsCache::new(Duration::from_secs(60), 10);
         let key = RangeKey { start: 0, end: 5 };
-        let result: Option<RangeResult> = cache.get(&key).await;
+        let result: Option<RangeResult> = cache.get(&key, Timestamp::from(0)).await;
         assert!(result.is_none());
     }
 
@@ -235,9 +252,52 @@ mod tests {
         cache
             .store(key.clone(), Arc::new(result.clone()), Timestamp::from(0))
             .await;
-        let retrieved: Option<RangeResult> = cache.get(&key).await;
+        let retrieved: Option<RangeResult> = cache.get(&key, Timestamp::from(0)).await;
 
         assert_eq!(retrieved, Some(result));
+    }
+
+    #[tokio::test]
+    async fn test_expired_entry_is_not_served() {
+        let cache = RequestsCache::new(Duration::from_secs(30), 10);
+        let key = RangeKey { start: 0, end: 5 };
+        let result = RangeResult(vec![0, 1, 2, 3, 4, 5]);
+
+        cache
+            .store(key.clone(), Arc::new(result.clone()), Timestamp::from(0))
+            .await;
+        // Within the TTL the entry is served; past it, it must not be — even though
+        // the cache is far below capacity and store-time eviction never runs.
+        let fresh: Option<RangeResult> = cache.get(&key, Timestamp::from(29_000_000)).await;
+        assert_eq!(fresh, Some(result));
+        let stale: Option<RangeResult> = cache.get(&key, Timestamp::from(31_000_000)).await;
+        assert!(stale.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_size_cap_holds_with_fresh_entries() {
+        let cache = RequestsCache::new(Duration::from_secs(60), 3);
+        // All entries fresh: TTL eviction frees nothing, so oldest-first eviction
+        // must keep the cache at its size cap.
+        for start in 0..10u64 {
+            let key = RangeKey {
+                start,
+                end: start + 1,
+            };
+            cache
+                .store(
+                    key,
+                    Arc::new(RangeResult(vec![start])),
+                    Timestamp::from(start),
+                )
+                .await;
+        }
+        assert!(cache.cache.read().await.len() <= 3);
+        // The newest entry survived.
+        let newest: Option<RangeResult> = cache
+            .get(&RangeKey { start: 9, end: 10 }, Timestamp::from(9))
+            .await;
+        assert_eq!(newest, Some(RangeResult(vec![9])));
     }
 
     #[tokio::test]
@@ -267,7 +327,7 @@ mod tests {
             .await;
 
         // Should get exact match, not extracted from larger range
-        let retrieved: Option<RangeResult> = cache.get(&exact_key).await;
+        let retrieved: Option<RangeResult> = cache.get(&exact_key, Timestamp::from(0)).await;
         assert_eq!(retrieved, Some(exact_result));
     }
 
@@ -288,7 +348,7 @@ mod tests {
 
         // Request a subset
         let subset_key = RangeKey { start: 3, end: 7 };
-        let retrieved: Option<RangeResult> = cache.get(&subset_key).await;
+        let retrieved: Option<RangeResult> = cache.get(&subset_key, Timestamp::from(0)).await;
 
         assert_eq!(retrieved, Some(RangeResult(vec![3, 4, 5, 6, 7])));
     }
@@ -305,7 +365,7 @@ mod tests {
 
         // Non-overlapping range
         let key2 = RangeKey { start: 10, end: 15 };
-        let retrieved: Option<RangeResult> = cache.get(&key2).await;
+        let retrieved: Option<RangeResult> = cache.get(&key2, Timestamp::from(0)).await;
 
         assert!(retrieved.is_none());
     }
@@ -406,7 +466,7 @@ mod tests {
             id: 5,
             always_fail_extraction: false,
         };
-        let retrieved: Option<SimpleResult> = cache.get(&target_key).await;
+        let retrieved: Option<SimpleResult> = cache.get(&target_key, Timestamp::from(0)).await;
 
         assert!(retrieved.is_some());
     }

--- a/linera-core/src/client/requests_scheduler/mod.rs
+++ b/linera-core/src/client/requests_scheduler/mod.rs
@@ -19,12 +19,18 @@ pub use scoring::ScoringWeights;
 pub const MAX_IN_FLIGHT_REQUESTS: usize = 100;
 /// Default maximum expected latency in milliseconds, used for score normalization.
 pub const MAX_ACCEPTED_LATENCY_MS: f64 = 5000.0;
-/// Default time-to-live for cached responses, in milliseconds.
-pub const CACHE_TTL_MS: u64 = 2000;
+/// Default time-to-live for cached responses, in milliseconds. Long enough that the
+/// bursts of repeated downloads a catch-up sync issues (seconds apart) hit the cache.
+pub const CACHE_TTL_MS: u64 = 30_000;
 /// Default maximum number of entries in the cache.
 pub const CACHE_MAX_SIZE: usize = 1000;
 /// Default maximum latency for an in-flight request before we stop deduplicating it, in milliseconds.
-pub const MAX_REQUEST_TTL_MS: u64 = 200;
+/// Must exceed request latency under load, or dedup turns itself off exactly when it
+/// is needed most: during the 2026-08-12 testnet storm the mean request took 649 ms
+/// against the previous 200 ms default, so every concurrent duplicate went to the
+/// network. 5 s covers degraded-validator latencies while still keeping new callers
+/// from piling onto a request that has been stuck longer than that.
+pub const MAX_REQUEST_TTL_MS: u64 = 5_000;
 /// Default smoothing factor for the Exponential Moving Averages of latency.
 pub const ALPHA_SMOOTHING_FACTOR: f64 = 0.1;
 /// Default delay in milliseconds between starting requests to different peers.

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -597,7 +597,7 @@ impl<Env: Environment> RequestsScheduler<Env> {
         Fut: Future<Output = Result<T, NodeError>> + 'static,
     {
         // Check cache for exact or subsuming match
-        if let Some(result) = self.cache.get(&key).await {
+        if let Some(result) = self.cache.get(&key, self.clock.current_time()).await {
             return Ok(result);
         }
 
@@ -732,13 +732,19 @@ impl<Env: Environment> RequestsScheduler<Env> {
         in_flight_guard.complete_and_broadcast(shared_result.clone());
 
         if let Ok(success) = shared_result.as_ref() {
-            self.cache
-                .store(
-                    key.clone(),
-                    Arc::new(success.clone()),
-                    self.clock.current_time(),
-                )
-                .await;
+            // A missing blob is a statement about one peer at one moment, not about
+            // the network: `download_blob` maps `BlobsNotFound` to `Ok(None)`, and
+            // caching that would blank the blob out for every peer for the whole TTL
+            // even while another in-flight peer has it.
+            if !matches!(success, RequestResult::Blob(None)) {
+                self.cache
+                    .store(
+                        key.clone(),
+                        Arc::new(success.clone()),
+                        self.clock.current_time(),
+                    )
+                    .await;
+            }
         }
         result
     }


### PR DESCRIPTION
## Motivation

The scheduler stops deduplicating an in-flight request once it is older than MAX_REQUEST_TTL_MS (200 ms) and forgets responses after CACHE_TTL_MS (2 s). During the 2026-08-12 testnet-conway restart storm the mean request took 649 ms, so identical concurrent downloads all went to the network at exactly the moment validators were overloaded — dedup disabled itself under the load it exists to absorb.

## Proposal

Raise the defaults: in-flight dedup window 200 ms → 5 s, response cache TTL 2 s → 30 s.

Review of this change surfaced three pre-existing cache defects the new TTLs would have amplified, fixed here as prerequisites:

- `get` never checked entry age — TTL was only enforced during store-time eviction, which only runs at capacity, so a quiet client could be served a stale entry indefinitely. `get` now takes `now` and skips expired entries (exact and subsumption paths).
- Negative blob lookups (`Ok(None)` from `BlobsNotFound`) were cached as successes under a peer-independent key: one lagging validator could blank a blob out for every peer for the whole TTL. `Blob(None)` is no longer cached.
- The size cap was not a bound: at capacity, eviction only removed expired entries, so a burst of fresh entries grew the map without limit (worst case insert-rate × TTL). Store now evicts oldest-first down to the cap; the false "LRU" doc claims are corrected.

Trade-off accepted and documented: a caller joining a stuck request may now wait up to ~5 s (bounded by the 4 s per-attempt gRPC timeout and owner-cancellation wakeups) before firing its own request — versus the storm-amplifying duplicate traffic of the old behavior.

## Test Plan

- Two new cache regression tests (expired-entry-not-served; size-cap-holds-with-fresh-entries); `cargo test -p linera-core requests_scheduler` 31/31.
- Clippy all-targets and fmt clean; `CLI.md` regenerated.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- The same TTLs are being applied operationally via env on the PM workers (linera-infra) until this lands in images.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)