### PR TITLE
Delay notification-stream reconnects so clean EOFs cannot resubscribe in a tight loop

### DIFF
--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -380,7 +380,10 @@ impl ValidatorNode for GrpcClient {
         );
 
         // A stream of `Result<grpc::Notification, tonic::Status>` that keeps calling
-        // `client.subscribe(request)` endlessly and without delay.
+        // `client.subscribe(request)` endlessly. Reconnects pause for `retry_delay`
+        // first: a server that cleanly closes the stream yields no error item, so the
+        // error backoff below never runs for it, and reconnecting immediately would
+        // hammer it with subscriptions in a tight loop.
         let retry_count_for_unfold = retry_count.clone();
         let cooldowns_for_unfold = subscription_cooldowns.clone();
         let address_for_unfold = address.clone();
@@ -395,6 +398,7 @@ impl ValidatorNode for GrpcClient {
                 let stream = if let Some(stream) = stream.take() {
                     future::Either::Right(stream)
                 } else {
+                    linera_base::time::timer::sleep(retry_delay).await;
                     match client.subscribe(subscription_request.clone()).await {
                         Err(err) => future::Either::Left(stream::iter(iter::once(Err(err)))),
                         Ok(response) => {


### PR DESCRIPTION
## Motivation

The gRPC notification subscription wraps an endlessly self-reconnecting inner stream. Error items pass through jittered exponential backoff — but a server that CLEANLY closes the stream produces no error item, so the unfold re-subscribes immediately, forever. Under load (validators slow, streams being shed) this degenerates into a tight subscribe loop: during the 2026-08-12 testnet-conway storm, Subscribe request volume more than doubled over baseline.

## Proposal

Sleep `retry_delay` (CLI default 1 s) before every reconnect attempt in the unfold. The initial subscription is untouched; error-path reconnects now pay backoff plus this flat delay (additive, bounded). Clean-EOF reconnects pace at a constant `retry_delay` — no escalation, matching the intent that clean rotation is normal — but bounded at ~1 subscribe/s per (chain, validator) instead of unbounded.

## Test Plan

- `cargo check`/`clippy -p linera-rpc --all-targets` clean; `timer::sleep` is already used in this function (wasm-safe).
- No automated reconnect test exists in the repo (verified by grep); this ships without one — the change is four lines around an existing await point, and the reviewer-verified analysis is in the PR discussion.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- Companion to the 2026-08-12 storm decomposition PRs.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)