### PR TITLE
Register metrics eagerly so presence does not depend on the workload

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -350,6 +350,18 @@ jobs:
       run: |
         ./scripts/check_chain_loads.sh
 
+  lint-metrics-registration:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+    - name: Check that every metric is registered at startup
+      run: |
+        ./scripts/check_metrics_registration.sh
+
   lint-check-copyright-headers:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -2094,43 +2094,40 @@ doc_scalar!(
 doc_scalar!(ApplicationDescription, "Description of a user application");
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use prometheus::HistogramVec;
 
     use crate::prometheus_util::{
         exponential_bucket_interval, exponential_bucket_latencies, register_histogram_vec,
     };
 
-    /// The time it takes to compress a bytecode.
-    pub static BYTECODE_COMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "bytecode_compression_latency",
-            "Bytecode compression latency",
-            &[],
-            exponential_bucket_latencies(10.0),
-        )
-    });
+    crate::declare_metrics! {
+        /// The time it takes to compress a bytecode.
+        pub static BYTECODE_COMPRESSION_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "bytecode_compression_latency",
+                "Bytecode compression latency",
+                &[],
+                exponential_bucket_latencies(10.0),
+            );
 
-    /// The time it takes to decompress a bytecode.
-    pub static BYTECODE_DECOMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "bytecode_decompression_latency",
-            "Bytecode decompression latency",
-            &[],
-            exponential_bucket_latencies(10.0),
-        )
-    });
+        /// The time it takes to decompress a bytecode.
+        pub static BYTECODE_DECOMPRESSION_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "bytecode_decompression_latency",
+                "Bytecode decompression latency",
+                &[],
+                exponential_bucket_latencies(10.0),
+            );
 
-    pub static BYTECODE_DECOMPRESSED_SIZE_BYTES: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "wasm_bytecode_decompressed_size_bytes",
-            "Decompressed size in bytes of WASM bytecodes stored on-chain",
-            &[],
-            exponential_bucket_interval(10_000.0, 100_000_000.0),
-        )
-    });
+        pub static BYTECODE_DECOMPRESSED_SIZE_BYTES: HistogramVec =
+            register_histogram_vec(
+                "wasm_bytecode_decompressed_size_bytes",
+                "Decompressed size in bytes of WASM bytecodes stored on-chain",
+                &[],
+                exponential_bucket_interval(10_000.0, 100_000_000.0),
+            );
+    }
 }
 
 #[cfg(test)]

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -207,4 +207,5 @@ pub async fn listen_for_shutdown_signals(shutdown_sender: CancellationToken) {
 #[cfg(with_metrics)]
 pub fn init_metrics() {
     data_types::metrics::init_metrics();
+    panic_hook::metrics::init_metrics();
 }

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -196,3 +196,13 @@ pub async fn listen_for_shutdown_signals(shutdown_sender: CancellationToken) {
         debug!("Received Ctrl+C");
     }
 }
+
+/// Registers every metric this crate declares.
+///
+/// Without this, a metric is only exported after the code path that observes it has run, so a
+/// rarely-taken path leaves its panels blank and makes a routine restart look like the metric
+/// was removed.
+#[cfg(with_metrics)]
+pub fn init_metrics() {
+    data_types::metrics::init_metrics();
+}

--- a/linera-base/src/panic_hook.rs
+++ b/linera-base/src/panic_hook.rs
@@ -15,29 +15,20 @@ use std::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use prometheus::IntCounter;
 
     use crate::prometheus_util::register_int_counter;
 
-    /// Panics observed by the hook installed by [`super::init`].
-    ///
-    /// A panic does not stop the process, so this counter is often the only durable signal
-    /// that one happened: whatever the panicking task was responsible for has stopped, and
-    /// the effect on the rest of the process depends entirely on who was joining it. Any
-    /// increase deserves investigation.
-    pub(super) static PANICS: LazyLock<IntCounter> =
-        LazyLock::new(|| register_int_counter("linera_panics_total", "Number of panics observed"));
-
-    /// Registers [`PANICS`] before anything has panicked.
-    ///
-    /// A lazily registered counter is absent from `/metrics` until it is first touched, so
-    /// without this the series would spring into existence on the first panic — leaving
-    /// dashboards showing no data rather than zero, and nothing for an alert to sit on.
-    pub(super) fn register() {
-        LazyLock::force(&PANICS);
+    crate::declare_metrics! {
+        /// Panics observed by the hook installed by [`super::init`].
+        ///
+        /// A panic does not stop the process, so this counter is often the only durable signal
+        /// that one happened: whatever the panicking task was responsible for has stopped, and
+        /// the effect on the rest of the process depends entirely on who was joining it. Any
+        /// increase deserves investigation.
+        pub(crate) static PANICS: IntCounter =
+            register_int_counter("panics_total", "Number of panics observed");
     }
 }
 
@@ -62,7 +53,7 @@ static INIT: Once = Once::new();
 pub fn init() {
     INIT.call_once(|| {
         #[cfg(with_metrics)]
-        metrics::register();
+        metrics::init_metrics();
         PREVIOUS_HOOK
             .set(std::panic::take_hook())
             .unwrap_or_else(|_| unreachable!("`call_once` runs this at most once"));
@@ -129,5 +120,21 @@ mod tests {
             1,
             "the hook installed before `init` ran exactly once",
         );
+    }
+
+    /// `register_int_counter` applies the `linera` namespace itself, so a name that already
+    /// carries the prefix is exported twice over, as `linera_linera_panics_total`.
+    #[cfg(with_metrics)]
+    #[test]
+    fn the_counter_is_exported_under_a_single_linera_prefix() {
+        crate::init_metrics();
+
+        let names = prometheus::gather()
+            .iter()
+            .map(|family| family.get_name().to_owned())
+            .collect::<Vec<_>>();
+
+        assert!(names.iter().any(|name| name == "linera_panics_total"));
+        assert!(!names.iter().any(|name| name.contains("linera_linera")));
     }
 }

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -4,6 +4,7 @@
 //! This module defines utility functions for interacting with Prometheus (logging metrics, etc)
 
 use prometheus::{
+    core::{MetricVec, MetricVecBuilder},
     exponential_buckets, histogram_opts, linear_buckets, register_gauge_vec, register_histogram,
     register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
     register_int_gauge_vec, GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge,
@@ -14,6 +15,47 @@ use crate::time::Instant;
 
 const LINERA_NAMESPACE: &str = "linera";
 
+/// Instantiates the sole child of a metric vector that has no labels.
+///
+/// A `MetricVec` exports one series per child, so registering it is not enough to make it
+/// appear in `/metrics`: with no child it emits nothing, which is indistinguishable from the
+/// metric having been renamed or removed. Creating the child up front exports it at zero
+/// until the code path that observes it first runs. Vectors that do have labels cannot get
+/// this treatment, because their label values are not known ahead of time.
+fn materialize_unlabeled<Builder: MetricVecBuilder>(
+    metric: MetricVec<Builder>,
+    label_names: &[&str],
+) -> MetricVec<Builder> {
+    if label_names.is_empty() {
+        metric.with_label_values(&[]);
+    }
+    metric
+}
+
+/// Declares Prometheus metrics as statics, along with an `init_metrics` that forces all of them.
+///
+/// A metric is only exported once its `LazyLock` has been forced, so one that is touched only
+/// on a rare code path disappears whenever its process is replaced. Generating the initializer
+/// from the declarations themselves means a newly added metric cannot be left out of it.
+#[macro_export]
+macro_rules! declare_metrics {
+    ($(
+        $(#[$attribute:meta])*
+        $visibility:vis static $name:ident: $metric_type:ty = $registration:expr;
+    )*) => {
+        $(
+            $(#[$attribute])*
+            $visibility static $name: ::std::sync::LazyLock<$metric_type> =
+                ::std::sync::LazyLock::new(|| $registration);
+        )*
+
+        /// Registers every metric declared in this module.
+        pub fn init_metrics() {
+            $( ::std::sync::LazyLock::force(&$name); )*
+        }
+    };
+}
+
 /// Wrapper around Prometheus `register_int_counter_vec!` macro which also sets the `linera` namespace
 pub fn register_int_counter_vec(
     name: &str,
@@ -21,7 +63,10 @@ pub fn register_int_counter_vec(
     label_names: &[&str],
 ) -> IntCounterVec {
     let counter_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
-    register_int_counter_vec!(counter_opts, label_names).expect("IntCounter can be created")
+    materialize_unlabeled(
+        register_int_counter_vec!(counter_opts, label_names).expect("IntCounter can be created"),
+        label_names,
+    )
 }
 
 /// Wrapper around Prometheus `register_int_counter_vec!` macro with `linera` namespace and a subsystem.
@@ -35,7 +80,10 @@ pub fn register_int_counter_vec_with_subsystem(
     let counter_opts = Opts::new(name, description)
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
-    register_int_counter_vec!(counter_opts, label_names).expect("IntCounter can be created")
+    materialize_unlabeled(
+        register_int_counter_vec!(counter_opts, label_names).expect("IntCounter can be created"),
+        label_names,
+    )
 }
 
 /// Wrapper around Prometheus `register_int_counter!` macro which also sets the `linera` namespace
@@ -57,7 +105,10 @@ pub fn register_histogram_vec(
         histogram_opts!(name, description).namespace(LINERA_NAMESPACE)
     };
 
-    register_histogram_vec!(histogram_opts, label_names).expect("Histogram can be created")
+    materialize_unlabeled(
+        register_histogram_vec!(histogram_opts, label_names).expect("Histogram can be created"),
+        label_names,
+    )
 }
 
 /// Wrapper around Prometheus `register_histogram_vec!` macro with `linera` namespace and a subsystem.
@@ -79,7 +130,10 @@ pub fn register_histogram_vec_with_subsystem(
             .subsystem(subsystem)
     };
 
-    register_histogram_vec!(histogram_opts, label_names).expect("Histogram can be created")
+    materialize_unlabeled(
+        register_histogram_vec!(histogram_opts, label_names).expect("Histogram can be created"),
+        label_names,
+    )
 }
 
 /// Wrapper around Prometheus `register_histogram!` macro which also sets the `linera` namespace
@@ -136,14 +190,20 @@ pub fn register_int_gauge_with_subsystem(
 /// Wrapper around Prometheus `register_int_gauge_vec!` macro which also sets the `linera` namespace
 pub fn register_int_gauge_vec(name: &str, description: &str, label_names: &[&str]) -> IntGaugeVec {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
-    register_int_gauge_vec!(gauge_opts, label_names).expect("IntGauge can be created")
+    materialize_unlabeled(
+        register_int_gauge_vec!(gauge_opts, label_names).expect("IntGauge can be created"),
+        label_names,
+    )
 }
 
 /// Wrapper around Prometheus `register_gauge_vec!` macro (floating-point gauge) which also sets
 /// the `linera` namespace. Use this for quantities with a fractional part (e.g. token balances).
 pub fn register_gauge_vec(name: &str, description: &str, label_names: &[&str]) -> GaugeVec {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
-    register_gauge_vec!(gauge_opts, label_names).expect("Gauge can be created")
+    materialize_unlabeled(
+        register_gauge_vec!(gauge_opts, label_names).expect("Gauge can be created"),
+        label_names,
+    )
 }
 
 /// Wrapper around Prometheus `register_int_gauge_vec!` macro with `linera` namespace and a subsystem.
@@ -157,7 +217,10 @@ pub fn register_int_gauge_vec_with_subsystem(
     let gauge_opts = Opts::new(name, description)
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
-    register_int_gauge_vec!(gauge_opts, label_names).expect("IntGauge can be created")
+    materialize_unlabeled(
+        register_int_gauge_vec!(gauge_opts, label_names).expect("IntGauge can be created"),
+        label_names,
+    )
 }
 
 /// Construct the bucket interval exponentially starting from a value and an ending value.

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -5,10 +5,10 @@
 
 use prometheus::{
     core::{MetricVec, MetricVecBuilder},
-    exponential_buckets, histogram_opts, linear_buckets, register_gauge_vec, register_histogram,
-    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
-    register_int_gauge_vec, GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge,
-    IntGaugeVec, Opts,
+    exponential_buckets, histogram_opts, linear_buckets, register_gauge, register_gauge_vec,
+    register_histogram, register_histogram_vec, register_int_counter, register_int_counter_vec,
+    register_int_gauge, register_int_gauge_vec, Gauge, GaugeVec, Histogram, HistogramVec,
+    IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts,
 };
 
 use crate::time::Instant;
@@ -194,6 +194,35 @@ pub fn register_int_gauge_vec(name: &str, description: &str, label_names: &[&str
         register_int_gauge_vec!(gauge_opts, label_names).expect("IntGauge can be created"),
         label_names,
     )
+}
+
+/// Wrapper around Prometheus `register_gauge!` macro (floating-point gauge) which also sets the
+/// `linera` namespace.
+pub fn register_gauge(name: &str, description: &str) -> Gauge {
+    let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
+    register_gauge!(gauge_opts).expect("Gauge can be created")
+}
+
+/// Wrapper around Prometheus `register_gauge!` macro with `linera` namespace and a subsystem.
+/// Results in metrics named `linera_<subsystem>_<name>`.
+pub fn register_gauge_with_subsystem(subsystem: &str, name: &str, description: &str) -> Gauge {
+    let gauge_opts = Opts::new(name, description)
+        .namespace(LINERA_NAMESPACE)
+        .subsystem(subsystem);
+    register_gauge!(gauge_opts).expect("Gauge can be created")
+}
+
+/// Wrapper around Prometheus `register_int_counter!` macro with `linera` namespace and a
+/// subsystem. Results in metrics named `linera_<subsystem>_<name>`.
+pub fn register_int_counter_with_subsystem(
+    subsystem: &str,
+    name: &str,
+    description: &str,
+) -> IntCounter {
+    let counter_opts = Opts::new(name, description)
+        .namespace(LINERA_NAMESPACE)
+        .subsystem(subsystem);
+    register_int_counter!(counter_opts).expect("IntCounter can be created")
 }
 
 /// Wrapper around Prometheus `register_gauge_vec!` macro (floating-point gauge) which also sets
@@ -388,6 +417,21 @@ impl MeasureLatency for Histogram {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pins the naming contract the `_with_subsystem` helpers document, so callers can drop a
+    /// hand-written prefix from every metric name and rely on the subsystem instead.
+    #[test]
+    fn subsystem_is_inserted_between_namespace_and_name() {
+        register_int_counter_with_subsystem(
+            "testsubsystem",
+            "testname",
+            "Pins the namespace/subsystem/name composition",
+        );
+
+        assert!(prometheus::gather()
+            .iter()
+            .any(|family| family.get_name() == "linera_testsubsystem_testname"));
+    }
 
     // Helper function for approximate floating point comparison
     fn assert_float_vec_eq(left: &[f64], right: &[f64]) {

--- a/linera-bridge/src/lib.rs
+++ b/linera-bridge/src/lib.rs
@@ -57,9 +57,11 @@ pub(crate) mod test_helpers;
 /// rarely-taken path leaves its panels blank and makes a routine restart look like the metric
 /// was removed.
 ///
-/// Ungated, unlike the equivalents in the other crates: this crate compiles its metrics
-/// unconditionally and has no `with_metrics` alias. It also serves no `/metrics` endpoint of
-/// its own, so it does not initialize its dependencies' metrics.
+/// Gated on `relay` rather than the `with_metrics` alias the other crates use: this crate has
+/// no such alias, and its metrics live in `relay`, which is itself behind that feature. It
+/// serves no `/metrics` endpoint of its own, so it does not initialize its dependencies'
+/// metrics.
+#[cfg(feature = "relay")]
 pub fn init_metrics() {
     relay::metrics::init_metrics();
 }

--- a/linera-bridge/src/lib.rs
+++ b/linera-bridge/src/lib.rs
@@ -50,3 +50,16 @@ mod gas;
 /// Shared test helpers for EVM contract deployment and interaction.
 #[cfg(all(test, feature = "offchain"))]
 pub(crate) mod test_helpers;
+
+/// Registers every metric this crate declares.
+///
+/// Without this, a metric is only exported after the code path that observes it has run, so a
+/// rarely-taken path leaves its panels blank and makes a routine restart look like the metric
+/// was removed.
+///
+/// Ungated, unlike the equivalents in the other crates: this crate compiles its metrics
+/// unconditionally and has no `with_metrics` alias. It also serves no `/metrics` endpoint of
+/// its own, so it does not initialize its dependencies' metrics.
+pub fn init_metrics() {
+    relay::metrics::init_metrics();
+}

--- a/linera-bridge/src/relay/metrics.rs
+++ b/linera-bridge/src/relay/metrics.rs
@@ -4,8 +4,16 @@
 //! Prometheus metrics for the bridge relay.
 
 use axum::{http::StatusCode, response::IntoResponse, routing::get, Router};
-use prometheus::{Gauge, IntCounter, IntGauge, Opts, TextEncoder};
+use linera_base::prometheus_util::{
+    register_gauge_with_subsystem, register_int_counter_with_subsystem,
+    register_int_gauge_with_subsystem,
+};
+use prometheus::{Gauge, IntCounter, IntGauge, TextEncoder};
 use tower_http::cors::CorsLayer;
+
+/// Every metric below is registered under this subsystem, so none of the names carries a
+/// `bridge_` prefix of its own — the exported name is `linera_bridge_<name>`.
+const SUBSYSTEM: &str = "bridge";
 
 pub(crate) fn deposit_detected() {
     DEPOSITS_DETECTED.inc();
@@ -72,6 +80,44 @@ async fn serve_metrics() -> impl IntoResponse {
     }
 }
 
+linera_base::declare_metrics! {
+    static DEPOSITS_DETECTED: IntCounter = register_int_counter_with_subsystem(
+        SUBSYSTEM, "deposits_detected", "Total deposits found by EVM scanner");
+
+    static DEPOSITS_COMPLETED: IntCounter = register_int_counter_with_subsystem(
+        SUBSYSTEM, "deposits_completed", "Deposits confirmed on Linera");
+
+    static DEPOSITS_PENDING: IntGauge = register_int_gauge_with_subsystem(
+        SUBSYSTEM, "deposits_pending", "Currently pending deposits");
+
+    static DEPOSITS_FAILED: IntGauge = register_int_gauge_with_subsystem(
+        SUBSYSTEM, "deposits_failed", "Permanently failed deposits");
+
+    static BURNS_DETECTED: IntCounter = register_int_counter_with_subsystem(
+        SUBSYSTEM, "burns_detected", "Total burns found by Linera scanner");
+
+    static BURNS_COMPLETED: IntCounter = register_int_counter_with_subsystem(
+        SUBSYSTEM, "burns_completed", "Burns forwarded to EVM");
+
+    static BURNS_PENDING: IntGauge = register_int_gauge_with_subsystem(
+        SUBSYSTEM, "burns_pending", "Currently pending burns");
+
+    static BURNS_FAILED: IntGauge = register_int_gauge_with_subsystem(
+        SUBSYSTEM, "burns_failed", "Permanently failed burns");
+
+    static LAST_SCANNED_EVM_BLOCK: IntGauge = register_int_gauge_with_subsystem(
+        SUBSYSTEM, "last_scanned_evm_block", "Last scanned EVM block number");
+
+    static LAST_SCANNED_LINERA_HEIGHT: IntGauge = register_int_gauge_with_subsystem(
+        SUBSYSTEM, "last_scanned_linera_height", "Last scanned Linera block height");
+
+    static RELAYER_EVM_BALANCE_WEI: Gauge = register_gauge_with_subsystem(
+        SUBSYSTEM, "evm_balance_wei", "Relayer EVM account balance in wei");
+
+    static RELAYER_LINERA_BALANCE_ATTO: Gauge = register_gauge_with_subsystem(
+        SUBSYSTEM, "linera_balance_atto", "Relayer Linera chain balance in attos");
+}
+
 #[cfg(test)]
 mod tests {
     use axum::{body::Body, http::Request};
@@ -92,105 +138,32 @@ mod tests {
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
     }
-}
 
-linera_base::declare_metrics! {
-    static DEPOSITS_DETECTED: IntCounter =
-        {
-            let opts = Opts::new(
-                "bridge_deposits_detected",
-                "Total deposits found by EVM scanner",
-            )
-            .namespace("linera");
-            prometheus::register_int_counter!(opts).unwrap()
-        };
+    /// The `bridge_` prefix moved out    /// the name strings cannot show the exported names are unchanged. Pin them instead.
+    #[test]
+    fn exported_names_are_unchanged_by_the_subsystem() {
+        crate::init_metrics();
 
-    static DEPOSITS_COMPLETED: IntCounter =
-        {
-            let opts =
-                Opts::new("bridge_deposits_completed", "Deposits confirmed on Linera").namespace("linera");
-            prometheus::register_int_counter!(opts).unwrap()
-        };
+        let exported = prometheus::gather()
+            .iter()
+            .map(|family| family.get_name().to_owned())
+            .collect::<std::collections::BTreeSet<_>>();
 
-    static DEPOSITS_PENDING: IntGauge =
-        {
-            let opts =
-                Opts::new("bridge_deposits_pending", "Currently pending deposits").namespace("linera");
-            prometheus::register_int_gauge!(opts).unwrap()
-        };
-
-    static DEPOSITS_FAILED: IntGauge =
-        {
-            let opts =
-                Opts::new("bridge_deposits_failed", "Permanently failed deposits").namespace("linera");
-            prometheus::register_int_gauge!(opts).unwrap()
-        };
-
-    static BURNS_DETECTED: IntCounter =
-        {
-            let opts = Opts::new(
-                "bridge_burns_detected",
-                "Total burns found by Linera scanner",
-            )
-            .namespace("linera");
-            prometheus::register_int_counter!(opts).unwrap()
-        };
-
-    static BURNS_COMPLETED: IntCounter =
-        {
-            let opts = Opts::new("bridge_burns_completed", "Burns forwarded to EVM").namespace("linera");
-            prometheus::register_int_counter!(opts).unwrap()
-        };
-
-    static BURNS_PENDING: IntGauge =
-        {
-            let opts = Opts::new("bridge_burns_pending", "Currently pending burns").namespace("linera");
-            prometheus::register_int_gauge!(opts).unwrap()
-        };
-
-    static BURNS_FAILED: IntGauge =
-        {
-            let opts = Opts::new("bridge_burns_failed", "Permanently failed burns").namespace("linera");
-            prometheus::register_int_gauge!(opts).unwrap()
-        };
-
-    static LAST_SCANNED_EVM_BLOCK: IntGauge =
-        {
-            let opts = Opts::new(
-                "bridge_last_scanned_evm_block",
-                "Last scanned EVM block number",
-            )
-            .namespace("linera");
-            prometheus::register_int_gauge!(opts).unwrap()
-        };
-
-    static LAST_SCANNED_LINERA_HEIGHT: IntGauge =
-        {
-            let opts = Opts::new(
-                "bridge_last_scanned_linera_height",
-                "Last scanned Linera block height",
-            )
-            .namespace("linera");
-            prometheus::register_int_gauge!(opts).unwrap()
-        };
-
-    static RELAYER_EVM_BALANCE_WEI: Gauge =
-        {
-            let opts = Opts::new(
-                "bridge_evm_balance_wei",
-                "Relayer EVM account balance in wei",
-            )
-            .namespace("linera");
-            prometheus::register_gauge!(opts).unwrap()
-        };
-
-    static RELAYER_LINERA_BALANCE_ATTO: Gauge =
-        {
-            let opts = Opts::new(
-                "bridge_linera_balance_atto",
-                "Relayer Linera chain balance in attos",
-            )
-            .namespace("linera");
-            prometheus::register_gauge!(opts).unwrap()
-        };
+        for expected in [
+            "linera_bridge_deposits_detected",
+            "linera_bridge_deposits_completed",
+            "linera_bridge_deposits_pending",
+            "linera_bridge_deposits_failed",
+            "linera_bridge_burns_detected",
+            "linera_bridge_burns_completed",
+            "linera_bridge_burns_pending",
+            "linera_bridge_burns_failed",
+            "linera_bridge_last_scanned_evm_block",
+            "linera_bridge_last_scanned_linera_height",
+            "linera_bridge_evm_balance_wei",
+            "linera_bridge_linera_balance_atto",
+        ] {
+            assert!(exported.contains(expected), "{expected} is not exported");
+        }
+    }
 }

--- a/linera-bridge/src/relay/metrics.rs
+++ b/linera-bridge/src/relay/metrics.rs
@@ -3,98 +3,9 @@
 
 //! Prometheus metrics for the bridge relay.
 
-use std::sync::LazyLock;
-
 use axum::{http::StatusCode, response::IntoResponse, routing::get, Router};
 use prometheus::{Gauge, IntCounter, IntGauge, Opts, TextEncoder};
 use tower_http::cors::CorsLayer;
-
-static DEPOSITS_DETECTED: LazyLock<IntCounter> = LazyLock::new(|| {
-    let opts = Opts::new(
-        "bridge_deposits_detected",
-        "Total deposits found by EVM scanner",
-    )
-    .namespace("linera");
-    prometheus::register_int_counter!(opts).unwrap()
-});
-
-static DEPOSITS_COMPLETED: LazyLock<IntCounter> = LazyLock::new(|| {
-    let opts =
-        Opts::new("bridge_deposits_completed", "Deposits confirmed on Linera").namespace("linera");
-    prometheus::register_int_counter!(opts).unwrap()
-});
-
-static DEPOSITS_PENDING: LazyLock<IntGauge> = LazyLock::new(|| {
-    let opts =
-        Opts::new("bridge_deposits_pending", "Currently pending deposits").namespace("linera");
-    prometheus::register_int_gauge!(opts).unwrap()
-});
-
-static DEPOSITS_FAILED: LazyLock<IntGauge> = LazyLock::new(|| {
-    let opts =
-        Opts::new("bridge_deposits_failed", "Permanently failed deposits").namespace("linera");
-    prometheus::register_int_gauge!(opts).unwrap()
-});
-
-static BURNS_DETECTED: LazyLock<IntCounter> = LazyLock::new(|| {
-    let opts = Opts::new(
-        "bridge_burns_detected",
-        "Total burns found by Linera scanner",
-    )
-    .namespace("linera");
-    prometheus::register_int_counter!(opts).unwrap()
-});
-
-static BURNS_COMPLETED: LazyLock<IntCounter> = LazyLock::new(|| {
-    let opts = Opts::new("bridge_burns_completed", "Burns forwarded to EVM").namespace("linera");
-    prometheus::register_int_counter!(opts).unwrap()
-});
-
-static BURNS_PENDING: LazyLock<IntGauge> = LazyLock::new(|| {
-    let opts = Opts::new("bridge_burns_pending", "Currently pending burns").namespace("linera");
-    prometheus::register_int_gauge!(opts).unwrap()
-});
-
-static BURNS_FAILED: LazyLock<IntGauge> = LazyLock::new(|| {
-    let opts = Opts::new("bridge_burns_failed", "Permanently failed burns").namespace("linera");
-    prometheus::register_int_gauge!(opts).unwrap()
-});
-
-static LAST_SCANNED_EVM_BLOCK: LazyLock<IntGauge> = LazyLock::new(|| {
-    let opts = Opts::new(
-        "bridge_last_scanned_evm_block",
-        "Last scanned EVM block number",
-    )
-    .namespace("linera");
-    prometheus::register_int_gauge!(opts).unwrap()
-});
-
-static LAST_SCANNED_LINERA_HEIGHT: LazyLock<IntGauge> = LazyLock::new(|| {
-    let opts = Opts::new(
-        "bridge_last_scanned_linera_height",
-        "Last scanned Linera block height",
-    )
-    .namespace("linera");
-    prometheus::register_int_gauge!(opts).unwrap()
-});
-
-static RELAYER_EVM_BALANCE_WEI: LazyLock<Gauge> = LazyLock::new(|| {
-    let opts = Opts::new(
-        "bridge_evm_balance_wei",
-        "Relayer EVM account balance in wei",
-    )
-    .namespace("linera");
-    prometheus::register_gauge!(opts).unwrap()
-});
-
-static RELAYER_LINERA_BALANCE_ATTO: LazyLock<Gauge> = LazyLock::new(|| {
-    let opts = Opts::new(
-        "bridge_linera_balance_atto",
-        "Relayer Linera chain balance in attos",
-    )
-    .namespace("linera");
-    prometheus::register_gauge!(opts).unwrap()
-});
 
 pub(crate) fn deposit_detected() {
     DEPOSITS_DETECTED.inc();
@@ -181,4 +92,105 @@ mod tests {
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
     }
+}
+
+linera_base::declare_metrics! {
+    static DEPOSITS_DETECTED: IntCounter =
+        {
+            let opts = Opts::new(
+                "bridge_deposits_detected",
+                "Total deposits found by EVM scanner",
+            )
+            .namespace("linera");
+            prometheus::register_int_counter!(opts).unwrap()
+        };
+
+    static DEPOSITS_COMPLETED: IntCounter =
+        {
+            let opts =
+                Opts::new("bridge_deposits_completed", "Deposits confirmed on Linera").namespace("linera");
+            prometheus::register_int_counter!(opts).unwrap()
+        };
+
+    static DEPOSITS_PENDING: IntGauge =
+        {
+            let opts =
+                Opts::new("bridge_deposits_pending", "Currently pending deposits").namespace("linera");
+            prometheus::register_int_gauge!(opts).unwrap()
+        };
+
+    static DEPOSITS_FAILED: IntGauge =
+        {
+            let opts =
+                Opts::new("bridge_deposits_failed", "Permanently failed deposits").namespace("linera");
+            prometheus::register_int_gauge!(opts).unwrap()
+        };
+
+    static BURNS_DETECTED: IntCounter =
+        {
+            let opts = Opts::new(
+                "bridge_burns_detected",
+                "Total burns found by Linera scanner",
+            )
+            .namespace("linera");
+            prometheus::register_int_counter!(opts).unwrap()
+        };
+
+    static BURNS_COMPLETED: IntCounter =
+        {
+            let opts = Opts::new("bridge_burns_completed", "Burns forwarded to EVM").namespace("linera");
+            prometheus::register_int_counter!(opts).unwrap()
+        };
+
+    static BURNS_PENDING: IntGauge =
+        {
+            let opts = Opts::new("bridge_burns_pending", "Currently pending burns").namespace("linera");
+            prometheus::register_int_gauge!(opts).unwrap()
+        };
+
+    static BURNS_FAILED: IntGauge =
+        {
+            let opts = Opts::new("bridge_burns_failed", "Permanently failed burns").namespace("linera");
+            prometheus::register_int_gauge!(opts).unwrap()
+        };
+
+    static LAST_SCANNED_EVM_BLOCK: IntGauge =
+        {
+            let opts = Opts::new(
+                "bridge_last_scanned_evm_block",
+                "Last scanned EVM block number",
+            )
+            .namespace("linera");
+            prometheus::register_int_gauge!(opts).unwrap()
+        };
+
+    static LAST_SCANNED_LINERA_HEIGHT: IntGauge =
+        {
+            let opts = Opts::new(
+                "bridge_last_scanned_linera_height",
+                "Last scanned Linera block height",
+            )
+            .namespace("linera");
+            prometheus::register_int_gauge!(opts).unwrap()
+        };
+
+    static RELAYER_EVM_BALANCE_WEI: Gauge =
+        {
+            let opts = Opts::new(
+                "bridge_evm_balance_wei",
+                "Relayer EVM account balance in wei",
+            )
+            .namespace("linera");
+            prometheus::register_gauge!(opts).unwrap()
+        };
+
+    static RELAYER_LINERA_BALANCE_ATTO: Gauge =
+        {
+            let opts = Opts::new(
+                "bridge_linera_balance_atto",
+                "Relayer Linera chain balance in attos",
+            )
+            .namespace("linera");
+            prometheus::register_gauge!(opts).unwrap()
+        };
 }

--- a/linera-cache/src/lib.rs
+++ b/linera-cache/src/lib.rs
@@ -36,3 +36,14 @@ mod value_cache;
 pub use arc::Arc;
 pub use unique_value_cache::UniqueValueCache;
 pub use value_cache::{ValueCache, DEFAULT_CLEANUP_INTERVAL_SECS};
+
+/// Registers every metric this crate declares.
+///
+/// Without this, a metric is only exported after the code path that observes it has run, so a
+/// rarely-taken path leaves its panels blank and makes a routine restart look like the metric
+/// was removed.
+#[cfg(with_metrics)]
+pub fn init_metrics() {
+    linera_base::init_metrics();
+    value_cache::metrics::init_metrics();
+}

--- a/linera-cache/src/value_cache.rs
+++ b/linera-cache/src/value_cache.rs
@@ -295,9 +295,7 @@ impl<V: Clone + Send + Sync + 'static> ValueCache<CryptoHash, V> {
 }
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{register_int_counter_vec, register_int_gauge_vec};
     use prometheus::{IntCounterVec, IntGaugeVec};
 
@@ -306,30 +304,28 @@ mod metrics {
     /// the same key/value types within one process.
     const LABELS: &[&str] = &["cache", "key_type", "value_type"];
 
-    pub static CACHE_HIT_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec("value_cache_hit", "Cache hits in `ValueCache`", LABELS)
-    });
+    linera_base::declare_metrics! {
+        pub static CACHE_HIT_COUNT: IntCounterVec =
+            register_int_counter_vec("value_cache_hit", "Cache hits in `ValueCache`", LABELS);
 
-    pub static CACHE_MISS_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec("value_cache_miss", "Cache misses in `ValueCache`", LABELS)
-    });
+        pub static CACHE_MISS_COUNT: IntCounterVec =
+            register_int_counter_vec("value_cache_miss", "Cache misses in `ValueCache`", LABELS);
 
-    pub static CACHE_ENTRIES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-        register_int_gauge_vec(
-            "value_cache_entries",
-            "Number of entries held in the bounded `ValueCache`, sampled at \
-             each cleanup sweep",
-            LABELS,
-        )
-    });
+        pub static CACHE_ENTRIES: IntGaugeVec =
+            register_int_gauge_vec(
+                "value_cache_entries",
+                "Number of entries held in the bounded `ValueCache`, sampled at \
+                 each cleanup sweep",
+                LABELS,
+            );
 
-    pub static CACHE_CAPACITY: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-        register_int_gauge_vec(
-            "value_cache_capacity",
-            "Maximum number of entries of the bounded `ValueCache`",
-            LABELS,
-        )
-    });
+        pub static CACHE_CAPACITY: IntGaugeVec =
+            register_int_gauge_vec(
+                "value_cache_capacity",
+                "Maximum number of entries of the bounded `ValueCache`",
+                LABELS,
+            );
+    }
 }
 
 #[cfg(test)]

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -133,121 +133,11 @@ impl BlockExecution {
 
 #[cfg(with_metrics)]
 pub(crate) mod metrics {
-    use std::sync::LazyLock;
-
     use linera_base::prometheus_util::{
         exponential_bucket_interval, register_histogram_vec, register_int_counter_vec,
     };
     use linera_execution::ResourceTracker;
     use prometheus::{HistogramVec, IntCounterVec};
-
-    pub static NUM_BLOCKS_EXECUTED: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "num_blocks_executed",
-            "Number of blocks executed",
-            &["phase"],
-        )
-    });
-
-    pub static BLOCK_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "block_execution_latency",
-            "Block execution latency",
-            &["phase"],
-            exponential_bucket_interval(50.0_f64, 10_000_000.0),
-        )
-    });
-
-    #[cfg(with_metrics)]
-    pub static MESSAGE_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "message_execution_latency",
-            "Message execution latency",
-            &["phase"],
-            exponential_bucket_interval(0.1_f64, 50_000.0),
-        )
-    });
-
-    pub static OPERATION_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "operation_execution_latency",
-            "Operation execution latency",
-            &["phase"],
-            exponential_bucket_interval(0.1_f64, 50_000.0),
-        )
-    });
-
-    pub static WASM_FUEL_USED_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "wasm_fuel_used_per_block",
-            "Wasm fuel used per block",
-            &["phase"],
-            exponential_bucket_interval(10.0, 100_000_000.0),
-        )
-    });
-
-    pub static EVM_FUEL_USED_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "evm_fuel_used_per_block",
-            "EVM fuel used per block",
-            &["phase"],
-            exponential_bucket_interval(10.0, 100_000_000.0),
-        )
-    });
-
-    pub static VM_NUM_READS_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "vm_num_reads_per_block",
-            "VM number of reads per block",
-            &["phase"],
-            exponential_bucket_interval(0.1, 100.0),
-        )
-    });
-
-    pub static VM_BYTES_READ_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "vm_bytes_read_per_block",
-            "VM number of bytes read per block",
-            &["phase"],
-            exponential_bucket_interval(0.1, 10_000_000.0),
-        )
-    });
-
-    pub static VM_BYTES_WRITTEN_PER_BLOCK: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "vm_bytes_written_per_block",
-            "VM number of bytes written per block",
-            &["phase"],
-            exponential_bucket_interval(0.1, 10_000_000.0),
-        )
-    });
-
-    pub static STATE_HASH_COMPUTATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "state_hash_computation_latency",
-            "Time to recompute the state hash, in microseconds",
-            &["phase"],
-            exponential_bucket_interval(1.0, 2_000_000.0),
-        )
-    });
-
-    pub static NUM_OUTBOXES: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "num_outboxes",
-            "Number of outboxes",
-            &[],
-            exponential_bucket_interval(1.0, 1_000_000.0),
-        )
-    });
-
-    pub static OUTBOX_COUNTERS_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "outbox_counters_size",
-            "Number of entries in the outbox_counters map (in-flight message heights)",
-            &[],
-            exponential_bucket_interval(1.0, 1_000_000.0),
-        )
-    });
 
     /// Tracks block execution metrics in Prometheus, labeled by the execution `phase`.
     pub(crate) fn track_block_metrics(
@@ -271,6 +161,104 @@ pub(crate) mod metrics {
         VM_BYTES_WRITTEN_PER_BLOCK
             .with_label_values(phase)
             .observe(tracker.bytes_written as f64);
+    }
+
+    linera_base::declare_metrics! {
+        pub static NUM_BLOCKS_EXECUTED: IntCounterVec =
+            register_int_counter_vec(
+                "num_blocks_executed",
+                "Number of blocks executed",
+                &["phase"],
+            );
+
+        pub static BLOCK_EXECUTION_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "block_execution_latency",
+                "Block execution latency",
+                &["phase"],
+                exponential_bucket_interval(50.0_f64, 10_000_000.0),
+            );
+
+        #[cfg(with_metrics)]
+        pub static MESSAGE_EXECUTION_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "message_execution_latency",
+                "Message execution latency",
+                &["phase"],
+                exponential_bucket_interval(0.1_f64, 50_000.0),
+            );
+
+        pub static OPERATION_EXECUTION_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "operation_execution_latency",
+                "Operation execution latency",
+                &["phase"],
+                exponential_bucket_interval(0.1_f64, 50_000.0),
+            );
+
+        pub static WASM_FUEL_USED_PER_BLOCK: HistogramVec =
+            register_histogram_vec(
+                "wasm_fuel_used_per_block",
+                "Wasm fuel used per block",
+                &["phase"],
+                exponential_bucket_interval(10.0, 100_000_000.0),
+            );
+
+        pub static EVM_FUEL_USED_PER_BLOCK: HistogramVec =
+            register_histogram_vec(
+                "evm_fuel_used_per_block",
+                "EVM fuel used per block",
+                &["phase"],
+                exponential_bucket_interval(10.0, 100_000_000.0),
+            );
+
+        pub static VM_NUM_READS_PER_BLOCK: HistogramVec =
+            register_histogram_vec(
+                "vm_num_reads_per_block",
+                "VM number of reads per block",
+                &["phase"],
+                exponential_bucket_interval(0.1, 100.0),
+            );
+
+        pub static VM_BYTES_READ_PER_BLOCK: HistogramVec =
+            register_histogram_vec(
+                "vm_bytes_read_per_block",
+                "VM number of bytes read per block",
+                &["phase"],
+                exponential_bucket_interval(0.1, 10_000_000.0),
+            );
+
+        pub static VM_BYTES_WRITTEN_PER_BLOCK: HistogramVec =
+            register_histogram_vec(
+                "vm_bytes_written_per_block",
+                "VM number of bytes written per block",
+                &["phase"],
+                exponential_bucket_interval(0.1, 10_000_000.0),
+            );
+
+        pub static STATE_HASH_COMPUTATION_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "state_hash_computation_latency",
+                "Time to recompute the state hash, in microseconds",
+                &["phase"],
+                exponential_bucket_interval(1.0, 2_000_000.0),
+            );
+
+        pub static NUM_OUTBOXES: HistogramVec =
+            register_histogram_vec(
+                "num_outboxes",
+                "Number of outboxes",
+                &[],
+                exponential_bucket_interval(1.0, 1_000_000.0),
+            );
+
+        pub static OUTBOX_COUNTERS_SIZE: HistogramVec =
+            register_histogram_vec(
+                "outbox_counters_size",
+                "Number of entries in the outbox_counters map (in-flight message heights)",
+                &[],
+                exponential_bucket_interval(1.0, 1_000_000.0),
+            );
     }
 }
 

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -25,29 +25,27 @@ use crate::{data_types::MessageBundle, ChainError};
 mod inbox_tests;
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_interval, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    pub static INBOX_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "inbox_size",
-            "Inbox size",
-            &[],
-            exponential_bucket_interval(1.0, 2_000_000.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        pub static INBOX_SIZE: HistogramVec =
+            register_histogram_vec(
+                "inbox_size",
+                "Inbox size",
+                &[],
+                exponential_bucket_interval(1.0, 2_000_000.0),
+            );
 
-    pub static REMOVED_BUNDLES: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "removed_bundles",
-            "Number of bundles removed by anticipation",
-            &[],
-            exponential_bucket_interval(1.0, 10_000.0),
-        )
-    });
+        pub static REMOVED_BUNDLES: HistogramVec =
+            register_histogram_vec(
+                "removed_bundles",
+                "Number of bundles removed by anticipation",
+                &[],
+                exponential_bucket_interval(1.0, 10_000.0),
+            );
+    }
 }
 
 /// The state of an inbox.

--- a/linera-chain/src/justification/mod.rs
+++ b/linera-chain/src/justification/mod.rs
@@ -67,23 +67,22 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_interval, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    /// The number of links in a justification chain a node verified. A chain grows by one link
-    /// per round a block had to fight through, so a rising tail here signals contention on some
-    /// height before it becomes a certificate-size or finalization problem.
-    pub static JUSTIFICATION_CHAIN_LENGTH: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "justification_chain_length",
-            "Number of links in a verified justification chain",
-            &[],
-            exponential_bucket_interval(1.0, 1024.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        /// The number of links in a justification chain a node verified. A chain grows by one link
+        /// per round a block had to fight through, so a rising tail here signals contention on some
+        /// height before it becomes a certificate-size or finalization problem.
+        pub static JUSTIFICATION_CHAIN_LENGTH: HistogramVec =
+            register_histogram_vec(
+                "justification_chain_length",
+                "Number of links in a verified justification chain",
+                &[],
+                exponential_bucket_interval(1.0, 1024.0),
+            );
+    }
 }
 
 /// One link in a justification chain: a quorum of validators that all voted to validate the

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -315,3 +315,19 @@ where
         self.map_err(|error| ChainError::ExecutionError(Box::new(error.into()), context))
     }
 }
+
+/// Registers every metric this crate declares.
+///
+/// Without this, a metric is only exported after the code path that observes it has run, so a
+/// rarely-taken path leaves its panels blank and makes a routine restart look like the metric
+/// was removed.
+#[cfg(with_metrics)]
+pub fn init_metrics() {
+    linera_base::init_metrics();
+    linera_execution::init_metrics();
+    linera_views::init_metrics();
+    chain::metrics::init_metrics();
+    inbox::metrics::init_metrics();
+    justification::metrics::init_metrics();
+    outbox::metrics::init_metrics();
+}

--- a/linera-chain/src/outbox.rs
+++ b/linera-chain/src/outbox.rs
@@ -21,19 +21,18 @@ mod outbox_tests;
 
 #[cfg(with_metrics)]
 pub(crate) mod metrics {
-    use std::sync::LazyLock;
-
     use linera_base::prometheus_util::{exponential_bucket_interval, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    pub static OUTBOX_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "outbox_size",
-            "Outbox size",
-            &[],
-            exponential_bucket_interval(1.0, 1_000_000.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        pub static OUTBOX_SIZE: HistogramVec =
+            register_histogram_vec(
+                "outbox_size",
+                "Outbox size",
+                &[],
+                exponential_bucket_interval(1.0, 1_000_000.0),
+            );
+    }
 }
 
 /// The state of an outbox

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -62,46 +62,42 @@ use crate::{
 pub(crate) type EventSubscriptionsResult = Vec<((ChainId, StreamId), EventSubscriptions)>;
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{
         exponential_bucket_interval, exponential_bucket_latencies, register_histogram,
         register_histogram_vec, register_int_counter, register_int_counter_vec,
     };
     use prometheus::{Histogram, HistogramVec, IntCounter, IntCounterVec};
 
-    pub static CREATE_NETWORK_ACTIONS_LATENCY: LazyLock<Histogram> = LazyLock::new(|| {
-        register_histogram(
-            "create_network_actions_latency",
-            "Time (ms) to create network actions",
-            exponential_bucket_latencies(10_000.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        pub static CREATE_NETWORK_ACTIONS_LATENCY: Histogram =
+            register_histogram(
+                "create_network_actions_latency",
+                "Time (ms) to create network actions",
+                exponential_bucket_latencies(10_000.0),
+            );
 
-    pub static NUM_INBOXES: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "num_inboxes",
-            "Number of inboxes",
-            &[],
-            exponential_bucket_interval(1.0, 10_000.0),
-        )
-    });
+        pub static NUM_INBOXES: HistogramVec =
+            register_histogram_vec(
+                "num_inboxes",
+                "Number of inboxes",
+                &[],
+                exponential_bucket_interval(1.0, 10_000.0),
+            );
 
-    pub static BLOCK_PROPOSALS_RECEIVED_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
-        register_int_counter(
-            "block_proposals_received_total",
-            "Total number of block proposals received by the worker",
-        )
-    });
+        pub static BLOCK_PROPOSALS_RECEIVED_TOTAL: IntCounter =
+            register_int_counter(
+                "block_proposals_received_total",
+                "Total number of block proposals received by the worker",
+            );
 
-    pub static BLOCK_PROPOSALS_REJECTED_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "block_proposals_rejected_total",
-            "Total number of block proposals rejected by the worker, labelled by error type",
-            &["error_type"],
-        )
-    });
+        pub static BLOCK_PROPOSALS_REJECTED_TOTAL: IntCounterVec =
+            register_int_counter_vec(
+                "block_proposals_rejected_total",
+                "Total number of block proposals rejected by the worker, labelled by error type",
+                &["error_type"],
+            );
+    }
 }
 
 /// The state of the chain worker.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -78,67 +78,60 @@ mod received_log;
 mod validator_trackers;
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{
         exponential_bucket_latencies, register_histogram_vec, register_int_counter_vec,
     };
     use prometheus::{HistogramVec, IntCounterVec};
 
-    pub static PROCESS_INBOX_WITHOUT_PREPARE_LATENCY: LazyLock<HistogramVec> =
-        LazyLock::new(|| {
+    linera_base::declare_metrics! {
+        pub static PROCESS_INBOX_WITHOUT_PREPARE_LATENCY: HistogramVec =
             register_histogram_vec(
                 "process_inbox_latency",
                 "process_inbox latency",
                 &[],
                 exponential_bucket_latencies(10_000.0),
-            )
-        });
+            );
 
-    pub static PREPARE_CHAIN_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "prepare_chain_latency",
-            "prepare_chain latency",
-            &[],
-            exponential_bucket_latencies(10_000.0),
-        )
-    });
+        pub static PREPARE_CHAIN_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "prepare_chain_latency",
+                "prepare_chain latency",
+                &[],
+                exponential_bucket_latencies(10_000.0),
+            );
 
-    pub static SYNCHRONIZE_CHAIN_STATE_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "synchronize_chain_state_latency",
-            "synchronize_chain_state latency",
-            &[],
-            exponential_bucket_latencies(10_000.0),
-        )
-    });
+        pub static SYNCHRONIZE_CHAIN_STATE_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "synchronize_chain_state_latency",
+                "synchronize_chain_state latency",
+                &[],
+                exponential_bucket_latencies(10_000.0),
+            );
 
-    pub static EXECUTE_BLOCK_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "execute_block_latency",
-            "execute_block latency",
-            &[],
-            exponential_bucket_latencies(10_000.0),
-        )
-    });
+        pub static EXECUTE_BLOCK_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "execute_block_latency",
+                "execute_block latency",
+                &[],
+                exponential_bucket_latencies(10_000.0),
+            );
 
-    pub static FIND_RECEIVED_CERTIFICATES_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "find_received_certificates_latency",
-            "find_received_certificates latency",
-            &[],
-            exponential_bucket_latencies(10_000.0),
-        )
-    });
+        pub static FIND_RECEIVED_CERTIFICATES_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "find_received_certificates_latency",
+                "find_received_certificates latency",
+                &[],
+                exponential_bucket_latencies(10_000.0),
+            );
 
-    pub static BLOCK_STAGING_FAILURES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "block_staging_failures_total",
-            "Total number of client block staging (execute_block) failures, labelled by error type",
-            &["error_type"],
-        )
-    });
+        pub static BLOCK_STAGING_FAILURES_TOTAL: IntCounterVec =
+            register_int_counter_vec(
+                "block_staging_failures_total",
+                "Total number of client block staging (execute_block) failures, labelled by error type",
+                &["error_type"],
+            );
+    }
 }
 
 /// Default number of certificates to download in a single batch.

--- a/linera-core/src/client/requests_scheduler/mod.rs
+++ b/linera-core/src/client/requests_scheduler/mod.rs
@@ -59,3 +59,8 @@ impl Default for RequestsSchedulerConfig {
         }
     }
 }
+
+#[cfg(with_metrics)]
+pub(crate) fn init_metrics() {
+    scheduler::metrics::init_metrics();
+}

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -35,58 +35,53 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-pub(super) mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{
         exponential_bucket_latencies, register_histogram_vec, register_int_counter,
         register_int_counter_vec,
     };
     use prometheus::{HistogramVec, IntCounter, IntCounterVec};
 
-    /// Histogram of response times per validator (in milliseconds)
-    pub(super) static VALIDATOR_RESPONSE_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "requests_scheduler_response_time_ms",
-            "Response time for requests to validators in milliseconds",
-            &["validator", "address"],
-            exponential_bucket_latencies(10000.0), // up to 10 seconds
-        )
-    });
+    linera_base::declare_metrics! {
+        /// Histogram of response times per validator (in milliseconds)
+        pub(super) static VALIDATOR_RESPONSE_TIME: HistogramVec =
+            register_histogram_vec(
+                "requests_scheduler_response_time_ms",
+                "Response time for requests to validators in milliseconds",
+                &["validator", "address"],
+                exponential_bucket_latencies(10000.0), // up to 10 seconds
+            );
 
-    /// Counter of total requests made to each validator
-    pub(super) static VALIDATOR_REQUEST_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "requests_scheduler_request_total",
-            "Total number of requests made to each validator",
-            &["validator", "address"],
-        )
-    });
+        /// Counter of total requests made to each validator
+        pub(super) static VALIDATOR_REQUEST_TOTAL: IntCounterVec =
+            register_int_counter_vec(
+                "requests_scheduler_request_total",
+                "Total number of requests made to each validator",
+                &["validator", "address"],
+            );
 
-    /// Counter of successful requests per validator
-    pub(super) static VALIDATOR_REQUEST_SUCCESS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "requests_scheduler_request_success",
-            "Number of successful requests to each validator",
-            &["validator", "address"],
-        )
-    });
+        /// Counter of successful requests per validator
+        pub(super) static VALIDATOR_REQUEST_SUCCESS: IntCounterVec =
+            register_int_counter_vec(
+                "requests_scheduler_request_success",
+                "Number of successful requests to each validator",
+                &["validator", "address"],
+            );
 
-    /// Counter for requests that were resolved from the response cache.
-    pub(super) static REQUEST_CACHE_DEDUPLICATION: LazyLock<IntCounter> = LazyLock::new(|| {
-        register_int_counter(
-            "requests_scheduler_request_deduplication_total",
-            "Number of requests that were deduplicated by finding the result in the cache.",
-        )
-    });
+        /// Counter for requests that were resolved from the response cache.
+        pub(super) static REQUEST_CACHE_DEDUPLICATION: IntCounter =
+            register_int_counter(
+                "requests_scheduler_request_deduplication_total",
+                "Number of requests that were deduplicated by finding the result in the cache.",
+            );
 
-    /// Counter for requests that were served from cache
-    pub static REQUEST_CACHE_HIT: LazyLock<IntCounter> = LazyLock::new(|| {
-        register_int_counter(
-            "requests_scheduler_request_cache_hit_total",
-            "Number of requests that were served from cache",
-        )
-    });
+        /// Counter for requests that were served from cache
+        pub static REQUEST_CACHE_HIT: IntCounter =
+            register_int_counter(
+                "requests_scheduler_request_cache_hit_total",
+                "Number of requests that were served from cache",
+            );
+    }
 }
 
 /// Manages a pool of validator nodes with intelligent load balancing and performance tracking.

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -55,3 +55,23 @@ pub use genesis_config::GenesisConfig;
 /// The maximum number of entries in a `received_log` included in a `ChainInfo` response.
 // TODO(#4638): Revisit the number.
 pub const CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES: usize = 20_000;
+
+/// Registers every metric this crate declares.
+///
+/// Without this, a metric is only exported after the code path that observes it has run, so a
+/// rarely-taken path leaves its panels blank and makes a routine restart look like the metric
+/// was removed.
+#[cfg(with_metrics)]
+pub fn init_metrics() {
+    linera_base::init_metrics();
+    linera_cache::init_metrics();
+    linera_chain::init_metrics();
+    linera_execution::init_metrics();
+    linera_storage::init_metrics();
+    linera_views::init_metrics();
+    chain_worker::state::metrics::init_metrics();
+    client::metrics::init_metrics();
+    client::requests_scheduler::init_metrics();
+    updater::metrics::init_metrics();
+    worker::metrics::init_metrics();
+}

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -48,56 +48,53 @@ pub type ClockSkewReport = (ValidatorPublicKey, TimeDelta);
 const MAX_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24); // 1 day.
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{
         exponential_bucket_latencies, register_histogram_vec, register_int_counter_vec,
     };
     use prometheus::{HistogramVec, IntCounterVec};
 
-    /// Requests dispatched to each validator while communicating with a quorum.
-    ///
-    /// Incremented at dispatch rather than on completion, so the series exists even for a
-    /// validator that never answers. Subtracting the responses below from this yields the
-    /// share of requests a validator left unanswered.
-    ///
-    /// The `address` label carries the validator's gRPC URL so that dashboards and alerts can
-    /// name a validator without an out-of-band lookup of its public key. It is functionally
-    /// dependent on `validator`, so it adds no series.
-    pub(super) static QUORUM_REQUESTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "communicate_with_quorum_requests_total",
-            "Requests dispatched to each validator while communicating with a quorum",
-            &["validator", "address"],
-        )
-    });
+    linera_base::declare_metrics! {
+        /// Requests dispatched to each validator while communicating with a quorum.
+        ///
+        /// Incremented at dispatch rather than on completion, so the series exists even for a
+        /// validator that never answers. Subtracting the responses below from this yields the
+        /// share of requests a validator left unanswered.
+        ///
+        /// The `address` label carries the validator's gRPC URL so that dashboards and alerts can
+        /// name a validator without an out-of-band lookup of its public key. It is functionally
+        /// dependent on `validator`, so it adds no series.
+        pub(super) static QUORUM_REQUESTS: IntCounterVec =
+            register_int_counter_vec(
+                "communicate_with_quorum_requests_total",
+                "Requests dispatched to each validator while communicating with a quorum",
+                &["validator", "address"],
+            );
 
-    /// Responses received from each validator while communicating with a quorum.
-    ///
-    /// The `outcome` label is `before_quorum` when the response arrived while a quorum was
-    /// still outstanding, and `after_quorum` when it only arrived during the grace period
-    /// that follows a quorum being reached. A validator whose responses are consistently
-    /// `after_quorum` is holding up nothing yet, but it is the one that will stall
-    /// confirmation as soon as any other validator degrades.
-    pub(super) static QUORUM_RESPONSES: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "communicate_with_quorum_responses_total",
-            "Responses from each validator, by whether a quorum had already been reached",
-            &["validator", "address", "outcome"],
-        )
-    });
+        /// Responses received from each validator while communicating with a quorum.
+        ///
+        /// The `outcome` label is `before_quorum` when the response arrived while a quorum was
+        /// still outstanding, and `after_quorum` when it only arrived during the grace period
+        /// that follows a quorum being reached. A validator whose responses are consistently
+        /// `after_quorum` is holding up nothing yet, but it is the one that will stall
+        /// confirmation as soon as any other validator degrades.
+        pub(super) static QUORUM_RESPONSES: IntCounterVec =
+            register_int_counter_vec(
+                "communicate_with_quorum_responses_total",
+                "Responses from each validator, by whether a quorum had already been reached",
+                &["validator", "address", "outcome"],
+            );
 
-    /// Time each validator took to respond while communicating with a quorum.
-    pub(super) static QUORUM_RESPONSE_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "communicate_with_quorum_response_time_ms",
-            "Time taken by each validator to respond while communicating with a quorum, \
-             in milliseconds",
-            &["validator", "address"],
-            exponential_bucket_latencies(60_000.0),
-        )
-    });
+        /// Time each validator took to respond while communicating with a quorum.
+        pub(super) static QUORUM_RESPONSE_TIME: HistogramVec =
+            register_histogram_vec(
+                "communicate_with_quorum_response_time_ms",
+                "Time taken by each validator to respond while communicating with a quorum, \
+                 in milliseconds",
+                &["validator", "address"],
+                exponential_bucket_latencies(60_000.0),
+            );
+    }
 }
 
 /// Used for `communicate_chain_action`

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -101,99 +101,13 @@ pub(crate) fn wrap_future<F: std::future::Future>(f: F) -> F {
 }
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{
         exponential_bucket_interval, register_histogram, register_histogram_vec,
         register_int_counter, register_int_counter_vec,
     };
     use linera_chain::{data_types::MessageAction, types::ConfirmedBlockCertificate};
     use prometheus::{Histogram, HistogramVec, IntCounter, IntCounterVec};
-
-    pub static NUM_ROUNDS_IN_CERTIFICATE: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "num_rounds_in_certificate",
-            "Number of rounds in certificate",
-            &["certificate_value", "round_type"],
-            exponential_bucket_interval(0.1, 50.0),
-        )
-    });
-
-    pub static NUM_ROUNDS_IN_BLOCK_PROPOSAL: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "num_rounds_in_block_proposal",
-            "Number of rounds in block proposal",
-            &["round_type"],
-            exponential_bucket_interval(0.1, 50.0),
-        )
-    });
-
-    pub static TRANSACTION_COUNT: LazyLock<IntCounterVec> =
-        LazyLock::new(|| register_int_counter_vec("transaction_count", "Transaction count", &[]));
-
-    pub static INCOMING_BUNDLE_COUNT: LazyLock<IntCounter> =
-        LazyLock::new(|| register_int_counter("incoming_bundle_count", "Incoming bundle count"));
-
-    pub static REJECTED_BUNDLE_COUNT: LazyLock<IntCounter> =
-        LazyLock::new(|| register_int_counter("rejected_bundle_count", "Rejected bundle count"));
-
-    pub static INCOMING_MESSAGE_COUNT: LazyLock<IntCounter> =
-        LazyLock::new(|| register_int_counter("incoming_message_count", "Incoming message count"));
-
-    pub static OPERATION_COUNT: LazyLock<IntCounter> =
-        LazyLock::new(|| register_int_counter("operation_count", "Operation count"));
-
-    pub static OPERATIONS_PER_BLOCK: LazyLock<Histogram> = LazyLock::new(|| {
-        register_histogram(
-            "operations_per_block",
-            "Number of operations per block",
-            exponential_bucket_interval(1.0, 10000.0),
-        )
-    });
-
-    pub static INCOMING_BUNDLES_PER_BLOCK: LazyLock<Histogram> = LazyLock::new(|| {
-        register_histogram(
-            "incoming_bundles_per_block",
-            "Number of incoming bundles per block",
-            exponential_bucket_interval(1.0, 10000.0),
-        )
-    });
-
-    pub static TRANSACTIONS_PER_BLOCK: LazyLock<Histogram> = LazyLock::new(|| {
-        register_histogram(
-            "transactions_per_block",
-            "Number of transactions per block",
-            exponential_bucket_interval(1.0, 10000.0),
-        )
-    });
-
-    pub static NUM_BLOCKS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec("num_blocks", "Number of blocks added to chains", &[])
-    });
-
-    pub static CERTIFICATES_SIGNED: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "certificates_signed",
-            "Number of confirmed block certificates signed by each validator",
-            &["validator_name"],
-        )
-    });
-
-    pub static CHAIN_INFO_QUERIES: LazyLock<IntCounter> = LazyLock::new(|| {
-        register_int_counter(
-            "chain_info_queries",
-            "Number of chain info queries processed",
-        )
-    });
-
-    pub static CROSS_CHAIN_BATCH_SIZE: LazyLock<Histogram> = LazyLock::new(|| {
-        register_histogram(
-            "cross_chain_batch_size",
-            "Number of cross-chain requests coalesced into a single per-chain batch",
-            exponential_bucket_interval(1.0, 1000.0),
-        )
-    });
 
     /// Holds metrics data extracted from a confirmed block certificate.
     pub struct MetricsData {
@@ -272,6 +186,83 @@ mod metrics {
                     .inc();
             }
         }
+    }
+
+    linera_base::declare_metrics! {
+        pub static NUM_ROUNDS_IN_CERTIFICATE: HistogramVec =
+            register_histogram_vec(
+                "num_rounds_in_certificate",
+                "Number of rounds in certificate",
+                &["certificate_value", "round_type"],
+                exponential_bucket_interval(0.1, 50.0),
+            );
+
+        pub static NUM_ROUNDS_IN_BLOCK_PROPOSAL: HistogramVec =
+            register_histogram_vec(
+                "num_rounds_in_block_proposal",
+                "Number of rounds in block proposal",
+                &["round_type"],
+                exponential_bucket_interval(0.1, 50.0),
+            );
+
+        pub static TRANSACTION_COUNT: IntCounterVec =
+            register_int_counter_vec("transaction_count", "Transaction count", &[]);
+
+        pub static INCOMING_BUNDLE_COUNT: IntCounter =
+            register_int_counter("incoming_bundle_count", "Incoming bundle count");
+
+        pub static REJECTED_BUNDLE_COUNT: IntCounter =
+            register_int_counter("rejected_bundle_count", "Rejected bundle count");
+
+        pub static INCOMING_MESSAGE_COUNT: IntCounter =
+            register_int_counter("incoming_message_count", "Incoming message count");
+
+        pub static OPERATION_COUNT: IntCounter =
+            register_int_counter("operation_count", "Operation count");
+
+        pub static OPERATIONS_PER_BLOCK: Histogram =
+            register_histogram(
+                "operations_per_block",
+                "Number of operations per block",
+                exponential_bucket_interval(1.0, 10000.0),
+            );
+
+        pub static INCOMING_BUNDLES_PER_BLOCK: Histogram =
+            register_histogram(
+                "incoming_bundles_per_block",
+                "Number of incoming bundles per block",
+                exponential_bucket_interval(1.0, 10000.0),
+            );
+
+        pub static TRANSACTIONS_PER_BLOCK: Histogram =
+            register_histogram(
+                "transactions_per_block",
+                "Number of transactions per block",
+                exponential_bucket_interval(1.0, 10000.0),
+            );
+
+        pub static NUM_BLOCKS: IntCounterVec =
+            register_int_counter_vec("num_blocks", "Number of blocks added to chains", &[]);
+
+        pub static CERTIFICATES_SIGNED: IntCounterVec =
+            register_int_counter_vec(
+                "certificates_signed",
+                "Number of confirmed block certificates signed by each validator",
+                &["validator_name"],
+            );
+
+        pub static CHAIN_INFO_QUERIES: IntCounter =
+            register_int_counter(
+                "chain_info_queries",
+                "Number of chain info queries processed",
+            );
+
+        pub static CROSS_CHAIN_BATCH_SIZE: Histogram =
+            register_histogram(
+                "cross_chain_batch_size",
+                "Number of cross-chain requests coalesced into a single per-chain batch",
+                exponential_bucket_interval(1.0, 1000.0),
+            );
     }
 }
 

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -117,29 +117,27 @@ pub const ALREADY_CREATED_CONTRACT_SELECTOR: &[u8] = &[23, 47, 106, 235];
 pub const JSON_EMPTY_VECTOR: &[u8] = &[91, 93];
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    pub static CONTRACT_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "evm_contract_instantiation_latency",
-            "EVM contract instantiation latency",
-            &[],
-            exponential_bucket_latencies(100.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        pub static CONTRACT_INSTANTIATION_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "evm_contract_instantiation_latency",
+                "EVM contract instantiation latency",
+                &[],
+                exponential_bucket_latencies(100.0),
+            );
 
-    pub static SERVICE_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "evm_service_instantiation_latency",
-            "EVM service instantiation latency",
-            &[],
-            exponential_bucket_latencies(100.0),
-        )
-    });
+        pub static SERVICE_INSTANTIATION_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "evm_service_instantiation_latency",
+                "EVM service instantiation latency",
+                &[],
+                exponential_bucket_latencies(100.0),
+            );
+    }
 }
 
 /// A user contract in a compiled EVM module.

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -50,31 +50,29 @@ pub struct ExecutionStateActor<'a, C> {
 }
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    /// Histogram of the latency to load a contract bytecode.
-    pub static LOAD_CONTRACT_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "load_contract_latency",
-            "Load contract latency",
-            &[],
-            exponential_bucket_latencies(250.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        /// Histogram of the latency to load a contract bytecode.
+        pub static LOAD_CONTRACT_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "load_contract_latency",
+                "Load contract latency",
+                &[],
+                exponential_bucket_latencies(250.0),
+            );
 
-    /// Histogram of the latency to load a service bytecode.
-    pub static LOAD_SERVICE_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "load_service_latency",
-            "Load service latency",
-            &[],
-            exponential_bucket_latencies(250.0),
-        )
-    });
+        /// Histogram of the latency to load a service bytecode.
+        pub static LOAD_SERVICE_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "load_service_latency",
+                "Load service latency",
+                &[],
+                exponential_bucket_latencies(250.0),
+            );
+    }
 }
 
 pub(crate) type ExecutionStateSender = mpsc::UnboundedSender<ExecutionRequest>;

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1794,3 +1794,19 @@ doc_scalar!(
     "A message to be sent and possibly executed in the receiver's block."
 );
 doc_scalar!(MessageKind, "The kind of outgoing message being sent");
+
+/// Registers every metric this crate declares.
+///
+/// Without this, a metric is only exported after the code path that observes it has run, so a
+/// rarely-taken path leaves its panels blank and makes a routine restart look like the metric
+/// was removed.
+#[cfg(with_metrics)]
+pub fn init_metrics() {
+    linera_base::init_metrics();
+    linera_views::init_metrics();
+    #[cfg(with_revm)]
+    evm::revm::metrics::init_metrics();
+    execution_state_actor::metrics::init_metrics();
+    system::metrics::init_metrics();
+    wasm::metrics::init_metrics();
+}

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -61,19 +61,18 @@ pub struct EpochEventData {
 
 /// The number of times the [`SystemOperation::OpenChain`] was executed.
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::register_int_counter_vec;
     use prometheus::IntCounterVec;
 
-    pub static OPEN_CHAIN_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "open_chain_count",
-            "The number of times the `OpenChain` operation was executed",
-            &[],
-        )
-    });
+    linera_base::declare_metrics! {
+        pub static OPEN_CHAIN_COUNT: IntCounterVec =
+            register_int_counter_vec(
+                "open_chain_count",
+                "The number of times the `OpenChain` operation was executed",
+                &[],
+            );
+    }
 }
 
 /// Per-block state of a chain: the timestamp of its most recent block together with

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -41,40 +41,37 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{
         exponential_bucket_interval, exponential_bucket_latencies, register_histogram_vec,
     };
     use prometheus::HistogramVec;
 
-    pub static CONTRACT_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "wasm_contract_instantiation_latency",
-            "Wasm contract instantiation latency",
-            &[],
-            exponential_bucket_latencies(100.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        pub static CONTRACT_INSTANTIATION_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "wasm_contract_instantiation_latency",
+                "Wasm contract instantiation latency",
+                &[],
+                exponential_bucket_latencies(100.0),
+            );
 
-    pub static SERVICE_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "wasm_service_instantiation_latency",
-            "Wasm service instantiation latency",
-            &[],
-            exponential_bucket_latencies(100.0),
-        )
-    });
+        pub static SERVICE_INSTANTIATION_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "wasm_service_instantiation_latency",
+                "Wasm service instantiation latency",
+                &[],
+                exponential_bucket_latencies(100.0),
+            );
 
-    pub static WASM_BYTECODE_SIZE_BYTES: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "wasm_bytecode_size_bytes",
-            "Size in bytes of WASM bytecodes being loaded",
-            &["type"],
-            exponential_bucket_interval(10_000.0, 100_000_000.0),
-        )
-    });
+        pub static WASM_BYTECODE_SIZE_BYTES: HistogramVec =
+            register_histogram_vec(
+                "wasm_bytecode_size_bytes",
+                "Size in bytes of WASM bytecodes being loaded",
+                &["type"],
+                exponential_bucket_interval(10_000.0, 100_000_000.0),
+            );
+    }
 }
 
 /// A user contract in a compiled WebAssembly module.

--- a/linera-exporter/src/lib.rs
+++ b/linera-exporter/src/lib.rs
@@ -24,3 +24,20 @@ pub mod util;
 
 #[cfg(test)]
 mod test_utils;
+
+/// Registers every metric this crate declares.
+///
+/// Without this, a metric is only exported after the code path that observes it has run, so a
+/// rarely-taken path leaves its panels blank and makes a routine restart look like the metric
+/// was removed.
+#[cfg(with_metrics)]
+pub fn init_metrics() {
+    linera_base::init_metrics();
+    linera_chain::init_metrics();
+    linera_core::init_metrics();
+    linera_execution::init_metrics();
+    linera_rpc::init_metrics();
+    linera_storage::init_metrics();
+    linera_views::init_metrics();
+    metrics::init_metrics();
+}

--- a/linera-exporter/src/main.rs
+++ b/linera-exporter/src/main.rs
@@ -167,12 +167,11 @@ impl Runnable for ExporterContext {
         tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
 
         #[cfg(with_metrics)]
-        linera_exporter::init_metrics();
-        #[cfg(with_metrics)]
         monitoring_server::start_metrics_with_profiling(
             self.config.metrics_address(),
             shutdown_notifier.clone(),
             self.enable_memory_profiling,
+            linera_exporter::init_metrics,
         )
         .await;
 

--- a/linera-exporter/src/main.rs
+++ b/linera-exporter/src/main.rs
@@ -167,6 +167,8 @@ impl Runnable for ExporterContext {
         tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
 
         #[cfg(with_metrics)]
+        linera_exporter::init_metrics();
+        #[cfg(with_metrics)]
         monitoring_server::start_metrics_with_profiling(
             self.config.metrics_address(),
             shutdown_notifier.clone(),

--- a/linera-exporter/src/metrics.rs
+++ b/linera-exporter/src/metrics.rs
@@ -1,89 +1,80 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::LazyLock;
-
 use linera_base::prometheus_util::{self};
 use prometheus::{Histogram, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec};
 
-pub(crate) static GET_BLOB_HISTOGRAM: LazyLock<Histogram> = LazyLock::new(|| {
-    prometheus_util::register_histogram_with_subsystem(
-        "exporter",
-        "get_blob_ms",
-        "Time it took to read a blob from the storage",
-        None,
-    )
-});
+linera_base::declare_metrics! {
+    pub(crate) static GET_BLOB_HISTOGRAM: Histogram =
+        prometheus_util::register_histogram_with_subsystem(
+            "exporter",
+            "get_blob_ms",
+            "Time it took to read a blob from the storage",
+            None,
+        );
 
-pub(crate) static GET_CERTIFICATE_HISTOGRAM: LazyLock<Histogram> = LazyLock::new(|| {
-    prometheus_util::register_histogram_with_subsystem(
-        "exporter",
-        "get_certificate_ms",
-        "Time it took to read a certificate from the storage",
-        None,
-    )
-});
+    pub(crate) static GET_CERTIFICATE_HISTOGRAM: Histogram =
+        prometheus_util::register_histogram_with_subsystem(
+            "exporter",
+            "get_certificate_ms",
+            "Time it took to read a certificate from the storage",
+            None,
+        );
 
-pub(crate) static GET_CANONICAL_BLOCK_HISTOGRAM: LazyLock<Histogram> = LazyLock::new(|| {
-    prometheus_util::register_histogram_with_subsystem(
-        "exporter",
-        "get_canonical_block_ms",
-        "Time it took to read a canonical block from the storage",
-        None,
-    )
-});
+    pub(crate) static GET_CANONICAL_BLOCK_HISTOGRAM: Histogram =
+        prometheus_util::register_histogram_with_subsystem(
+            "exporter",
+            "get_canonical_block_ms",
+            "Time it took to read a canonical block from the storage",
+            None,
+        );
 
-pub(crate) static SAVE_HISTOGRAM: LazyLock<Histogram> = LazyLock::new(|| {
-    prometheus_util::register_histogram_with_subsystem(
-        "exporter",
-        "state_save_ms",
-        "Time it took to save the exporter state to the storage",
-        None,
-    )
-});
+    pub(crate) static SAVE_HISTOGRAM: Histogram =
+        prometheus_util::register_histogram_with_subsystem(
+            "exporter",
+            "state_save_ms",
+            "Time it took to save the exporter state to the storage",
+            None,
+        );
 
-pub(crate) static DISPATCH_BLOCK_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec_with_subsystem(
-        "exporter",
-        "dispatch_block_ms",
-        "Time it took to dispatch a block to a destination",
-        &["destination"],
-        None,
-    )
-});
+    pub(crate) static DISPATCH_BLOCK_HISTOGRAM: HistogramVec =
+        prometheus_util::register_histogram_vec_with_subsystem(
+            "exporter",
+            "dispatch_block_ms",
+            "Time it took to dispatch a block to a destination",
+            &["destination"],
+            None,
+        );
 
-pub(crate) static DISPATCH_BLOB_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec_with_subsystem(
-        "exporter",
-        "dispatch_blob_ms",
-        "Time it took to dispatch a blob to a validator destination",
-        &["destination"],
-        None,
-    )
-});
+    pub(crate) static DISPATCH_BLOB_HISTOGRAM: HistogramVec =
+        prometheus_util::register_histogram_vec_with_subsystem(
+            "exporter",
+            "dispatch_blob_ms",
+            "Time it took to dispatch a blob to a validator destination",
+            &["destination"],
+            None,
+        );
 
-pub(crate) static DESTINATION_STATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec_with_subsystem(
-        "exporter",
-        "destination_state_counter",
-        "Current state (height) of the destination as seen by the exporter",
-        &["destination"],
-    )
-});
+    pub(crate) static DESTINATION_STATE_COUNTER: IntCounterVec =
+        prometheus_util::register_int_counter_vec_with_subsystem(
+            "exporter",
+            "destination_state_counter",
+            "Current state (height) of the destination as seen by the exporter",
+            &["destination"],
+        );
 
-pub(crate) static VALIDATOR_EXPORTER_QUEUE_LENGTH: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-    prometheus_util::register_int_gauge_vec_with_subsystem(
-        "exporter",
-        "validator_queue_length",
-        "Length of the block queue for validator exporters",
-        &["destination"],
-    )
-});
+    pub(crate) static VALIDATOR_EXPORTER_QUEUE_LENGTH: IntGaugeVec =
+        prometheus_util::register_int_gauge_vec_with_subsystem(
+            "exporter",
+            "validator_queue_length",
+            "Length of the block queue for validator exporters",
+            &["destination"],
+        );
 
-pub(crate) static EXPORTER_NOTIFICATION_QUEUE_LENGTH: LazyLock<IntGauge> = LazyLock::new(|| {
-    prometheus_util::register_int_gauge_with_subsystem(
-        "exporter",
-        "notification_queue_length",
-        "Length of the notification queue for the exporter service",
-    )
-});
+    pub(crate) static EXPORTER_NOTIFICATION_QUEUE_LENGTH: IntGauge =
+        prometheus_util::register_int_gauge_with_subsystem(
+            "exporter",
+            "notification_queue_length",
+            "Length of the notification queue for the exporter service",
+        );
+}

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -52,118 +52,106 @@ use crate::database::FaucetDatabase;
 
 // Prometheus metrics for the faucet
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{
         exponential_bucket_interval, register_gauge_vec, register_histogram_vec,
         register_int_counter_vec,
     };
     use prometheus::{GaugeVec, HistogramVec, IntCounterVec};
 
-    pub static CLAIM_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "faucet_claim_requests_total",
-            "Total number of claim requests by result",
-            &["result"],
-        )
-    });
+    linera_base::declare_metrics! {
+        pub static CLAIM_REQUESTS_TOTAL: IntCounterVec =
+            register_int_counter_vec(
+                "faucet_claim_requests_total",
+                "Total number of claim requests by result",
+                &["result"],
+            );
 
-    pub static CLAIM_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "faucet_claim_latency_ms",
-            "End-to-end latency of claim requests in milliseconds",
-            &["result"],
-            exponential_bucket_interval(0.5, 8000.0),
-        )
-    });
+        pub static CLAIM_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "faucet_claim_latency_ms",
+                "End-to-end latency of claim requests in milliseconds",
+                &["result"],
+                exponential_bucket_interval(0.5, 8000.0),
+            );
 
-    pub static CHAINS_CREATED_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "faucet_chains_created_total",
-            "Total number of chains created by the faucet",
-            &[],
-        )
-    });
+        pub static CHAINS_CREATED_TOTAL: IntCounterVec =
+            register_int_counter_vec(
+                "faucet_chains_created_total",
+                "Total number of chains created by the faucet",
+                &[],
+            );
 
-    pub static BATCH_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "faucet_batch_size",
-            "Number of chain creation requests per batch",
-            &[],
-            Some(vec![1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0]),
-        )
-    });
+        pub static BATCH_SIZE: HistogramVec =
+            register_histogram_vec(
+                "faucet_batch_size",
+                "Number of chain creation requests per batch",
+                &[],
+                Some(vec![1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0]),
+            );
 
-    pub static BATCH_PROCESSING_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "faucet_batch_processing_latency_ms",
-            "Time to process a batch of chain creation requests in milliseconds",
-            &["result"],
-            exponential_bucket_interval(0.5, 8000.0),
-        )
-    });
+        pub static BATCH_PROCESSING_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "faucet_batch_processing_latency_ms",
+                "Time to process a batch of chain creation requests in milliseconds",
+                &["result"],
+                exponential_bucket_interval(0.5, 8000.0),
+            );
 
-    pub static QUEUE_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "faucet_queue_size",
-            "Number of pending claim requests in the queue",
-            &[],
-            Some(vec![
-                0.0, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0,
-            ]),
-        )
-    });
+        pub static QUEUE_SIZE: HistogramVec =
+            register_histogram_vec(
+                "faucet_queue_size",
+                "Number of pending claim requests in the queue",
+                &[],
+                Some(vec![
+                    0.0, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 500.0,
+                ]),
+            );
 
-    pub static QUEUE_WAIT_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "faucet_queue_wait_time_ms",
-            "Time a request spends in the queue before processing in milliseconds",
-            &[],
-            exponential_bucket_interval(0.5, 2000.0),
-        )
-    });
+        pub static QUEUE_WAIT_TIME: HistogramVec =
+            register_histogram_vec(
+                "faucet_queue_wait_time_ms",
+                "Time a request spends in the queue before processing in milliseconds",
+                &[],
+                exponential_bucket_interval(0.5, 2000.0),
+            );
 
-    pub static FAUCET_BALANCE: LazyLock<GaugeVec> = LazyLock::new(|| {
-        register_gauge_vec(
-            "faucet_balance_amount",
-            "Current balance of the faucet chain, in tokens",
-            &[],
-        )
-    });
+        pub static FAUCET_BALANCE: GaugeVec =
+            register_gauge_vec(
+                "faucet_balance_amount",
+                "Current balance of the faucet chain, in tokens",
+                &[],
+            );
 
-    pub static RATE_LIMIT_REJECTIONS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "faucet_rate_limit_rejections_total",
-            "Number of requests rejected due to rate limiting",
-            &[],
-        )
-    });
+        pub static RATE_LIMIT_REJECTIONS: IntCounterVec =
+            register_int_counter_vec(
+                "faucet_rate_limit_rejections_total",
+                "Number of requests rejected due to rate limiting",
+                &[],
+            );
 
-    pub static INSUFFICIENT_BALANCE_REJECTIONS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "faucet_insufficient_balance_rejections_total",
-            "Number of requests rejected due to insufficient faucet balance",
-            &[],
-        )
-    });
+        pub static INSUFFICIENT_BALANCE_REJECTIONS: IntCounterVec =
+            register_int_counter_vec(
+                "faucet_insufficient_balance_rejections_total",
+                "Number of requests rejected due to insufficient faucet balance",
+                &[],
+            );
 
-    pub static DATABASE_OPERATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "faucet_database_operation_latency_ms",
-            "Database operation latency in milliseconds",
-            &["operation"],
-            exponential_bucket_interval(0.5, 2000.0),
-        )
-    });
+        pub static DATABASE_OPERATION_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "faucet_database_operation_latency_ms",
+                "Database operation latency in milliseconds",
+                &["operation"],
+                exponential_bucket_interval(0.5, 2000.0),
+            );
 
-    pub static RETRYABLE_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "faucet_retryable_errors_total",
-            "Number of chain execution retryable errors by type",
-            &["error_type"],
-        )
-    });
+        pub static RETRYABLE_ERRORS: IntCounterVec =
+            register_int_counter_vec(
+                "faucet_retryable_errors_total",
+                "Number of chain execution retryable errors by type",
+                &["error_type"],
+            );
+    }
 }
 
 /// Refusal messages returned by the claim paths. Shared as constants because the
@@ -197,6 +185,21 @@ pub(crate) async fn graphiql(uri: axum::http::Uri) -> impl axum::response::IntoR
             .subscription_endpoint("/ws")
             .finish(),
     )
+}
+
+/// Registers every metric reachable from this crate.
+///
+/// Without this, a metric is only exported after the code path that observes it has run, so a
+/// rarely-taken path leaves its panels blank and makes a routine restart look like the metric
+/// was removed.
+#[cfg(with_metrics)]
+pub fn init_metrics() {
+    linera_base::init_metrics();
+    linera_chain::init_metrics();
+    linera_core::init_metrics();
+    linera_execution::init_metrics();
+    linera_storage::init_metrics();
+    metrics::init_metrics();
 }
 
 #[cfg(test)]
@@ -1268,6 +1271,8 @@ where
         let port = self.port;
         let index_handler = axum::routing::get(graphiql).post(Self::index_handler);
 
+        #[cfg(feature = "metrics")]
+        crate::init_metrics();
         #[cfg(feature = "metrics")]
         monitoring_server::start_metrics_with_profiling(
             self.metrics_address(),

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -1272,12 +1272,11 @@ where
         let index_handler = axum::routing::get(graphiql).post(Self::index_handler);
 
         #[cfg(feature = "metrics")]
-        crate::init_metrics();
-        #[cfg(feature = "metrics")]
         monitoring_server::start_metrics_with_profiling(
             self.metrics_address(),
             cancellation_token.clone(),
             self.enable_memory_profiling,
+            crate::init_metrics,
         )
         .await;
 

--- a/linera-metrics/src/monitoring_server.rs
+++ b/linera-metrics/src/monitoring_server.rs
@@ -75,19 +75,27 @@ pub async fn start_metrics_with_profiling(
     address: impl ToSocketAddrs + Debug + Send + 'static,
     shutdown_signal: CancellationToken,
     enable_memory_profiling: bool,
+    register_metrics: impl FnOnce(),
 ) {
     let memory_profiling = MemoryProfiling::try_activate(enable_memory_profiling).await;
-    start_metrics(address, shutdown_signal, memory_profiling);
+    start_metrics(address, shutdown_signal, memory_profiling, register_metrics);
 }
 
 /// Starts the metrics HTTP server on `address`, serving `/metrics` and, when profiling is
 /// enabled and available, the memory-profiling endpoints. Runs until `shutdown_signal` fires.
+///
+/// `register_metrics` is the caller's `init_metrics`. It is a parameter rather than a direct
+/// call because this crate sits below `linera-views` and friends in the dependency graph and
+/// cannot reach their metrics; taking it here makes forgetting to register a compile error
+/// instead of a metric that silently only appears once its code path first runs.
 pub fn start_metrics(
     address: impl ToSocketAddrs + Debug + Send + 'static,
     shutdown_signal: CancellationToken,
     memory_profiling: MemoryProfiling,
+    register_metrics: impl FnOnce(),
 ) {
     crate::runtime_metrics::register();
+    register_metrics();
     let app = metrics_router(memory_profiling);
 
     tokio::spawn(async move {

--- a/linera-rpc/src/cross_chain_message_queue.rs
+++ b/linera-rpc/src/cross_chain_message_queue.rs
@@ -23,28 +23,26 @@ use tracing::{error, trace, warn};
 use crate::config::ShardId;
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{
         exponential_bucket_latencies, register_histogram, register_int_gauge,
     };
     use prometheus::{Histogram, IntGauge};
 
-    pub static CROSS_CHAIN_MESSAGE_TASKS: LazyLock<IntGauge> = LazyLock::new(|| {
-        register_int_gauge(
-            "cross_chain_message_tasks",
-            "Number of concurrent cross-chain message tasks",
-        )
-    });
+    linera_base::declare_metrics! {
+        pub static CROSS_CHAIN_MESSAGE_TASKS: IntGauge =
+            register_int_gauge(
+                "cross_chain_message_tasks",
+                "Number of concurrent cross-chain message tasks",
+            );
 
-    pub static CROSS_CHAIN_QUEUE_WAIT_TIME: LazyLock<Histogram> = LazyLock::new(|| {
-        register_histogram(
-            "cross_chain_queue_wait_time",
-            "Time (ms) a cross-chain message waits in queue before handle_request is called",
-            exponential_bucket_latencies(10_000.0),
-        )
-    });
+        pub static CROSS_CHAIN_QUEUE_WAIT_TIME: Histogram =
+            register_histogram(
+                "cross_chain_queue_wait_time",
+                "Time (ms) a cross-chain message waits in queue before handle_request is called",
+                exponential_bucket_latencies(10_000.0),
+            );
+    }
 }
 
 #[expect(clippy::too_many_arguments)]

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -28,19 +28,18 @@ use linera_chain::{
     },
 };
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::register_int_counter_vec;
     use prometheus::IntCounterVec;
 
-    pub static VALIDATOR_SUBSCRIPTION_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "validator_subscription_errors",
-            "Number of notification subscription stream errors per validator",
-            &["address"],
-        )
-    });
+    linera_base::declare_metrics! {
+        pub static VALIDATOR_SUBSCRIPTION_ERRORS: IntCounterVec =
+            register_int_counter_vec(
+                "validator_subscription_errors",
+                "Number of notification subscription stream errors per validator",
+                &["address"],
+            );
+    }
 }
 
 use linera_core::{

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -107,6 +107,13 @@ pub fn extract_grpc_method_name(path: &str) -> &str {
     }
 }
 
+#[cfg(with_metrics)]
+pub(crate) fn init_metrics() {
+    client::metrics::init_metrics();
+    #[cfg(with_server)]
+    server::metrics::init_metrics();
+}
+
 #[cfg(test)]
 mod method_name_tests {
     use super::*;

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -50,9 +50,7 @@ type CrossChainSender = mpsc::Sender<(linera_core::data_types::CrossChainRequest
 type NotificationSender = tokio::sync::broadcast::Sender<Notification>;
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{
         exponential_bucket_interval, linear_bucket_interval, register_histogram_vec,
         register_int_counter_vec,
@@ -61,87 +59,79 @@ mod metrics {
 
     use super::super::{ERROR_TYPE_LABEL, METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL};
 
-    pub static SERVER_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "server_request_latency",
-            "Server request latency",
-            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
-            linear_bucket_interval(1.0, 50.0, 5000.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        pub static SERVER_REQUEST_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "server_request_latency",
+                "Server request latency",
+                &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
+                linear_bucket_interval(1.0, 50.0, 5000.0),
+            );
 
-    pub static SERVER_REQUEST_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "server_request_count",
-            "Server request count",
-            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
-        )
-    });
+        pub static SERVER_REQUEST_COUNT: IntCounterVec =
+            register_int_counter_vec(
+                "server_request_count",
+                "Server request count",
+                &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
+            );
 
-    pub static SERVER_REQUEST_SUCCESS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "server_request_success",
-            "Server request success",
-            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
-        )
-    });
+        pub static SERVER_REQUEST_SUCCESS: IntCounterVec =
+            register_int_counter_vec(
+                "server_request_success",
+                "Server request success",
+                &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
+            );
 
-    pub static SERVER_REQUEST_ERROR: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "server_request_error",
-            "Server request error",
-            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL, ERROR_TYPE_LABEL],
-        )
-    });
+        pub static SERVER_REQUEST_ERROR: IntCounterVec =
+            register_int_counter_vec(
+                "server_request_error",
+                "Server request error",
+                &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL, ERROR_TYPE_LABEL],
+            );
 
-    pub static SERVER_REQUEST_CANCELLED: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "server_request_cancelled",
-            "Server requests whose handler future was dropped before completion (e.g. client-side timeout / disconnect)",
-            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
-        )
-    });
+        pub static SERVER_REQUEST_CANCELLED: IntCounterVec =
+            register_int_counter_vec(
+                "server_request_cancelled",
+                "Server requests whose handler future was dropped before completion (e.g. client-side timeout / disconnect)",
+                &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
+            );
 
-    pub static CROSS_CHAIN_MESSAGE_CHANNEL_FULL: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "cross_chain_message_channel_full",
-            "Cross-chain message channel full",
-            &[],
-        )
-    });
+        pub static CROSS_CHAIN_MESSAGE_CHANNEL_FULL: IntCounterVec =
+            register_int_counter_vec(
+                "cross_chain_message_channel_full",
+                "Cross-chain message channel full",
+                &[],
+            );
 
-    pub static NOTIFICATIONS_SKIPPED_RECEIVER_LAG: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "notifications_skipped_receiver_lag",
-            "Number of notifications skipped because receiver lagged behind sender",
-            &[],
-        )
-    });
+        pub static NOTIFICATIONS_SKIPPED_RECEIVER_LAG: IntCounterVec =
+            register_int_counter_vec(
+                "notifications_skipped_receiver_lag",
+                "Number of notifications skipped because receiver lagged behind sender",
+                &[],
+            );
 
-    pub static NOTIFICATIONS_DROPPED_NO_RECEIVER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "notifications_dropped_no_receiver",
-            "Number of notifications dropped because no receiver was available",
-            &[],
-        )
-    });
+        pub static NOTIFICATIONS_DROPPED_NO_RECEIVER: IntCounterVec =
+            register_int_counter_vec(
+                "notifications_dropped_no_receiver",
+                "Number of notifications dropped because no receiver was available",
+                &[],
+            );
 
-    pub static NOTIFICATION_BATCH_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "notification_batch_size",
-            "Number of notifications per batch sent to proxy",
-            &[],
-            exponential_bucket_interval(1.0, 250.0),
-        )
-    });
+        pub static NOTIFICATION_BATCH_SIZE: HistogramVec =
+            register_histogram_vec(
+                "notification_batch_size",
+                "Number of notifications per batch sent to proxy",
+                &[],
+                exponential_bucket_interval(1.0, 250.0),
+            );
 
-    pub static NOTIFICATION_BATCHES_SENT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "notification_batches_sent",
-            "Total notification batches sent",
-            &["status"],
-        )
-    });
+        pub static NOTIFICATION_BATCHES_SENT: IntCounterVec =
+            register_int_counter_vec(
+                "notification_batches_sent",
+                "Total notification batches sent",
+                &["status"],
+            );
+    }
 }
 
 /// Handles batched forwarding of notifications to proxy and exporters.

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -104,3 +104,19 @@ pub(crate) fn jittered_backoff_delay(
     let max_delay_ms = capped_delay_ms * 6 / 5; // 120%
     std::time::Duration::from_millis(rand::thread_rng().gen_range(min_delay_ms..=max_delay_ms))
 }
+
+/// Registers every metric this crate declares.
+///
+/// Without this, a metric is only exported after the code path that observes it has run, so a
+/// rarely-taken path leaves its panels blank and makes a routine restart look like the metric
+/// was removed.
+#[cfg(with_metrics)]
+pub fn init_metrics() {
+    linera_base::init_metrics();
+    linera_chain::init_metrics();
+    linera_core::init_metrics();
+    linera_execution::init_metrics();
+    linera_storage::init_metrics();
+    cross_chain_message_queue::metrics::init_metrics();
+    grpc::init_metrics();
+}

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -873,11 +873,11 @@ impl Runnable for Job {
                         #[cfg(with_metrics)]
                         {
                             let metrics_address = std::net::SocketAddr::from(([127, 0, 0, 1], 0));
-                            linera_service::init_metrics();
                             monitoring_server::start_metrics(
                                 metrics_address,
                                 shutdown_notifier.clone(),
                                 monitoring_server::MemoryProfiling::Disabled,
+                                linera_service::init_metrics,
                             );
                         }
 
@@ -1181,11 +1181,11 @@ impl Runnable for Job {
                         #[cfg(with_metrics)]
                         {
                             let metrics_address = std::net::SocketAddr::from(([127, 0, 0, 1], 0));
-                            linera_service::init_metrics();
                             monitoring_server::start_metrics(
                                 metrics_address,
                                 shutdown_notifier.clone(),
                                 monitoring_server::MemoryProfiling::Disabled,
+                                linera_service::init_metrics,
                             );
                         }
 

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -873,6 +873,7 @@ impl Runnable for Job {
                         #[cfg(with_metrics)]
                         {
                             let metrics_address = std::net::SocketAddr::from(([127, 0, 0, 1], 0));
+                            linera_service::init_metrics();
                             monitoring_server::start_metrics(
                                 metrics_address,
                                 shutdown_notifier.clone(),
@@ -1180,6 +1181,7 @@ impl Runnable for Job {
                         #[cfg(with_metrics)]
                         {
                             let metrics_address = std::net::SocketAddr::from(([127, 0, 0, 1], 0));
+                            linera_service::init_metrics();
                             monitoring_server::start_metrics(
                                 metrics_address,
                                 shutdown_notifier.clone(),

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -26,3 +26,22 @@ pub mod tracing;
 /// Assorted helper utilities for the service binaries.
 pub mod util;
 pub use linera_wallet_json::PersistentWallet as Wallet;
+
+/// Registers every metric this crate declares.
+///
+/// Without this, a metric is only exported after the code path that observes it has run, so a
+/// rarely-taken path leaves its panels blank and makes a routine restart look like the metric
+/// was removed.
+#[cfg(with_metrics)]
+pub fn init_metrics() {
+    linera_base::init_metrics();
+    linera_chain::init_metrics();
+    linera_core::init_metrics();
+    linera_execution::init_metrics();
+    linera_exporter::init_metrics();
+    linera_faucet_server::init_metrics();
+    linera_rpc::init_metrics();
+    linera_storage::init_metrics();
+    linera_views::init_metrics();
+    node_service::query_cache_metrics::init_metrics();
+}

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -1424,12 +1424,11 @@ where
             axum::routing::get(util::graphiql).post(Self::application_handler);
 
         #[cfg(with_metrics)]
-        crate::init_metrics();
-        #[cfg(with_metrics)]
         monitoring_server::start_metrics_with_profiling(
             self.metrics_address(),
             cancellation_token.clone(),
             self.enable_memory_profiling,
+            crate::init_metrics,
         )
         .await;
 

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -1075,38 +1075,34 @@ where
 }
 
 #[cfg(with_metrics)]
-mod query_cache_metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod query_cache_metrics {
     use linera_base::prometheus_util::{register_int_counter_vec, register_int_gauge};
     use prometheus::{IntCounterVec, IntGauge};
 
-    pub static QUERY_CACHE_HIT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec("query_response_cache_hit", "Query response cache hits", &[])
-    });
+    linera_base::declare_metrics! {
+        pub static QUERY_CACHE_HIT: IntCounterVec =
+            register_int_counter_vec("query_response_cache_hit", "Query response cache hits", &[]);
 
-    pub static QUERY_CACHE_MISS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "query_response_cache_miss",
-            "Query response cache misses",
-            &[],
-        )
-    });
+        pub static QUERY_CACHE_MISS: IntCounterVec =
+            register_int_counter_vec(
+                "query_response_cache_miss",
+                "Query response cache misses",
+                &[],
+            );
 
-    pub static QUERY_CACHE_INVALIDATION: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "query_response_cache_invalidation",
-            "Query response cache invalidations (per chain)",
-            &[],
-        )
-    });
+        pub static QUERY_CACHE_INVALIDATION: IntCounterVec =
+            register_int_counter_vec(
+                "query_response_cache_invalidation",
+                "Query response cache invalidations (per chain)",
+                &[],
+            );
 
-    pub static QUERY_CACHE_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
-        register_int_gauge(
-            "query_response_cache_entries",
-            "Current number of cached query responses across all chains",
-        )
-    });
+        pub static QUERY_CACHE_ENTRIES: IntGauge =
+            register_int_gauge(
+                "query_response_cache_entries",
+                "Current number of cached query responses across all chains",
+            );
+    }
 }
 
 /// Per-chain cache state: an LRU map plus the `next_block_height` at the time the
@@ -1427,6 +1423,8 @@ where
         let application_handler =
             axum::routing::get(util::graphiql).post(Self::application_handler);
 
+        #[cfg(with_metrics)]
+        crate::init_metrics();
         #[cfg(with_metrics)]
         monitoring_server::start_metrics_with_profiling(
             self.metrics_address(),

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -60,46 +60,43 @@ use tower::{builder::ServiceBuilder, Layer, Service};
 use tracing::{debug, info, instrument, Instrument as _, Level};
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{
         linear_bucket_interval, register_histogram_vec, register_int_counter_vec,
     };
     use linera_rpc::grpc::{ERROR_TYPE_LABEL, METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL};
     use prometheus::{HistogramVec, IntCounterVec};
 
-    pub static PROXY_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "proxy_request_latency",
-            "Proxy request latency",
-            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
-            linear_bucket_interval(1.0, 50.0, 5000.0),
-        )
-    });
-    pub static PROXY_REQUEST_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "proxy_request_count",
-            "Proxy request count",
-            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
-        )
-    });
+    linera_base::declare_metrics! {
+        pub static PROXY_REQUEST_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "proxy_request_latency",
+                "Proxy request latency",
+                &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
+                linear_bucket_interval(1.0, 50.0, 5000.0),
+            );
 
-    pub static PROXY_REQUEST_SUCCESS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "proxy_request_success",
-            "Proxy request success",
-            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
-        )
-    });
+        pub static PROXY_REQUEST_COUNT: IntCounterVec =
+            register_int_counter_vec(
+                "proxy_request_count",
+                "Proxy request count",
+                &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
+            );
 
-    pub static PROXY_REQUEST_ERROR: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "proxy_request_error",
-            "Proxy request error",
-            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL, ERROR_TYPE_LABEL],
-        )
-    });
+        pub static PROXY_REQUEST_SUCCESS: IntCounterVec =
+            register_int_counter_vec(
+                "proxy_request_success",
+                "Proxy request success",
+                &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
+            );
+
+        pub static PROXY_REQUEST_ERROR: IntCounterVec =
+            register_int_counter_vec(
+                "proxy_request_error",
+                "Proxy request error",
+                &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL, ERROR_TYPE_LABEL],
+            );
+    }
 }
 
 #[cfg(with_metrics)]
@@ -308,6 +305,10 @@ where
         info!("Starting proxy");
         let mut join_set = JoinSet::new();
 
+        #[cfg(with_metrics)]
+        linera_service::init_metrics();
+        #[cfg(with_metrics)]
+        metrics::init_metrics();
         #[cfg(with_metrics)]
         monitoring_server::start_metrics_with_profiling(
             self.metrics_address(),

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -306,14 +306,14 @@ where
         let mut join_set = JoinSet::new();
 
         #[cfg(with_metrics)]
-        linera_service::init_metrics();
-        #[cfg(with_metrics)]
-        metrics::init_metrics();
-        #[cfg(with_metrics)]
         monitoring_server::start_metrics_with_profiling(
             self.metrics_address(),
             shutdown_signal.clone(),
             enable_memory_profiling,
+            || {
+                linera_service::init_metrics();
+                metrics::init_metrics();
+            },
         )
         .await;
 

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -320,6 +320,10 @@ where
         let address = self.get_listen_address();
 
         #[cfg(with_metrics)]
+        linera_service::init_metrics();
+        #[cfg(with_metrics)]
+        grpc::metrics::init_metrics();
+        #[cfg(with_metrics)]
         monitoring_server::start_metrics_with_profiling(
             address,
             shutdown_signal.clone(),

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -320,14 +320,14 @@ where
         let address = self.get_listen_address();
 
         #[cfg(with_metrics)]
-        linera_service::init_metrics();
-        #[cfg(with_metrics)]
-        grpc::metrics::init_metrics();
-        #[cfg(with_metrics)]
         monitoring_server::start_metrics_with_profiling(
             address,
             shutdown_signal.clone(),
             enable_memory_profiling,
+            || {
+                linera_service::init_metrics();
+                grpc::metrics::init_metrics();
+            },
         )
         .await;
 

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -142,11 +142,11 @@ impl ServerContext {
 
             #[cfg(with_metrics)]
             if let Some(port) = shard.metrics_port {
-                linera_service::init_metrics();
                 monitoring_server::start_metrics(
                     (listen_address.clone(), port),
                     shutdown_signal.clone(),
                     monitoring_server::MemoryProfiling::from(enable_memory_profiling),
+                    linera_service::init_metrics,
                 );
             }
 
@@ -192,11 +192,11 @@ impl ServerContext {
         for (state, shard_id, shard) in states {
             #[cfg(with_metrics)]
             if let Some(port) = shard.metrics_port {
-                linera_service::init_metrics();
                 monitoring_server::start_metrics(
                     (listen_address.to_string(), port),
                     shutdown_signal.clone(),
                     monitoring_server::MemoryProfiling::from(enable_memory_profiling),
+                    linera_service::init_metrics,
                 );
             }
 

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -142,6 +142,7 @@ impl ServerContext {
 
             #[cfg(with_metrics)]
             if let Some(port) = shard.metrics_port {
+                linera_service::init_metrics();
                 monitoring_server::start_metrics(
                     (listen_address.clone(), port),
                     shutdown_signal.clone(),
@@ -191,6 +192,7 @@ impl ServerContext {
         for (state, shard_id, shard) in states {
             #[cfg(with_metrics)]
             if let Some(port) = shard.metrics_port {
+                linera_service::init_metrics();
                 monitoring_server::start_metrics(
                     (listen_address.to_string(), port),
                     shutdown_signal.clone(),

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -49,8 +49,6 @@ use crate::{ChainRuntimeContext, Clock, Storage};
 /// Prometheus metrics for storage operations.
 #[cfg(with_metrics)]
 pub mod metrics {
-    use std::sync::LazyLock;
-
     use linera_base::prometheus_util::{
         exponential_bucket_interval, exponential_bucket_latencies, linear_bucket_interval,
         register_histogram, register_histogram_vec, register_int_counter, register_int_counter_vec,
@@ -64,235 +62,211 @@ pub mod metrics {
     /// Label value for items served from the database.
     pub(super) const DB: &str = "db";
 
-    /// The metric counting how often a blob is tested for existence from storage
-    pub(super) static CONTAINS_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "contains_blob",
-            "The metric counting how often a blob is tested for existence from storage",
-            &[SOURCE_LABEL],
-        )
-    });
+    linera_base::declare_metrics! {
+        /// The metric counting how often a blob is tested for existence from storage
+        pub(super) static CONTAINS_BLOB_COUNTER: IntCounterVec =
+            register_int_counter_vec(
+                "contains_blob",
+                "The metric counting how often a blob is tested for existence from storage",
+                &[SOURCE_LABEL],
+            );
 
-    /// The metric counting how often multiple blobs are tested for existence from storage
-    pub(super) static CONTAINS_BLOBS_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "contains_blobs",
-            "The metric counting how often multiple blobs are tested for existence from storage",
-            &[SOURCE_LABEL],
-        )
-    });
+        /// The metric counting how often multiple blobs are tested for existence from storage
+        pub(super) static CONTAINS_BLOBS_COUNTER: IntCounterVec =
+            register_int_counter_vec(
+                "contains_blobs",
+                "The metric counting how often multiple blobs are tested for existence from storage",
+                &[SOURCE_LABEL],
+            );
 
-    /// The metric counting how often a blob state is tested for existence from storage
-    pub(super) static CONTAINS_BLOB_STATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "contains_blob_state",
-            "The metric counting how often a blob state is tested for existence from storage",
-            &[SOURCE_LABEL],
-        )
-    });
+        /// The metric counting how often a blob state is tested for existence from storage
+        pub(super) static CONTAINS_BLOB_STATE_COUNTER: IntCounterVec =
+            register_int_counter_vec(
+                "contains_blob_state",
+                "The metric counting how often a blob state is tested for existence from storage",
+                &[SOURCE_LABEL],
+            );
 
-    /// The metric counting how often a certificate is tested for existence from storage.
-    pub(super) static CONTAINS_CERTIFICATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "contains_certificate",
-            "The metric counting how often a certificate is tested for existence from storage",
-            &[SOURCE_LABEL],
-        )
-    });
+        /// The metric counting how often a certificate is tested for existence from storage.
+        pub(super) static CONTAINS_CERTIFICATE_COUNTER: IntCounterVec =
+            register_int_counter_vec(
+                "contains_certificate",
+                "The metric counting how often a certificate is tested for existence from storage",
+                &[SOURCE_LABEL],
+            );
 
-    /// The metric counting how often a hashed certificate value is read from storage.
-    #[doc(hidden)]
-    pub static READ_CONFIRMED_BLOCK_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "read_confirmed_block",
-            "The metric counting how often a hashed confirmed block is read from storage",
-            &[SOURCE_LABEL],
-        )
-    });
+        /// The metric counting how often a hashed certificate value is read from storage.
+        #[doc(hidden)]
+        pub static READ_CONFIRMED_BLOCK_COUNTER: IntCounterVec =
+            register_int_counter_vec(
+                "read_confirmed_block",
+                "The metric counting how often a hashed confirmed block is read from storage",
+                &[SOURCE_LABEL],
+            );
 
-    /// The metric counting how often confirmed blocks are read from storage.
-    #[doc(hidden)]
-    pub(super) static READ_CONFIRMED_BLOCKS_COUNTER: LazyLock<IntCounterVec> =
-        LazyLock::new(|| {
+        /// The metric counting how often confirmed blocks are read from storage.
+        #[doc(hidden)]
+        pub(super) static READ_CONFIRMED_BLOCKS_COUNTER: IntCounterVec =
             register_int_counter_vec(
                 "read_confirmed_blocks",
                 "The metric counting how often confirmed blocks are read from storage",
                 &[SOURCE_LABEL],
-            )
-        });
+            );
 
-    /// The metric counting how often a blob is read from storage.
-    #[doc(hidden)]
-    pub(super) static READ_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "read_blob",
-            "The metric counting how often a blob is read from storage",
-            &[SOURCE_LABEL],
-        )
-    });
+        /// The metric counting how often a blob is read from storage.
+        #[doc(hidden)]
+        pub(super) static READ_BLOB_COUNTER: IntCounterVec =
+            register_int_counter_vec(
+                "read_blob",
+                "The metric counting how often a blob is read from storage",
+                &[SOURCE_LABEL],
+            );
 
-    /// The metric counting how often a blob state is read from storage.
-    #[doc(hidden)]
-    pub(super) static READ_BLOB_STATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "read_blob_state",
-            "The metric counting how often a blob state is read from storage",
-            &[SOURCE_LABEL],
-        )
-    });
+        /// The metric counting how often a blob state is read from storage.
+        #[doc(hidden)]
+        pub(super) static READ_BLOB_STATE_COUNTER: IntCounterVec =
+            register_int_counter_vec(
+                "read_blob_state",
+                "The metric counting how often a blob state is read from storage",
+                &[SOURCE_LABEL],
+            );
 
-    /// The metric counting how often a blob is written to storage.
-    #[doc(hidden)]
-    pub(super) static WRITE_BLOB_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
-        register_int_counter(
-            "write_blob",
-            "The metric counting how often a blob is written to storage",
-        )
-    });
+        /// The metric counting how often a blob is written to storage.
+        #[doc(hidden)]
+        pub(super) static WRITE_BLOB_COUNTER: IntCounter =
+            register_int_counter(
+                "write_blob",
+                "The metric counting how often a blob is written to storage",
+            );
 
-    /// The metric counting how often a certificate is read from storage.
-    #[doc(hidden)]
-    pub static READ_CERTIFICATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "read_certificate",
-            "The metric counting how often a certificate is read from storage",
-            &[SOURCE_LABEL],
-        )
-    });
+        /// The metric counting how often a certificate is read from storage.
+        #[doc(hidden)]
+        pub static READ_CERTIFICATE_COUNTER: IntCounterVec =
+            register_int_counter_vec(
+                "read_certificate",
+                "The metric counting how often a certificate is read from storage",
+                &[SOURCE_LABEL],
+            );
 
-    /// The metric counting how often certificates are read from storage.
-    #[doc(hidden)]
-    pub(super) static READ_CERTIFICATES_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "read_certificates",
-            "The metric counting how often certificate are read from storage",
-            &[SOURCE_LABEL],
-        )
-    });
+        /// The metric counting how often certificates are read from storage.
+        #[doc(hidden)]
+        pub(super) static READ_CERTIFICATES_COUNTER: IntCounterVec =
+            register_int_counter_vec(
+                "read_certificates",
+                "The metric counting how often certificate are read from storage",
+                &[SOURCE_LABEL],
+            );
 
-    /// The metric counting how often a certificate is written to storage.
-    #[doc(hidden)]
-    pub static WRITE_CERTIFICATE_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
-        register_int_counter(
-            "write_certificate",
-            "The metric counting how often a certificate is written to storage",
-        )
-    });
+        /// The metric counting how often a certificate is written to storage.
+        #[doc(hidden)]
+        pub static WRITE_CERTIFICATE_COUNTER: IntCounter =
+            register_int_counter(
+                "write_certificate",
+                "The metric counting how often a certificate is written to storage",
+            );
 
-    /// Serialized size of the lite-certificate component (round + value hash + validator
-    /// signatures), observed when a confirmed certificate is written to storage. Bytes are
-    /// taken from the already-produced BCS output, so this adds no extra serialization work.
-    /// Sized to track the signature component, which is what grows under post-quantum
-    /// signature migration (10x for Falcon-512, 38x for ML-DSA-44).
-    pub(super) static CERTIFICATE_LITE_BYTES: LazyLock<Histogram> = LazyLock::new(|| {
-        register_histogram(
-            "certificate_lite_bytes",
-            "Serialized size of the lite-certificate (signatures + metadata) in bytes",
-            exponential_bucket_interval(128.0, 2_097_152.0),
-        )
-    });
+        /// Serialized size of the lite-certificate component (round + value hash + validator
+        /// signatures), observed when a confirmed certificate is written to storage. Bytes are
+        /// taken from the already-produced BCS output, so this adds no extra serialization work.
+        /// Sized to track the signature component, which is what grows under post-quantum
+        /// signature migration (10x for Falcon-512, 38x for ML-DSA-44).
+        pub(super) static CERTIFICATE_LITE_BYTES: Histogram =
+            register_histogram(
+                "certificate_lite_bytes",
+                "Serialized size of the lite-certificate (signatures + metadata) in bytes",
+                exponential_bucket_interval(128.0, 2_097_152.0),
+            );
 
-    /// Serialized size of the certificate value (block payload), observed when a confirmed
-    /// certificate is written to storage. Bytes are taken from the already-produced BCS
-    /// output. Range matches the gRPC max message size cap.
-    pub(super) static CERTIFICATE_VALUE_BYTES: LazyLock<Histogram> = LazyLock::new(|| {
-        register_histogram(
-            "certificate_value_bytes",
-            "Serialized size of the certificate value (block payload) in bytes",
-            exponential_bucket_interval(256.0, 16_777_216.0),
-        )
-    });
+        /// Serialized size of the certificate value (block payload), observed when a confirmed
+        /// certificate is written to storage. Bytes are taken from the already-produced BCS
+        /// output. Range matches the gRPC max message size cap.
+        pub(super) static CERTIFICATE_VALUE_BYTES: Histogram =
+            register_histogram(
+                "certificate_value_bytes",
+                "Serialized size of the certificate value (block payload) in bytes",
+                exponential_bucket_interval(256.0, 16_777_216.0),
+            );
 
-    /// Number of validator signatures attached to each confirmed certificate. Linear buckets
-    /// because committee size is small (typically under 20) and resolution at single-signer
-    /// granularity matters more than range.
-    pub(super) static CERTIFICATE_SIGNER_COUNT: LazyLock<Histogram> = LazyLock::new(|| {
-        register_histogram(
-            "certificate_signer_count",
-            "Number of validator signatures attached to each confirmed certificate",
-            linear_bucket_interval(1.0, 1.0, 20.0),
-        )
-    });
+        /// Number of validator signatures attached to each confirmed certificate. Linear buckets
+        /// because committee size is small (typically under 20) and resolution at single-signer
+        /// granularity matters more than range.
+        pub(super) static CERTIFICATE_SIGNER_COUNT: Histogram =
+            register_histogram(
+                "certificate_signer_count",
+                "Number of validator signatures attached to each confirmed certificate",
+                linear_bucket_interval(1.0, 1.0, 20.0),
+            );
 
-    /// The latency to load a chain state.
-    #[doc(hidden)]
-    pub(crate) static LOAD_CHAIN_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "load_chain_latency",
-            "The latency to load a chain state",
-            &[],
-            exponential_bucket_latencies(1000.0),
-        )
-    });
+        /// The latency to load a chain state.
+        #[doc(hidden)]
+        pub(crate) static LOAD_CHAIN_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "load_chain_latency",
+                "The latency to load a chain state",
+                &[],
+                exponential_bucket_latencies(1000.0),
+            );
 
-    /// The metric counting how often an event is read from storage.
-    #[doc(hidden)]
-    pub(super) static READ_EVENT_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "read_event",
-            "The metric counting how often an event is read from storage",
-            &[SOURCE_LABEL],
-        )
-    });
+        /// The metric counting how often an event is read from storage.
+        #[doc(hidden)]
+        pub(super) static READ_EVENT_COUNTER: IntCounterVec =
+            register_int_counter_vec(
+                "read_event",
+                "The metric counting how often an event is read from storage",
+                &[SOURCE_LABEL],
+            );
 
-    /// The metric counting how often an event is tested for existence from storage
-    pub(super) static CONTAINS_EVENT_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "contains_event",
-            "The metric counting how often an event is tested for existence from storage",
-            &[SOURCE_LABEL],
-        )
-    });
+        /// The metric counting how often an event is tested for existence from storage
+        pub(super) static CONTAINS_EVENT_COUNTER: IntCounterVec =
+            register_int_counter_vec(
+                "contains_event",
+                "The metric counting how often an event is tested for existence from storage",
+                &[SOURCE_LABEL],
+            );
 
-    /// The metric counting how often an event is written to storage.
-    #[doc(hidden)]
-    pub(super) static WRITE_EVENT_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
-        register_int_counter(
-            "write_event",
-            "The metric counting how often an event is written to storage",
-        )
-    });
+        /// The metric counting how often an event is written to storage.
+        #[doc(hidden)]
+        pub(super) static WRITE_EVENT_COUNTER: IntCounter =
+            register_int_counter(
+                "write_event",
+                "The metric counting how often an event is written to storage",
+            );
 
-    /// The metric counting how often a block hash is read by height from storage.
-    #[doc(hidden)]
-    pub(super) static READ_BLOCK_HASH_BY_HEIGHT_COUNTER: LazyLock<IntCounterVec> =
-        LazyLock::new(|| {
+        /// The metric counting how often a block hash is read by height from storage.
+        #[doc(hidden)]
+        pub(super) static READ_BLOCK_HASH_BY_HEIGHT_COUNTER: IntCounterVec =
             register_int_counter_vec(
                 "read_block_hash_by_height",
                 "The metric counting how often a block hash is read by height from storage",
                 &[SOURCE_LABEL],
-            )
-        });
+            );
 
-    /// The metric counting how often an event block height is read from storage.
-    #[doc(hidden)]
-    pub(super) static READ_EVENT_BLOCK_HEIGHT_COUNTER: LazyLock<IntCounterVec> =
-        LazyLock::new(|| {
+        /// The metric counting how often an event block height is read from storage.
+        #[doc(hidden)]
+        pub(super) static READ_EVENT_BLOCK_HEIGHT_COUNTER: IntCounterVec =
             register_int_counter_vec(
                 "read_event_block_height",
                 "The metric counting how often an event block height is read from storage",
                 &[SOURCE_LABEL],
-            )
-        });
+            );
 
-    /// The metric counting how often the network description is read from storage.
-    #[doc(hidden)]
-    pub(super) static READ_NETWORK_DESCRIPTION: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "network_description",
-            "The metric counting how often the network description is read from storage",
-            &[SOURCE_LABEL],
-        )
-    });
+        /// The metric counting how often the network description is read from storage.
+        #[doc(hidden)]
+        pub(super) static READ_NETWORK_DESCRIPTION: IntCounterVec =
+            register_int_counter_vec(
+                "network_description",
+                "The metric counting how often the network description is read from storage",
+                &[SOURCE_LABEL],
+            );
 
-    /// The metric counting how often the network description is written to storage.
-    #[doc(hidden)]
-    pub(super) static WRITE_NETWORK_DESCRIPTION: LazyLock<IntCounter> = LazyLock::new(|| {
-        register_int_counter(
-            "write_network_description",
-            "The metric counting how often the network description is written to storage",
-        )
-    });
+        /// The metric counting how often the network description is written to storage.
+        #[doc(hidden)]
+        pub(super) static WRITE_NETWORK_DESCRIPTION: IntCounter =
+            register_int_counter(
+                "write_network_description",
+                "The metric counting how often the network description is written to storage",
+            );
+    }
 }
 
 /// The key used for blobs. The Blob ID itself is contained in the root key.

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -670,6 +670,21 @@ pub trait Clock {
     }
 }
 
+/// Registers every metric this crate declares.
+///
+/// Without this, a metric is only exported after the code path that observes it has run, so a
+/// rarely-taken path leaves its panels blank and makes a routine restart look like the metric
+/// was removed.
+#[cfg(with_metrics)]
+pub fn init_metrics() {
+    linera_base::init_metrics();
+    linera_cache::init_metrics();
+    linera_chain::init_metrics();
+    linera_execution::init_metrics();
+    linera_views::init_metrics();
+    db_storage::metrics::init_metrics();
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -18,86 +18,75 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::register_int_counter_vec;
     use prometheus::IntCounterVec;
 
-    /// The total number of cache read value misses.
-    pub static READ_VALUE_CACHE_MISS_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "num_read_value_cache_miss",
-            "Number of read value cache misses",
-            &[],
-        )
-    });
+    linera_base::declare_metrics! {
+        /// The total number of cache read value misses.
+        pub static READ_VALUE_CACHE_MISS_COUNT: IntCounterVec =
+            register_int_counter_vec(
+                "num_read_value_cache_miss",
+                "Number of read value cache misses",
+                &[],
+            );
 
-    /// The total number of read value cache hits.
-    pub static READ_VALUE_CACHE_HIT_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "num_read_value_cache_hits",
-            "Number of read value cache hits",
-            &[],
-        )
-    });
+        /// The total number of read value cache hits.
+        pub static READ_VALUE_CACHE_HIT_COUNT: IntCounterVec =
+            register_int_counter_vec(
+                "num_read_value_cache_hits",
+                "Number of read value cache hits",
+                &[],
+            );
 
-    /// The total number of contains key cache misses.
-    pub static CONTAINS_KEY_CACHE_MISS_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "num_contains_key_cache_miss",
-            "Number of contains key cache misses",
-            &[],
-        )
-    });
+        /// The total number of contains key cache misses.
+        pub static CONTAINS_KEY_CACHE_MISS_COUNT: IntCounterVec =
+            register_int_counter_vec(
+                "num_contains_key_cache_miss",
+                "Number of contains key cache misses",
+                &[],
+            );
 
-    /// The total number of contains key cache hits.
-    pub static CONTAINS_KEY_CACHE_HIT_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "num_contains_key_cache_hit",
-            "Number of contains key cache hits",
-            &[],
-        )
-    });
+        /// The total number of contains key cache hits.
+        pub static CONTAINS_KEY_CACHE_HIT_COUNT: IntCounterVec =
+            register_int_counter_vec(
+                "num_contains_key_cache_hit",
+                "Number of contains key cache hits",
+                &[],
+            );
 
-    /// The total number of find_keys_by_prefix cache misses.
-    pub static FIND_KEYS_BY_PREFIX_CACHE_MISS_COUNT: LazyLock<IntCounterVec> =
-        LazyLock::new(|| {
+        /// The total number of find_keys_by_prefix cache misses.
+        pub static FIND_KEYS_BY_PREFIX_CACHE_MISS_COUNT: IntCounterVec =
             register_int_counter_vec(
                 "num_find_keys_by_prefix_cache_miss",
                 "Number of find keys by prefix cache misses",
                 &[],
-            )
-        });
+            );
 
-    /// The total number of find_keys_by_prefix cache hits.
-    pub static FIND_KEYS_BY_PREFIX_CACHE_HIT_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "num_find_keys_by_prefix_cache_hit",
-            "Number of find keys by prefix cache hits",
-            &[],
-        )
-    });
+        /// The total number of find_keys_by_prefix cache hits.
+        pub static FIND_KEYS_BY_PREFIX_CACHE_HIT_COUNT: IntCounterVec =
+            register_int_counter_vec(
+                "num_find_keys_by_prefix_cache_hit",
+                "Number of find keys by prefix cache hits",
+                &[],
+            );
 
-    /// The total number of find_key_values_by_prefix cache misses.
-    pub static FIND_KEY_VALUES_BY_PREFIX_CACHE_MISS_COUNT: LazyLock<IntCounterVec> =
-        LazyLock::new(|| {
+        /// The total number of find_key_values_by_prefix cache misses.
+        pub static FIND_KEY_VALUES_BY_PREFIX_CACHE_MISS_COUNT: IntCounterVec =
             register_int_counter_vec(
                 "num_find_key_values_by_prefix_cache_miss",
                 "Number of find key values by prefix cache misses",
                 &[],
-            )
-        });
+            );
 
-    /// The total number of find_key_values_by_prefix cache hits.
-    pub static FIND_KEY_VALUES_BY_PREFIX_CACHE_HIT_COUNT: LazyLock<IntCounterVec> =
-        LazyLock::new(|| {
+        /// The total number of find_key_values_by_prefix cache hits.
+        pub static FIND_KEY_VALUES_BY_PREFIX_CACHE_HIT_COUNT: IntCounterVec =
             register_int_counter_vec(
                 "num_find_key_values_by_prefix_cache_hit",
                 "Number of find key values by prefix cache hits",
                 &[],
-            )
-        });
+            );
+    }
 }
 
 /// The maximum number of entries in the cache.

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -121,3 +121,26 @@ pub use views::{
     key_value_store_view, lazy_register_view, log_view, map_view, queue_view,
     reentrant_collection_view, register_view, set_view,
 };
+
+/// Registers every metric this crate declares.
+///
+/// Without this, a metric is only exported after the code path that observes it has run, so a
+/// rarely-taken path leaves its panels blank and makes a routine restart look like the metric
+/// was removed.
+#[cfg(with_metrics)]
+pub fn init_metrics() {
+    linera_base::init_metrics();
+    metrics::init_metrics();
+    backends::lru_caching::metrics::init_metrics();
+    views::bucket_queue_view::metrics::init_metrics();
+    views::collection_view::metrics::init_metrics();
+    views::historical_hash_wrapper::metrics::init_metrics();
+    views::key_value_store_view::metrics::init_metrics();
+    views::lazy_register_view::metrics::init_metrics();
+    views::log_view::metrics::init_metrics();
+    views::map_view::metrics::init_metrics();
+    views::queue_view::metrics::init_metrics();
+    views::reentrant_collection_view::metrics::init_metrics();
+    views::register_view::metrics::init_metrics();
+    views::set_view::metrics::init_metrics();
+}

--- a/linera-views/src/metrics.rs
+++ b/linera-views/src/metrics.rs
@@ -15,43 +15,77 @@ pub fn increment_counter(counter: &LazyLock<IntCounterVec>, struct_name: &str, b
     counter.with_label_values(&labels).inc();
 }
 
-/// The metric tracking the latency of the loading of views.
-#[doc(hidden)]
-pub static LOAD_VIEW_LATENCY: LazyLock<prometheus::HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
-        "load_view_latency",
-        "Load view latency in milliseconds",
-        &[],
-        exponential_bucket_latencies(1000.0),
-    )
-});
+linera_base::declare_metrics! {
+    /// The metric tracking the latency of the loading of views.
+    #[doc(hidden)]
+    pub static LOAD_VIEW_LATENCY: prometheus::HistogramVec =
+        prometheus_util::register_histogram_vec(
+            "load_view_latency",
+            "Load view latency in milliseconds",
+            &[],
+            exponential_bucket_latencies(1000.0),
+        );
 
-/// The metric counting how often a view is read from storage.
-#[doc(hidden)]
-pub static LOAD_VIEW_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
-        "load_view",
-        "The metric counting how often a view is read from storage",
-        &["type", "base_key"],
-    )
-});
-/// The metric counting how often a view is written from storage.
-#[doc(hidden)]
-pub static SAVE_VIEW_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_vec(
-        "save_view",
-        "The metric counting how often a view is written from storage",
-        &["type", "base_key"],
-    )
-});
+    /// The metric counting how often a view is read from storage.
+    #[doc(hidden)]
+    pub static LOAD_VIEW_COUNTER: IntCounterVec =
+        prometheus_util::register_int_counter_vec(
+            "load_view",
+            "The metric counting how often a view is read from storage",
+            &["type", "base_key"],
+        );
 
-/// The metric tracking the latency of saving views.
-#[doc(hidden)]
-pub static SAVE_VIEW_LATENCY: LazyLock<prometheus::HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
-        "save_view_latency",
-        "Save view latency in milliseconds",
-        &["type"],
-        exponential_bucket_latencies(1000.0),
-    )
-});
+    /// The metric counting how often a view is written from storage.
+    #[doc(hidden)]
+    pub static SAVE_VIEW_COUNTER: IntCounterVec =
+        prometheus_util::register_int_counter_vec(
+            "save_view",
+            "The metric counting how often a view is written from storage",
+            &["type", "base_key"],
+        );
+
+    /// The metric tracking the latency of saving views.
+    #[doc(hidden)]
+    pub static SAVE_VIEW_LATENCY: prometheus::HistogramVec =
+        prometheus_util::register_histogram_vec(
+            "save_view_latency",
+            "Save view latency in milliseconds",
+            &["type"],
+            exponential_bucket_latencies(1000.0),
+        );
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn label_free_metrics_are_exported_before_their_code_path_runs() {
+        crate::init_metrics();
+
+        let families = prometheus::gather();
+        let contains_keys = families
+            .iter()
+            .find(|family| family.get_name() == "linera_key_value_store_view_contains_keys_latency")
+            .expect("a label-free metric must be exported once init_metrics has run");
+
+        let histogram = contains_keys
+            .get_metric()
+            .first()
+            .expect("registering the vector must also create its single label-free child")
+            .get_histogram();
+        assert_eq!(histogram.get_sample_count(), 0);
+    }
+
+    /// Registration alone exports nothing — a vector emits one series per child, and a
+    /// labelled one has no children until a label combination is observed. This is why
+    /// forcing the `LazyLock` is not on its own enough, and why labelled metrics stay
+    /// workload-gated.
+    #[test]
+    fn labelled_metrics_stay_absent_until_a_label_combination_is_observed() {
+        crate::init_metrics();
+
+        let exported = prometheus::gather().iter().any(|family| {
+            family.get_name() == "linera_load_view" && !family.get_metric().is_empty()
+        });
+        assert!(!exported);
+    }
+}

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -20,21 +20,20 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    /// The runtime of hash computation
-    pub static BUCKET_QUEUE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "bucket_queue_view_hash_runtime",
-            "BucketQueueView hash runtime",
-            &[],
-            exponential_bucket_latencies(5.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        /// The runtime of hash computation
+        pub static BUCKET_QUEUE_VIEW_HASH_RUNTIME: HistogramVec =
+            register_histogram_vec(
+                "bucket_queue_view_hash_runtime",
+                "BucketQueueView hash runtime",
+                &[],
+                exponential_bucket_latencies(5.0),
+            );
+    }
 }
 
 /// Key tags to create the sub-keys of a [`BucketQueueView`] on top of the base key.

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -28,21 +28,20 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    /// The runtime of hash computation
-    pub static COLLECTION_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "collection_view_hash_runtime",
-            "CollectionView hash runtime",
-            &[],
-            exponential_bucket_latencies(5.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        /// The runtime of hash computation
+        pub static COLLECTION_VIEW_HASH_RUNTIME: HistogramVec =
+            register_histogram_vec(
+                "collection_view_hash_runtime",
+                "CollectionView hash runtime",
+                &[],
+                exponential_bucket_latencies(5.0),
+            );
+    }
 }
 
 /// A view that supports accessing a collection of views of the same kind, indexed by a

--- a/linera-views/src/views/historical_hash_wrapper.rs
+++ b/linera-views/src/views/historical_hash_wrapper.rs
@@ -21,22 +21,20 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    /// The runtime of hash computation
-    pub static HISTORICALLY_HASHABLE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> =
-        LazyLock::new(|| {
+    linera_base::declare_metrics! {
+        /// The runtime of hash computation
+        pub static HISTORICALLY_HASHABLE_VIEW_HASH_RUNTIME: HistogramVec =
             register_histogram_vec(
                 "historically_hashable_view_hash_runtime",
                 "HistoricallyHashableView hash runtime",
                 &[],
                 exponential_bucket_latencies(5.0),
-            )
-        });
+            );
+    }
 }
 
 /// Wrapper to compute the hash of the view based on its history of modifications.

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -34,97 +34,83 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    /// The latency of hash computation
-    pub static KEY_VALUE_STORE_VIEW_HASH_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "key_value_store_view_hash_latency",
-            "KeyValueStoreView hash latency",
-            &[],
-            exponential_bucket_latencies(5.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        /// The latency of hash computation
+        pub static KEY_VALUE_STORE_VIEW_HASH_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "key_value_store_view_hash_latency",
+                "KeyValueStoreView hash latency",
+                &[],
+                exponential_bucket_latencies(5.0),
+            );
 
-    /// The latency of get operation
-    pub static KEY_VALUE_STORE_VIEW_GET_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "key_value_store_view_get_latency",
-            "KeyValueStoreView get latency",
-            &[],
-            exponential_bucket_latencies(5.0),
-        )
-    });
+        /// The latency of get operation
+        pub static KEY_VALUE_STORE_VIEW_GET_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "key_value_store_view_get_latency",
+                "KeyValueStoreView get latency",
+                &[],
+                exponential_bucket_latencies(5.0),
+            );
 
-    /// The latency of multi get
-    pub static KEY_VALUE_STORE_VIEW_MULTI_GET_LATENCY: LazyLock<HistogramVec> =
-        LazyLock::new(|| {
+        /// The latency of multi get
+        pub static KEY_VALUE_STORE_VIEW_MULTI_GET_LATENCY: HistogramVec =
             register_histogram_vec(
                 "key_value_store_view_multi_get_latency",
                 "KeyValueStoreView multi get latency",
                 &[],
                 exponential_bucket_latencies(5.0),
-            )
-        });
+            );
 
-    /// The latency of contains key
-    pub static KEY_VALUE_STORE_VIEW_CONTAINS_KEY_LATENCY: LazyLock<HistogramVec> =
-        LazyLock::new(|| {
+        /// The latency of contains key
+        pub static KEY_VALUE_STORE_VIEW_CONTAINS_KEY_LATENCY: HistogramVec =
             register_histogram_vec(
                 "key_value_store_view_contains_key_latency",
                 "KeyValueStoreView contains key latency",
                 &[],
                 exponential_bucket_latencies(5.0),
-            )
-        });
+            );
 
-    /// The latency of contains keys
-    pub static KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_LATENCY: LazyLock<HistogramVec> =
-        LazyLock::new(|| {
+        /// The latency of contains keys
+        pub static KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_LATENCY: HistogramVec =
             register_histogram_vec(
                 "key_value_store_view_contains_keys_latency",
                 "KeyValueStoreView contains keys latency",
                 &[],
                 exponential_bucket_latencies(5.0),
-            )
-        });
+            );
 
-    /// The latency of find keys by prefix operation
-    pub static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_LATENCY: LazyLock<HistogramVec> =
-        LazyLock::new(|| {
+        /// The latency of find keys by prefix operation
+        pub static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_LATENCY: HistogramVec =
             register_histogram_vec(
                 "key_value_store_view_find_keys_by_prefix_latency",
                 "KeyValueStoreView find keys by prefix latency",
                 &[],
                 exponential_bucket_latencies(5.0),
-            )
-        });
+            );
 
-    /// The latency of find key values by prefix operation
-    pub static KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_LATENCY: LazyLock<HistogramVec> =
-        LazyLock::new(|| {
+        /// The latency of find key values by prefix operation
+        pub static KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_LATENCY: HistogramVec =
             register_histogram_vec(
                 "key_value_store_view_find_key_values_by_prefix_latency",
                 "KeyValueStoreView find key values by prefix latency",
                 &[],
                 exponential_bucket_latencies(5.0),
-            )
-        });
+            );
 
-    /// The latency of write batch operation
-    pub static KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY: LazyLock<HistogramVec> =
-        LazyLock::new(|| {
+        /// The latency of write batch operation
+        pub static KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY: HistogramVec =
             register_histogram_vec(
                 "key_value_store_view_write_batch_latency",
                 "KeyValueStoreView write batch latency",
                 &[],
                 exponential_bucket_latencies(5.0),
-            )
-        });
+            );
+    }
 }
 
 #[cfg(with_testing)]

--- a/linera-views/src/views/lazy_register_view.rs
+++ b/linera-views/src/views/lazy_register_view.rs
@@ -19,21 +19,20 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    /// The runtime of hash computation
-    pub static LAZY_REGISTER_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "lazy_register_view_hash_runtime",
-            "LazyRegisterView hash runtime",
-            &[],
-            exponential_bucket_latencies(5.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        /// The runtime of hash computation
+        pub static LAZY_REGISTER_VIEW_HASH_RUNTIME: HistogramVec =
+            register_histogram_vec(
+                "lazy_register_view_hash_runtime",
+                "LazyRegisterView hash runtime",
+                &[],
+                exponential_bucket_latencies(5.0),
+            );
+    }
 }
 
 /// A view that supports modifying a single value of type `T`.

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -23,21 +23,20 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    /// The runtime of hash computation
-    pub static LOG_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "log_view_hash_runtime",
-            "LogView hash runtime",
-            &[],
-            exponential_bucket_latencies(5.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        /// The runtime of hash computation
+        pub static LOG_VIEW_HASH_RUNTIME: HistogramVec =
+            register_histogram_vec(
+                "log_view_hash_runtime",
+                "LogView hash runtime",
+                &[],
+                exponential_bucket_latencies(5.0),
+            );
+    }
 }
 
 /// Key tags to create the sub-keys of a `LogView` on top of the base key.

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -20,21 +20,20 @@
 use linera_base::prometheus_util::MeasureLatency as _;
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    /// The runtime of hash computation
-    pub static MAP_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "map_view_hash_runtime",
-            "MapView hash runtime",
-            &[],
-            exponential_bucket_latencies(5.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        /// The runtime of hash computation
+        pub static MAP_VIEW_HASH_RUNTIME: HistogramVec =
+            register_histogram_vec(
+                "map_view_hash_runtime",
+                "MapView hash runtime",
+                &[],
+                exponential_bucket_latencies(5.0),
+            );
+    }
 }
 
 use std::{

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -23,21 +23,20 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    /// The runtime of hash computation
-    pub static QUEUE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "queue_view_hash_runtime",
-            "QueueView hash runtime",
-            &[],
-            exponential_bucket_latencies(5.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        /// The runtime of hash computation
+        pub static QUEUE_VIEW_HASH_RUNTIME: HistogramVec =
+            register_histogram_vec(
+                "queue_view_hash_runtime",
+                "QueueView hash runtime",
+                &[],
+                exponential_bucket_latencies(5.0),
+            );
+    }
 }
 
 /// Key tags to create the sub-keys of a `QueueView` on top of the base key.

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -29,22 +29,20 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    /// The runtime of hash computation
-    pub static REENTRANT_COLLECTION_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> =
-        LazyLock::new(|| {
+    linera_base::declare_metrics! {
+        /// The runtime of hash computation
+        pub static REENTRANT_COLLECTION_VIEW_HASH_RUNTIME: HistogramVec =
             register_histogram_vec(
                 "reentrant_collection_view_hash_runtime",
                 "ReentrantCollectionView hash runtime",
                 &[],
                 exponential_bucket_latencies(5.0),
-            )
-        });
+            );
+    }
 }
 
 /// A read-only accessor for a particular subview in a [`ReentrantCollectionView`].

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -16,21 +16,20 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    /// The runtime of hash computation
-    pub static REGISTER_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "register_view_hash_runtime",
-            "RegisterView hash runtime",
-            &[],
-            exponential_bucket_latencies(5.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        /// The runtime of hash computation
+        pub static REGISTER_VIEW_HASH_RUNTIME: HistogramVec =
+            register_histogram_vec(
+                "register_view_hash_runtime",
+                "RegisterView hash runtime",
+                &[],
+                exponential_bucket_latencies(5.0),
+            );
+    }
 }
 
 /// A view that supports modifying a single value of type `T`.

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -19,21 +19,20 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
     use prometheus::HistogramVec;
 
-    /// The runtime of hash computation
-    pub static SET_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "set_view_hash_runtime",
-            "SetView hash runtime",
-            &[],
-            exponential_bucket_latencies(5.0),
-        )
-    });
+    linera_base::declare_metrics! {
+        /// The runtime of hash computation
+        pub static SET_VIEW_HASH_RUNTIME: HistogramVec =
+            register_histogram_vec(
+                "set_view_hash_runtime",
+                "SetView hash runtime",
+                &[],
+                exponential_bucket_latencies(5.0),
+            );
+    }
 }
 
 /// A [`View`] that supports inserting and removing values indexed by a key.

--- a/scripts/check_metrics_registration.sh
+++ b/scripts/check_metrics_registration.sh
@@ -26,6 +26,27 @@ crate_dir_of() {
     echo "$dir"
 }
 
+# 0. Every metric registration must go through `declare_metrics!`, so a new module cannot
+# reintroduce a hand-rolled `LazyLock` that no init_metrics knows about.
+#
+# prometheus_util.rs defines the helpers themselves; metering.rs registers one set per store
+# instance under names built at runtime, which a macro over statics cannot express; and
+# linera-explorer-new is a separate cargo workspace with its own metrics.
+while read -r file; do
+    case "$file" in
+        linera-base/src/prometheus_util.rs) continue ;;
+        linera-views/src/backends/metering.rs) continue ;;
+        linera-explorer-new/*) continue ;;
+    esac
+    if ! grep -qa 'declare_metrics!' "$file"; then
+        echo "ERROR: $file registers metrics without declare_metrics!."
+        echo "       Declare them with linera_base::declare_metrics! so that the generated"
+        echo "       init_metrics() registers them at startup instead of on first use."
+        status=1
+    fi
+done < <(grep -rlaE 'register_(histogram|int_counter|int_gauge|gauge)' --include='*.rs' \
+         linera-*/src linera-*/*/src 2>/dev/null)
+
 # 1. Every module that declares metrics must be called from somewhere in its own crate.
 while read -r file; do
     crate="$(crate_dir_of "$file")"

--- a/scripts/check_metrics_registration.sh
+++ b/scripts/check_metrics_registration.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Check that every metric declaration is reachable from an `init_metrics`.
+#
+# A metric only appears in `/metrics` once it has been registered, and `declare_metrics!`
+# statics register on first use. A module left out of its crate's `init_metrics`, or a crate
+# left out of a dependent's, therefore reverts silently to the old behaviour: the metric shows
+# up only after the code path that observes it first runs, and disappears again whenever the
+# process is replaced. Nothing else catches this — the generated `init_metrics` is `pub`, so
+# rustc's dead_code lint does not fire when it goes uncalled.
+
+set -uo pipefail
+
+# Make sure we're at the source of the repo.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+status=0
+
+# Nearest ancestor holding a Cargo.toml, so nested members like linera-faucet/server resolve.
+crate_dir_of() {
+    local dir
+    dir="$(dirname "$1")"
+    while [ "$dir" != "." ] && [ ! -f "$dir/Cargo.toml" ]; do
+        dir="$(dirname "$dir")"
+    done
+    echo "$dir"
+}
+
+# 1. Every module that declares metrics must be called from somewhere in its own crate.
+while read -r file; do
+    crate="$(crate_dir_of "$file")"
+
+    # Module path of the file itself, relative to src/, with mod.rs and lib.rs collapsed.
+    path="${file#"$crate"/src/}"
+    path="${path%.rs}"
+    path="${path%/mod}"
+    [ "$path" = "lib" ] && path=""
+
+    module="$(grep -aoE 'mod [a-z_]*metrics \{' "$file" | head -1 | awk '{print $2}')"
+    if [ -n "$module" ]; then
+        # An inline `mod <name>metrics` block.
+        path="${path:+$path/}$module"
+    fi
+
+    # A call only has to name the last two segments to be unambiguous within a crate; at the
+    # crate root there is only one.
+    token="$(echo "$path" | tr '/' '\n' | tail -2 | paste -sd: - | sed 's/:/::/g')"
+
+    # A two-segment token is unambiguous wherever it appears, so any path may precede it. A
+    # single-segment one is a crate-root module, and must not be satisfied by some
+    # `<other>::metrics::init_metrics()` belonging to an inline module.
+    if [[ "$token" == *::* ]]; then
+        found=$(grep -raF "${token}::init_metrics" --include='*.rs' "$crate/src" | head -1)
+    else
+        found=$(grep -raE "(^|[^:[:alnum:]_])${token}::init_metrics" --include='*.rs' "$crate/src" | head -1)
+    fi
+
+    if [ -z "$found" ]; then
+        echo "ERROR: $file declares metrics that no init_metrics() in $crate calls."
+        echo "       Add a call to ${token}::init_metrics() reachable from that crate's init_metrics()."
+        status=1
+    fi
+done < <(grep -ral 'declare_metrics!' --include='*.rs' linera-*/src linera-*/*/src 2>/dev/null)
+
+# 2. Every crate exposing `init_metrics` must be initialized by each dependent that exposes one,
+# so a binary reaching one aggregate reaches everything below it.
+#
+# linera-bridge is deliberately excluded: it serves no /metrics endpoint, and its `relay`
+# feature does not turn on the `metrics` feature of its dependencies, so calling their
+# `init_metrics` would not compile.
+declare -A HAS_INIT
+while read -r manifest; do
+    dir="$(dirname "$manifest")"
+    [ -f "$dir/src/lib.rs" ] || continue
+    grep -aq '^pub fn init_metrics()' "$dir/src/lib.rs" || continue
+    name="$(grep -am1 '^name = ' "$manifest" | sed 's/name = "\(.*\)"/\1/')"
+    HAS_INIT["$name"]="$dir"
+done < <(find linera-* -maxdepth 2 -name Cargo.toml -not -path '*/target/*')
+
+for name in "${!HAS_INIT[@]}"; do
+    [ "$name" = "linera-bridge" ] && continue
+    dir="${HAS_INIT[$name]}"
+    while read -r dependency; do
+        [ -n "${HAS_INIT[$dependency]:-}" ] || continue
+        [ "$dependency" = "$name" ] && continue
+        call="${dependency//-/_}::init_metrics()"
+        if ! grep -aqF "$call" "$dir/src/lib.rs"; then
+            echo "ERROR: $name depends on $dependency but its init_metrics() never calls $call."
+            status=1
+        fi
+    done < <(awk '/^\[dependencies\]/{f=1;next} /^\[/{f=0} f' "$dir/Cargo.toml" \
+             | grep -oE '^linera-[a-z-]+')
+done
+
+if [ "$status" -ne 0 ]; then
+    echo
+    echo "See scripts/check_metrics_registration.sh for why this matters."
+fi
+
+exit "$status"


### PR DESCRIPTION
## Motivation

`LineraMetricStoppedReporting` fired on 2026-08-13 for
`linera_key_value_store_view_contains_keys_latency_{bucket,count,sum}`. It was a false
positive, and the alert's only firing in 30 days.

Every Linera metric is a `LazyLock` static whose `register_*` call runs on **first use**, so
presence tracks the *workload*, not the binary. The only production caller of that one is the
`ContainsKeys` host function — a Wasm app asking for a multi-key existence check. Fleet-wide
that happened **exactly once**: a single series, `_count` frozen at `1` for the full 30-day
retention window. A worker rollout replaced the pod, the `LazyLock` reset, and the metric
vanished with nothing broken.

Any panel querying such a metric renders blank, which is indistinguishable from idle, and a
routine restart looks identical to the metric having been removed.

This is not hypothetical or mine alone: #6660 hit the same problem independently a week later
and hand-rolled a private `register()` for its panic counter, noting that *"a lazily registered
counter is absent from `/metrics` until it is first touched — leaving dashboards showing no
data rather than zero, and nothing for an alert to sit on."* That is exactly this bug; this PR
makes the fix shared instead of per-module.

### Registration alone exports nothing

A `*Vec` collector with no children emits **no series**. Forcing the `LazyLock` registers the
collector and still exports nothing; the child has to be materialized via
`with_label_values(&[])`.

Measurable in production. `KeyValueStoreMetrics::new()` registers its whole set eagerly, no
`LazyLock` — yet within that same constructor, on the same pods, series counts differ:

| Metric | Series |
|---|---|
| `connect_latency`, `contains_key_latency`, `read_value_bytes_latency` | 44 |
| `write_batch_*` | 34 |
| `clear_journal_latency`, `open_exclusive_latency` | 32 |
| `contains_keys_latency`, `contains_keys_key_sizes`, `contains_keys_num_entries` | 30 |

If registration created series these would all be 44. They track usage instead.

## Proposal

**1. Materialize the label-free child** (`linera-base/src/prometheus_util.rs`). Each
`register_*_vec` helper routes through `materialize_unlabeled`, which calls
`with_label_values(&[])` when `label_names` is empty. This alone fixes every eagerly registered
metric, including the whole `metering.rs` family set.

**2. `declare_metrics!`** — a macro expanding the existing declaration shape into the `LazyLock`
statics **plus** that module's `init_metrics()`, so a newly added metric cannot be left out of
it. 37 metrics modules across 12 crates converted; each crate's `init_metrics()` also
initializes the linera crates it depends on, derived from its `[dependencies]`.

**3. `init_metrics` is a required parameter of `monitoring_server::start_metrics{,_with_profiling}`.**
It cannot be called *inside* those functions — `linera-metrics` sits below `linera-views` and
friends and cannot reach their metrics — but taking it as an argument makes forgetting to
register a compile error rather than a silently workload-gated metric. It sits next to the
existing `runtime_metrics::register()`.

**4. Everything goes through the `prometheus_util` wrappers.** `linera-bridge` was the only
crate bypassing them: 12 raw `prometheus::register_*!` calls, 12 hand-rolled
`.namespace("linera")`, and 12 `.unwrap()`s. Its repeated `bridge_` prefix now lives in a single
`const SUBSYSTEM` via the `*_with_subsystem` helpers. Adds the three plain-metric helpers that
were missing (`register_gauge`, `register_gauge_with_subsystem`,
`register_int_counter_with_subsystem`).

**5. `scripts/check_metrics_registration.sh` + a `lint-metrics-registration` CI job**, so none
of the above depends on anyone remembering it. Three invariants:

- every metric registration goes through `declare_metrics!`;
- every module declaring metrics is called from its crate's `init_metrics()`;
- every crate exposing `init_metrics()` is called by each dependent that has one.

The dependency set is read from each `[dependencies]` section, so a new crate or edge needs no
list maintained. `linera-bridge` is the one encoded exception, with its reason: it serves no
`/metrics` endpoint, and its `relay` feature does not enable `metrics` on its dependencies.

### Fixes a doubled prefix in #6660

`register_int_counter` applies the `linera` namespace itself, so the panic counter's
fully-qualified `"linera_panics_total"` was exported as **`linera_linera_panics_total`**
(verified by running it). Corrected to `panics_total`, and its module folded into
`declare_metrics!` so the bespoke `register()` is no longer needed. A test pins both that
`linera_panics_total` exists and that nothing matches `linera_linera`.

### What this does not fix

Labelled vectors cannot have children pre-created, because their label values are not known
ahead of time. Roughly 70 of the ~172 statics are labelled and stay workload-gated; the ~90
label-free vectors and plain metrics become always-present. This is a documented limit, and a
test pins it so nobody later "fixes" it by making the gate uniform.

## Test Plan

**Regression test** (`linera-views/src/metrics.rs`): after `init_metrics()`,
`linera_key_value_store_view_contains_keys_latency` is present with `sample_count == 0`
**without** `contains_keys` ever being called.

**Mechanism test**: `linera_load_view` (labelled) stays absent after `init_metrics()`, proving
registration alone exports nothing and pinning why the gate is scoped to label-free metrics.

**Naming tests**: the `linera_<subsystem>_<name>` contract (previously documented but unused
and unverified), the 12 `linera_bridge_*` names after the prefix moved into the subsystem, and
the single-prefix panic counter.

**The CI lint was verified to fail**, by breaking each invariant and reading the exit code:

```
clean tree                          exit=0
metric registered outside the macro exit=1   (upstream's panic_hook.rs, verbatim)
module missing from its crate       exit=1
crate missing from the cascade      exit=1
```

**No metric name changed** by the 172-static conversion: every touched file's string-literal
multiset was compared byte-for-byte against the base, with only the files where tests were
added differing.

CI gates: `lint-cargo-clippy`, `lint-cargo-fmt`, `lint-cargo-doc`, `lint-taplo-fmt`,
`lint-cargo-machete`, `lint-metrics-registration`, `metrics-test`, `bridge-check`,
`bridge-tests` and the full `test` suite all pass.

Metrics are `#[cfg(with_metrics)]` = `all(not(target_arch = "wasm32"), feature = "metrics")`, so
there is no wasm impact.

**Cardinality.** Measured against production: one pm worker exports 2,129 series over 379 metric
names; a label-free histogram is 12 series. The per-pod shortfall against the union across pm
workers is ~37 names, so roughly +450 series/pod — about 2% of the 161k `linera_*` series live
today.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

`main` first; the `testnet_conway` cherry-pick follows once this merges.

Worth flagging for rollout: an always-present zero metric changes what absence-based queries
mean. `absent()` and `or vector(0)` behave differently and `rate()` returns 0 instead of
no-data. Dashboards and rules should be grepped for those before this reaches a network. The
intended consequence is that
[linera-infra#1740](https://github.com/linera-io/linera-infra/pull/1740) can no longer fire for
these metrics, because they stop disappearing.

## Links

- The alert rule and the activity gate that works around this:
  [linera-infra#1740](https://github.com/linera-io/linera-infra/pull/1740)
- #6660, whose panic counter is folded into the shared mechanism here
