### PR TITLE
Run each task group concurrently so a slow group cannot delay the others

### DIFF
--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use async_graphql::InputType as _;
-use futures::{future, stream::StreamExt, FutureExt};
+use futures::{stream::StreamExt, FutureExt};
 use linera_base::{
     data_types::{TimeDelta, Timestamp},
     identifiers::{ApplicationId, ChainId},
@@ -214,7 +214,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
             let actions = match self.query_actions(application_id, app_cursor, now).await {
                 Ok(actions) => actions,
                 Err(error) => {
-                    error!("Error reading application actions: {error}");
+                    error!(%application_id, %error, "Error reading application actions");
                     // Retry in at most 1 minute.
                     self.deadlines.push(Reverse((
                         now.saturating_add(TimeDelta::from_secs(60)),
@@ -239,29 +239,30 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 tokio::spawn(async move {
                     // Run each group concurrently, so that a slow or failing group never
                     // delays the outcomes of the others.
-                    let handles = group_tasks(actions.execute_tasks).into_iter().map(|tasks| {
-                        tokio::spawn(Self::process_group(
-                            application_id,
-                            tasks,
-                            chain_client.clone(),
-                            operators.clone(),
-                            retry_delay,
-                        ))
-                    });
+                    let mut handles = Vec::new();
+                    for (group, tasks) in group_tasks(actions.execute_tasks) {
+                        handles.push((
+                            group.clone(),
+                            tokio::spawn(Self::process_group(
+                                application_id,
+                                group,
+                                tasks,
+                                chain_client.clone(),
+                                operators.clone(),
+                                retry_delay,
+                            )),
+                        ));
+                    }
                     // `None` sorts before any timestamp, so the maximum is the latest retry
                     // any group asked for: a task failing on every attempt cannot shorten the
                     // delay protecting the operator.
-                    let retry_at = future::join_all(handles)
-                        .await
-                        .into_iter()
-                        .map(|result| {
-                            result.unwrap_or_else(|error| {
-                                error!(%application_id, %error, "Task group panicked");
-                                Some(Timestamp::now().saturating_add(retry_delay))
-                            })
-                        })
-                        .max()
-                        .flatten();
+                    let mut retry_at = None;
+                    for (group, handle) in handles {
+                        retry_at = retry_at.max(handle.await.unwrap_or_else(|error| {
+                            error!(%application_id, ?group, %error, "Task group panicked");
+                            Some(Timestamp::now().saturating_add(retry_delay))
+                        }));
+                    }
                     if batch_sender
                         .send(BatchResult {
                             application_id,
@@ -269,7 +270,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                         })
                         .is_err()
                     {
-                        error!("Batch receiver dropped for {application_id}");
+                        error!(%application_id, "Batch receiver dropped");
                     }
                 });
             }
@@ -288,6 +289,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
     /// call to `nextActions`. Returns the timestamp at which to retry the group, if it failed.
     async fn process_group(
         application_id: ApplicationId,
+        group: Option<String>,
         tasks: Vec<Task>,
         chain_client: ChainClient<Env>,
         operators: OperatorMap,
@@ -305,11 +307,11 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
             let outcome = match handle.await {
                 Ok(Ok(outcome)) => outcome,
                 Ok(Err(error)) => {
-                    error!(%application_id, %error, "Error executing task");
+                    error!(%application_id, ?group, %error, "Error executing task");
                     return Some(Timestamp::now().saturating_add(retry_delay));
                 }
                 Err(error) => {
-                    error!(%application_id, %error, "Task panicked");
+                    error!(%application_id, ?group, %error, "Task panicked");
                     return Some(Timestamp::now().saturating_add(retry_delay));
                 }
             };
@@ -406,10 +408,12 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         retry_delay: TimeDelta,
     ) -> Result<(), Timestamp> {
         info!("Submitting task outcome for {application_id}: {task_outcome:?}");
+        // An outcome's id is the group it belongs to.
+        let group = &task_outcome.id;
         let retry_with_delay = || Timestamp::now().saturating_add(retry_delay);
         let query = task_outcome_query(task_outcome);
         let bytes = serde_json::to_vec(&json!({"query": query})).map_err(|error| {
-            error!(%application_id, %error, "Error serializing task outcome query");
+            error!(%application_id, ?group, %error, "Error serializing task outcome query");
             retry_with_delay()
         })?;
         let query = linera_execution::Query::User {
@@ -426,7 +430,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
             .query_application(query, None)
             .await
             .map_err(|error| {
-                error!(%application_id, %error, "Error querying application");
+                error!(%application_id, ?group, %error, "Error querying application");
                 retry_with_delay()
             })?;
         if !operations.is_empty() {
@@ -434,16 +438,16 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 .execute_operations(operations, vec![])
                 .await
                 .map_err(|error| {
-                    error!(%application_id, %error, "Error executing operations");
+                    error!(%application_id, ?group, %error, "Error executing operations");
                     retry_with_delay()
                 })? {
                 ClientOutcome::Committed(_) => {}
                 ClientOutcome::WaitForTimeout(timeout) => {
-                    error!(%application_id, "Not the round leader, retrying after {}", timeout.timestamp);
+                    error!(%application_id, ?group, "Not the round leader, retrying after {}", timeout.timestamp);
                     return Err(timeout.timestamp);
                 }
                 ClientOutcome::Conflict(_) => {
-                    debug!(%application_id, "Block conflict, retrying immediately");
+                    debug!(%application_id, ?group, "Block conflict, retrying immediately");
                     return Err(Timestamp::now());
                 }
             }
@@ -456,12 +460,12 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
 ///
 /// Tasks sharing an id, and all the tasks without one, can only be told apart by position, so
 /// they belong to the same group. A distinctly identified task is a group of its own.
-fn group_tasks(tasks: Vec<Task>) -> Vec<Vec<Task>> {
+fn group_tasks(tasks: Vec<Task>) -> Vec<(Option<String>, Vec<Task>)> {
     let mut groups = BTreeMap::<Option<String>, Vec<Task>>::new();
     for task in tasks {
         groups.entry(task.id.clone()).or_default().push(task);
     }
-    groups.into_values().collect()
+    groups.into_iter().collect()
 }
 
 /// Builds the GraphQL query submitting `task_outcome` to its application.
@@ -492,11 +496,19 @@ mod tests {
         }
     }
 
-    fn inputs(groups: Vec<Vec<Task>>) -> Vec<Vec<String>> {
+    /// The inputs of each group, keyed by the group's id.
+    fn inputs(groups: Vec<(Option<String>, Vec<Task>)>) -> Vec<(Option<String>, Vec<String>)> {
         groups
             .into_iter()
-            .map(|tasks| tasks.into_iter().map(|task| task.input).collect())
+            .map(|(group, tasks)| (group, tasks.into_iter().map(|task| task.input).collect()))
             .collect()
+    }
+
+    fn group(id: Option<&str>, inputs: &[&str]) -> (Option<String>, Vec<String>) {
+        (
+            id.map(str::to_string),
+            inputs.iter().map(|input| input.to_string()).collect(),
+        )
     }
 
     #[test]
@@ -504,7 +516,7 @@ mod tests {
         let tasks = vec![task(Some("1"), "first"), task(Some("2"), "second")];
         assert_eq!(
             inputs(group_tasks(tasks)),
-            vec![vec!["first"], vec!["second"]]
+            vec![group(Some("1"), &["first"]), group(Some("2"), &["second"])]
         );
     }
 
@@ -517,7 +529,10 @@ mod tests {
         ];
         assert_eq!(
             inputs(group_tasks(tasks)),
-            vec![vec!["first", "third"], vec!["second"]]
+            vec![
+                group(None, &["first", "third"]),
+                group(Some("1"), &["second"])
+            ]
         );
     }
 
@@ -530,7 +545,10 @@ mod tests {
         ];
         assert_eq!(
             inputs(group_tasks(tasks)),
-            vec![vec!["first", "third"], vec!["second"]]
+            vec![
+                group(Some("dup"), &["first", "third"]),
+                group(Some("other"), &["second"])
+            ]
         );
     }
 

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -507,7 +507,7 @@ mod tests {
     fn group(id: Option<&str>, inputs: &[&str]) -> (Option<String>, Vec<String>) {
         (
             id.map(str::to_string),
-            inputs.iter().map(|input| input.to_string()).collect(),
+            inputs.iter().copied().map(str::to_string).collect(),
         )
     }
 

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -237,52 +237,31 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 let retry_delay = self.retry_delay;
                 let operators = self.operators.clone();
                 tokio::spawn(async move {
-                    // Run all tasks concurrently, keeping the group each one belongs to.
-                    // Tasks sharing an id, and all the tasks without one, can only be told
-                    // apart by position, so they form a group whose outcomes must stay
-                    // ordered. A distinctly identified task is a group of its own.
-                    let results = future::join_all(actions.execute_tasks.into_iter().map(|task| {
-                        let operators = operators.clone();
-                        let group = task.id.clone();
-                        async move {
-                            let result =
-                                tokio::spawn(Self::execute_task(application_id, task, operators))
-                                    .await
-                                    .unwrap_or_else(|error| {
-                                        Err(anyhow::anyhow!("task panicked: {error}"))
-                                    });
-                            (group, result)
-                        }
-                    }))
-                    .await;
-                    // Tasks are assumed idempotent: whatever is not submitted here is
-                    // recomputed by the next call to `nextActions`.
-                    let (outcomes, errors) = split_batch_results(results);
-                    // `None` sorts before any timestamp, so keeping the maximum keeps the
-                    // latest retry the batch asked for: a task failing on every attempt
-                    // cannot shorten the delay protecting the operator.
-                    let mut retry_at = None;
-                    for error in errors {
-                        error!(%application_id, %error, "Error executing task");
-                        retry_at = retry_at.max(Some(Timestamp::now().saturating_add(retry_delay)));
-                    }
-                    let mut failed_groups = BTreeSet::new();
-                    for (group, outcome) in outcomes {
-                        if failed_groups.contains(&group) {
-                            continue;
-                        }
-                        if let Err(timestamp) = Self::submit_task_outcome(
-                            &chain_client,
+                    // Run each group concurrently, so that a slow or failing group never
+                    // delays the outcomes of the others.
+                    let handles = group_tasks(actions.execute_tasks).into_iter().map(|tasks| {
+                        tokio::spawn(Self::process_group(
                             application_id,
-                            &outcome,
+                            tasks,
+                            chain_client.clone(),
+                            operators.clone(),
                             retry_delay,
-                        )
+                        ))
+                    });
+                    // `None` sorts before any timestamp, so the maximum is the latest retry
+                    // any group asked for: a task failing on every attempt cannot shorten the
+                    // delay protecting the operator.
+                    let retry_at = future::join_all(handles)
                         .await
-                        {
-                            retry_at = retry_at.max(Some(timestamp));
-                            failed_groups.insert(group);
-                        }
-                    }
+                        .into_iter()
+                        .map(|result| {
+                            result.unwrap_or_else(|error| {
+                                error!(%application_id, %error, "Task group panicked");
+                                Some(Timestamp::now().saturating_add(retry_delay))
+                            })
+                        })
+                        .max()
+                        .flatten();
                     if batch_sender
                         .send(BatchResult {
                             application_id,
@@ -295,6 +274,53 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 });
             }
         }
+    }
+
+    /// Runs the tasks of one group, submitting their outcomes in order and stopping at the
+    /// first failure: the outcomes of a group are matched by position, so the application must
+    /// never see a gap in the sequence.
+    ///
+    /// Only the submissions are ordered. They contend for the chain's proposal lock, so
+    /// running a task only once its predecessor is committed would make every query wait
+    /// behind the block production of unrelated groups.
+    ///
+    /// Tasks are assumed idempotent, so whatever is left unsubmitted is recomputed by the next
+    /// call to `nextActions`. Returns the timestamp at which to retry the group, if it failed.
+    async fn process_group(
+        application_id: ApplicationId,
+        tasks: Vec<Task>,
+        chain_client: ChainClient<Env>,
+        operators: OperatorMap,
+        retry_delay: TimeDelta,
+    ) -> Option<Timestamp> {
+        let mut handles = Vec::with_capacity(tasks.len());
+        for task in tasks {
+            handles.push(tokio::spawn(Self::execute_task(
+                application_id,
+                task,
+                operators.clone(),
+            )));
+        }
+        for handle in handles {
+            let outcome = match handle.await {
+                Ok(Ok(outcome)) => outcome,
+                Ok(Err(error)) => {
+                    error!(%application_id, %error, "Error executing task");
+                    return Some(Timestamp::now().saturating_add(retry_delay));
+                }
+                Err(error) => {
+                    error!(%application_id, %error, "Task panicked");
+                    return Some(Timestamp::now().saturating_add(retry_delay));
+                }
+            };
+            if let Err(timestamp) =
+                Self::submit_task_outcome(&chain_client, application_id, &outcome, retry_delay)
+                    .await
+            {
+                return Some(timestamp);
+            }
+        }
+        None
     }
 
     async fn execute_task(
@@ -426,32 +452,16 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
     }
 }
 
-/// Splits the results of a finished batch into the outcomes to submit, each with the group it
-/// belongs to, and the errors to report.
+/// Groups the tasks of a batch by id, keeping their relative order.
 ///
-/// Outcomes of different groups are independent, but within a group the ones ordered after a
-/// failure are dropped and recomputed on the next attempt, so that an application matching
-/// them by position sees no gap in the sequence.
-fn split_batch_results(
-    results: Vec<(Option<String>, Result<TaskOutcome, anyhow::Error>)>,
-) -> (Vec<(Option<String>, TaskOutcome)>, Vec<anyhow::Error>) {
-    let mut outcomes = Vec::new();
-    let mut errors = Vec::new();
-    let mut failed_groups = BTreeSet::new();
-    for (group, result) in results {
-        match result {
-            Ok(outcome) => {
-                if !failed_groups.contains(&group) {
-                    outcomes.push((group, outcome));
-                }
-            }
-            Err(error) => {
-                errors.push(error);
-                failed_groups.insert(group);
-            }
-        }
+/// Tasks sharing an id, and all the tasks without one, can only be told apart by position, so
+/// they belong to the same group. A distinctly identified task is a group of its own.
+fn group_tasks(tasks: Vec<Task>) -> Vec<Vec<Task>> {
+    let mut groups = BTreeMap::<Option<String>, Vec<Task>>::new();
+    for task in tasks {
+        groups.entry(task.id.clone()).or_default().push(task);
     }
-    (outcomes, errors)
+    groups.into_values().collect()
 }
 
 /// Builds the GraphQL query submitting `task_outcome` to its application.
@@ -474,62 +484,54 @@ mod tests {
         }
     }
 
-    type BatchResult = (Option<String>, Result<TaskOutcome, anyhow::Error>);
-
-    fn success(id: Option<&str>, output: &str) -> BatchResult {
-        (id.map(str::to_string), Ok(outcome(id, output)))
+    fn task(id: Option<&str>, input: &str) -> Task {
+        Task {
+            id: id.map(str::to_string),
+            operator: "echo".to_string(),
+            input: input.to_string(),
+        }
     }
 
-    fn failure(id: Option<&str>) -> BatchResult {
-        (id.map(str::to_string), Err(anyhow::anyhow!("boom")))
-    }
-
-    fn outputs(outcomes: Vec<(Option<String>, TaskOutcome)>) -> Vec<String> {
-        outcomes
+    fn inputs(groups: Vec<Vec<Task>>) -> Vec<Vec<String>> {
+        groups
             .into_iter()
-            .map(|(_, outcome)| outcome.output)
+            .map(|tasks| tasks.into_iter().map(|task| task.input).collect())
             .collect()
     }
 
     #[test]
-    fn test_split_batch_results_drops_a_failed_group() {
-        // Tasks without an id all belong to the same group.
-        let results = vec![
-            success(None, "first"),
-            failure(None),
-            success(None, "third"),
-        ];
-        let (outcomes, errors) = split_batch_results(results);
-        assert_eq!(outputs(outcomes), vec!["first"]);
-        assert_eq!(errors.len(), 1);
+    fn test_group_tasks_keeps_distinctly_identified_tasks_apart() {
+        let tasks = vec![task(Some("1"), "first"), task(Some("2"), "second")];
+        assert_eq!(
+            inputs(group_tasks(tasks)),
+            vec![vec!["first"], vec!["second"]]
+        );
     }
 
     #[test]
-    fn test_split_batch_results_keeps_distinctly_identified_siblings() {
-        let results = vec![
-            failure(Some("1")),
-            success(Some("2"), "second"),
-            failure(Some("3")),
-            success(Some("4"), "fourth"),
+    fn test_group_tasks_gathers_the_unidentified_ones() {
+        let tasks = vec![
+            task(None, "first"),
+            task(Some("1"), "second"),
+            task(None, "third"),
         ];
-        let (outcomes, errors) = split_batch_results(results);
-        assert_eq!(outputs(outcomes), vec!["second", "fourth"]);
-        assert_eq!(errors.len(), 2);
+        assert_eq!(
+            inputs(group_tasks(tasks)),
+            vec![vec!["first", "third"], vec!["second"]]
+        );
     }
 
     #[test]
-    fn test_split_batch_results_only_drops_the_siblings_sharing_an_id() {
-        // Only what is ordered after the failure *and* shares its id is dropped.
-        let results = vec![
-            success(Some("dup"), "before"),
-            failure(Some("dup")),
-            success(Some("dup"), "after"),
-            success(Some("other"), "other"),
-            success(None, "unidentified"),
+    fn test_group_tasks_gathers_the_ones_sharing_an_id() {
+        let tasks = vec![
+            task(Some("dup"), "first"),
+            task(Some("other"), "second"),
+            task(Some("dup"), "third"),
         ];
-        let (outcomes, errors) = split_batch_results(results);
-        assert_eq!(outputs(outcomes), vec!["before", "other", "unidentified"]);
-        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            inputs(group_tasks(tasks)),
+            vec![vec!["first", "third"], vec!["second"]]
+        );
     }
 
     #[test]

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -1624,11 +1624,11 @@ async fn test_node_service_with_task_processor() -> Result<()> {
     Ok(())
 }
 
-/// Test that task processor outcomes are submitted in the order they were requested,
-/// even when a later task finishes before an earlier one.
+/// Test that a slow task does not delay the outcome of a distinctly identified sibling: the
+/// example application gives every task an id, so each one is a group of its own.
 #[cfg(feature = "storage-service")]
 #[test_log::test(tokio::test)]
-async fn test_task_processor_outcome_ordering() -> Result<()> {
+async fn test_task_processor_slow_task_does_not_delay_siblings() -> Result<()> {
     use std::{io::Write, os::unix::fs::PermissionsExt};
 
     use linera_base::{abi::ContractAbi, identifiers::ApplicationId};
@@ -1660,7 +1660,7 @@ async fn test_task_processor_outcome_ordering() -> Result<()> {
     {
         let mut file = std::fs::File::create(&slow_path)?;
         writeln!(file, "#!/bin/sh")?;
-        writeln!(file, "sleep 1")?;
+        writeln!(file, "sleep 5")?;
         writeln!(file, "cat")?;
     }
     std::fs::set_permissions(&slow_path, std::fs::Permissions::from_mode(0o755))?;
@@ -1702,17 +1702,19 @@ async fn test_task_processor_outcome_ordering() -> Result<()> {
     // Wait for the block containing the RequestTask operations.
     notifications.wait_for_block(None).await?;
 
-    // Wait for the two blocks containing the StoreResult operations.
+    // Wait for the first block containing a StoreResult operation. It must be the one of the
+    // fast task, submitted while the slow task requested before it is still running.
     notifications.wait_for_block(None).await?;
+    let results: Vec<String> = app.query_json("results").await?;
+    assert_eq!(results, vec!["fast_result"]);
+
+    // Wait for the block containing the StoreResult operation of the slow task.
     notifications.wait_for_block(None).await?;
 
     let task_count: u64 = app.query_json("taskCount").await?;
     assert_eq!(task_count, 2);
-
-    // Verify the results are in request order (slow first, fast second),
-    // not completion order (which would be fast first).
     let results: Vec<String> = app.query_json("results").await?;
-    assert_eq!(results, vec!["slow_result", "fast_result"]);
+    assert_eq!(results, vec!["fast_result", "slow_result"]);
 
     net.ensure_is_running().await?;
     net.terminate().await?;


### PR DESCRIPTION
## Motivation

#6697 stopped a failing task from discarding its siblings' outcomes, but left a second coupling
in place: `future::join_all` over the whole batch is a barrier, so *no* outcome is submitted
until the slowest task in the batch returns. A task querying a slow upstream delays the publish
of every other group by the difference, even though those groups are entirely unrelated to it —
the same coupling as #6696 in its latency form rather than its failure form.

## Proposal

Run one `tokio` task per group instead of one per batch. Each group awaits only its own tasks
and submits their outcomes as they arrive, so a group publishes as soon as *its* work is done.

Within a group the tasks are still all started up front, and only the submissions are ordered.
Making a task wait for its predecessor's outcome to be committed would be the obvious
simplification, but it would be a bad trade: submissions contend for the chain's proposal lock
(`ChainClient::try_execute_block` takes the per-chain `proposal_mutex`), so every query would end
up queued behind the block production of unrelated groups. A group of N tasks therefore costs
`max(query) + N × submit` rather than `N × (query + submit)`.

Concurrent submission across groups is safe for the same reason: the proposal mutex is shared by
all `ChainClient` clones for the chain, so submitters queue on it rather than racing into
conflicts.

This also removes machinery: "stop at the first failure in this group" is now just a `return`
from the group's own loop, so `split_batch_results` and the `failed_groups` bookkeeping are gone,
replaced by `group_tasks`.

Two couplings are deliberately left for later: the batch still reports back only once its slowest
group has finished, so the next round for that application waits for it; and there is still no
per-task timeout, so a hung operator stalls its application indefinitely.

## Test Plan

- New unit tests for `group_tasks`: distinctly identified tasks stay apart, unidentified ones are
  gathered, and ones sharing an id are gathered.
- `test_task_processor_outcome_ordering` asserted that outcomes arrive in request order. The
  example application gives every task a distinct id, so those tasks are distinct groups, whose
  outcomes the documented contract lets commute — that assertion was pinning an accident of the
  old sequential submit loop. It is replaced by
  `test_task_processor_slow_task_does_not_delay_siblings`, which asserts the property this PR is
  about: after the first `StoreResult` block, the only stored result is the fast task's, i.e. it
  was published while the task requested before it was still running. That assertion fails
  against the barrier this PR removes.
- `test_task_processor_failing_task_does_not_block_siblings` and
  `test_node_service_with_task_processor` still pass.

Known gap: with the example application identifying every task, no end-to-end test now covers the
ordered path (an id-less group stopping at the first failure), which is what applications
predating `Task::id` use. Covering it would mean giving the example a way to request a task
without an id.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

## Links

- Follow-up to #6697 (testnet backport #6698)
- Issue: #6696
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
