### PR TITLE
[testnet] Keep the project template on icu versions supporting Rust 1.86

### DIFF
--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -14,6 +14,13 @@ serde_json = {{ version = "1.0" }}
 # TODO(#4742): Remove the pinned versions once the `linera-*` crates work with Rust > 1.86.0.
 allocative_derive = {{ version = ">=0.3, <0.3.5" }}
 darling = {{ version = ">=0.20, <0.23" }}
+icu_collections = {{ version = ">=2, <2.3" }}
+icu_locale_core = {{ version = ">=2, <2.3" }}
+icu_normalizer = {{ version = ">=2, <2.3" }}
+icu_normalizer_data = {{ version = ">=2, <2.3" }}
+icu_properties = {{ version = ">=2, <2.3" }}
+icu_properties_data = {{ version = ">=2, <2.3" }}
+icu_provider = {{ version = ">=2, <2.3" }}
 ruint = {{ version = ">=1, <1.18" }}
 serde_with = {{ version = ">=3, <3.18" }}
 time = {{ version = ">=0.3, <0.3.47" }}


### PR DESCRIPTION
## Motivation

`default-features-and-witty-integration-test` has been failing on `testnet_conway` since
ab7d8b70, with `test_project_new` panicking at `linera-service/tests/local.rs:44` — the
`cargo test` run of the scaffolded project:

```
error: rustc 1.86.0 is not supported by the following packages:
  icu_collections@2.3.0 requires rustc 1.88
  icu_locale_core@2.3.0 requires rustc 1.88
  icu_normalizer@2.3.0 requires rustc 1.88
  icu_normalizer_data@2.3.0 requires rustc 1.88
  icu_properties@2.3.0 requires rustc 1.88
  icu_properties_data@2.3.0 requires rustc 1.88
  icu_provider@2.3.0 requires rustc 1.88
```

The commit is not the cause. `icu_* 2.3.0` was published on 2026-08-13 at 23:28 UTC, raising its
MSRV from 1.86 to 1.88; the last green run on this branch was at 20:23 and ab7d8b70 is simply the
first commit whose CI ran afterwards. It touches five files, none of them a manifest or the
lockfile, and cannot affect dependency resolution.

Only this test is affected because `linera project new` emits no `Cargo.lock`, so the generated
project resolves against crates.io from scratch and picks up the new release. The workspace pins
`icu_collections` at 2.0.0 in its lockfile and CI resolves with `--locked`, so nothing else sees
it. `main` is unaffected because it pins Rust 1.95. The crates arrive transitively, via
`url -> idna -> idna_adapter -> icu_normalizer`.

## Proposal

Add the seven `icu_*` crates to the `TODO(#4742)` upper-bound list the template already carries
for exactly this situation. Version 2.2.0 of each declares `rust-version = "1.86"`, so `<2.3`
keeps the generated project resolvable with this branch's toolchain.

This is the same treatment as `allocative_derive`, `darling`, `ruint`, `serde_with`, `time`,
`time-core`, `unicode-segmentation` and the `tonic*` crates in that block, and it has the same
shortcoming: the list grows every time any crate in the transitive graph raises its MSRV past
1.86, and each time CI goes red first.

A durable alternative, for a follow-up: give the template `rust-version = "1.86.0"` and generate a
`.cargo/config.toml` with `[resolver] incompatible-rust-versions = "fallback"`. Cargo's MSRV-aware
resolver (stable since Cargo 1.84, so usable on this branch) would then pick the newest version
each dependency supports for 1.86 on its own, and the whole `TODO(#4742)` block could go away.

## Test Plan

`cargo test -p linera-service --test local test_project_new` fails on `testnet_conway` and passes
with this change, reproducing the CI failure and its fix locally.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Blocks every open PR against `testnet_conway`, e.g. #6706.
- Context: #4742, the pinned-versions block this extends.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
