### PR TITLE
[testnet_conway] explorer: don't panic when shortening a non-hash identifier (#6709)

### DIFF
--- a/linera-explorer/src/components/Chain.vue
+++ b/linera-explorer/src/components/Chain.vue
@@ -245,7 +245,7 @@ function pendingBundleCount(): number {
                                     <span v-if="msg.messageMetadata?.systemMessage?.systemMessageType">
                                       {{ msg.messageMetadata.systemMessage.systemMessageType }}
                                       <span v-if="msg.messageMetadata.systemMessage.credit" class="ms-1">
-                                        {{ displayValue(msg.messageMetadata.systemMessage.credit.amount) }} to {{ short_hash(msg.messageMetadata.systemMessage.credit.target) }}
+                                        {{ displayValue(msg.messageMetadata.systemMessage.credit.amount) }} to {{ short_id(msg.messageMetadata.systemMessage.credit.target) }}
                                       </span>
                                       <span v-if="msg.messageMetadata.systemMessage.withdraw" class="ms-1">
                                         {{ displayValue(msg.messageMetadata.systemMessage.withdraw.amount) }}

--- a/linera-explorer/src/components/shorten.test.ts
+++ b/linera-explorer/src/components/shorten.test.ts
@@ -1,0 +1,27 @@
+import { short_crypto_hash, short_app_id, short_id } from '../../pkg/linera_explorer'
+import { set_test_config } from './utils'
+
+const HASH = '1fe0d0bb557f1a9057a2fca119566b439aa70d04918b71ea1485d5da2c7566b5'
+// `AccountOwner` is displayed with a `0x` prefix, so it is not a valid `CryptoHash`.
+const OWNER = '0x5487b70625ce71f7ee29154ad32aefa1c526cb483bdb783dea2e1d17bc497844'
+
+beforeAll(async () => {
+  await set_test_config()
+})
+
+test('short_crypto_hash shortens a hash', () => {
+  expect(short_crypto_hash(HASH)).toBe('1fe0d0bb557f1a90')
+})
+
+test('short_crypto_hash falls back instead of panicking on a non-hash', () => {
+  // Regression test: an `AccountOwner` used to panic here, taking down the whole UI.
+  expect(short_crypto_hash(OWNER)).toBe('0x54..7844')
+  expect(short_crypto_hash('')).toBe('')
+  expect(short_crypto_hash('not a hash at all')).toBe('not .. all')
+})
+
+test('short_id and short_app_id elide the middle of long identifiers only', () => {
+  expect(short_id('0x00')).toBe('0x00')
+  expect(short_id(OWNER)).toBe('0x54..7844')
+  expect(short_app_id(HASH)).toBe('1fe0..66b5')
+})

--- a/linera-explorer/src/components/utils.ts
+++ b/linera-explorer/src/components/utils.ts
@@ -1,7 +1,7 @@
 import JSONFormatter from 'json-formatter-js'
 import { Scalars } from '../../gql/operations'
 import { TransactionMetadata, IncomingBundle, Operation } from '../../gql/service'
-import { initSync, short_crypto_hash, short_app_id } from "../../pkg/linera_explorer"
+import { initSync, short_crypto_hash, short_app_id, short_id } from "../../pkg/linera_explorer"
 import { config } from '@vue/test-utils'
 
 export function json_load(id: string, data: any) {
@@ -25,6 +25,7 @@ async function set_test_config_aux() {
 
   config.global.mocks.short_hash = short_crypto_hash
   config.global.mocks.short_app_id = short_app_id
+  config.global.mocks.short_id = short_id
   config.global.mocks.json_load = json_load
   config.global.mocks.operation_id = operation_id
   return

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -809,20 +809,36 @@ pub async fn route(app: JsValue, path: JsValue, args: JsValue) {
     route_aux(&app, &data, &path, &args, false).await
 }
 
-/// Returns a shortened, debug-formatted representation of a crypto hash string.
+/// Returns a shortened representation of a crypto hash string.
+///
+/// Identifiers that are not crypto hashes are elided in the middle instead: these
+/// helpers are called from templates, where a panic tears down the whole UI rather
+/// than just the offending value.
 #[wasm_bindgen]
 pub fn short_crypto_hash(s: &str) -> String {
-    let hash = CryptoHash::from_str(s).expect("not a crypto hash");
-    format!("{hash:?}")
+    match CryptoHash::from_str(s) {
+        // Use `Display`, which honours the precision; `Debug` prints the full hash.
+        Ok(hash) => format!("{hash:.16}"),
+        Err(_) => short_id(s),
+    }
+}
+
+/// Returns a shortened representation of an identifier, eliding its middle.
+#[wasm_bindgen]
+pub fn short_id(s: &str) -> String {
+    let chars = s.chars().collect::<Vec<_>>();
+    if chars.len() <= 12 {
+        return s.to_string();
+    }
+    let head = chars[..4].iter().collect::<String>();
+    let tail = chars[chars.len() - 4..].iter().collect::<String>();
+    format!("{head}..{tail}")
 }
 
 /// Returns a shortened representation of an application ID string.
 #[wasm_bindgen]
 pub fn short_app_id(s: &str) -> String {
-    if s.len() <= 12 {
-        return s.to_string();
-    }
-    format!("{}..{}", &s[..4], &s[s.len() - 4..])
+    short_id(s)
 }
 
 fn set_onpopstate(app: JsValue) {

--- a/linera-explorer/src/main.ts
+++ b/linera-explorer/src/main.ts
@@ -1,4 +1,4 @@
-import init, { start, short_crypto_hash, short_app_id } from "../pkg/linera_explorer"
+import init, { start, short_crypto_hash, short_app_id, short_id } from "../pkg/linera_explorer"
 import { createApp, ComponentPublicInstance } from 'vue'
 import { json_load, operation_id } from './components/utils'
 import { Scalars } from '../gql/operations'
@@ -12,6 +12,7 @@ declare module '@vue/runtime-core' {
   interface ComponentCustomProperties {
     short_app_id: (id: string) => string,
     short_hash: (hash: string) => string,
+    short_id: (id: string) => string,
     json_load: (id: string, data: any) => void,
     operation_id: (key: Scalars['OperationKey']['output']) => string,
     $root: ComponentPublicInstance<{ route: (name?: string, args?: [string, string][]) => void }>,
@@ -22,6 +23,7 @@ init().then(() => {
   const app = createApp(App)
   app.config.globalProperties.short_hash = short_crypto_hash
   app.config.globalProperties.short_app_id = short_app_id
+  app.config.globalProperties.short_id = short_id
   app.config.globalProperties.json_load = json_load
   app.config.globalProperties.operation_id = operation_id
   start(app.mount('#app'))


### PR DESCRIPTION
Backport of #6709 to `testnet_conway`. Cherry-picked cleanly; `lib.rs` auto-merged
because the file has drifted elsewhere, but the three touched functions and the
`Chain.vue` call site are identical on this branch.

## Motivation

Opening a chain that has received a transfer breaks the whole explorer UI:

```
panicked at linera-explorer/src/lib.rs:815:40:
not a crypto hash: NonHexDigits(InvalidHexCharacter { c: 'x', index: 1 })
```

`short_crypto_hash` is exposed to the templates as the `short_hash` global and
called `CryptoHash::from_str(s).expect("not a crypto hash")`. `Chain.vue` passes it
the `target` of a `Credit` system message, which is an `AccountOwner`, not a hash —
and `AccountOwner`'s `Display` writes a `0x` prefix, so the parse fails on the `x` at
index 1. Because this happens inside a render function, the panic tears down the
entire Vue tree rather than just that one cell.

Separately, `short_crypto_hash` has not actually been shortening anything: it
formatted the hash with `Debug`, and #4603 changed `CryptoHash`'s `Debug` from
`hex::encode(&self.0[..8])` to `hex::encode(self.0)`. Every "short" hash in the
explorer has been rendering at full length since then.

## Proposal

- `short_crypto_hash` no longer panics. Input that is not a crypto hash is elided in
  the middle instead. A helper called from a template must never panic, whatever the
  node hands it.
- Its success path uses `Display` (which honours the precision) instead of `Debug`,
  restoring the 16-hex-character output. This is a visible change: hashes across the
  explorer go back to being shortened.
- The elision logic moves into a new exported `short_id`, which `short_app_id` now
  delegates to. It counts `chars` rather than bytes so the fallback path cannot panic
  on a multi-byte string either.
- `Chain.vue` calls `short_id` for the `Credit` target, since an account owner is not
  a hash. This was the only site passing a non-hash to `short_hash`; every other
  caller passes a `ChainId` or a `CryptoHash`.

## Test Plan

Run on this branch, not just on `main`:

```
cd linera-explorer
npm run rust && npm run ts && npx vitest run   # 15 files, 37 tests passing
cargo clippy -p linera-explorer --target wasm32-unknown-unknown --all-targets  # clean
```

- New `linera-explorer/src/components/shorten.test.ts` covers hash shortening, the
  account-owner input that used to panic, and the short/long boundary.
- The panic above was observed in a browser against a local service node on this
  branch; the fix itself has not been re-exercised manually in the UI, only through
  the unit tests. With the fix, `short_id` renders that credit target as `0x54..7844`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

This *is* the backport.

## Links

- Backport of #6709.
- Regression introduced by #4603, which made `CryptoHash: Debug` print the full hash.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
