### PR TITLE
Credit daily faucet claims to the chain balance

### DIFF
--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -168,7 +168,7 @@ impl Faucet {
             .claim)
     }
 
-    /// Claims daily tokens for the given owner.
+    /// Claims daily tokens for the given owner, credited to the balance of their chain.
     /// The user must have already claimed a chain. Each user can claim once per
     /// 24-hour period.
     pub async fn daily_claim(

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -450,7 +450,7 @@ where
         record_claim_latency(self.do_claim(owner)).await
     }
 
-    /// Transfers a daily amount of tokens to the user's existing chain.
+    /// Transfers a daily amount of tokens to the balance of the user's existing chain.
     /// The user must have already claimed a chain. Each user can claim once per 24-hour
     /// period, measured from their initial claim time.
     async fn daily_claim(&self, owner: AccountOwner) -> Result<ClaimOutcome, Error> {
@@ -906,11 +906,13 @@ where
         let mut operations = Vec::new();
         for request in &requests {
             let operation = if let Some(target_chain_id) = request.target_chain_id {
+                // Credit the chain balance, like the initial claim does, so that the tokens
+                // can pay for fees on blocks that are not authenticated by the owner.
                 Operation::system(SystemOperation::Transfer {
                     owner: AccountOwner::CHAIN,
                     recipient: Account {
                         chain_id: target_chain_id,
-                        owner: request.owner,
+                        owner: AccountOwner::CHAIN,
                     },
                     amount: request.amount,
                 })

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -9,7 +9,7 @@ use futures::lock::Mutex;
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash, InMemorySigner, TestString},
     data_types::{Amount, Epoch, Timestamp},
-    identifiers::{AccountOwner, ChainId},
+    identifiers::{Account, AccountOwner, ChainId},
 };
 use linera_client::chain_listener;
 use linera_core::{
@@ -17,8 +17,8 @@ use linera_core::{
     environment,
     test_utils::{MemoryStorageBuilder, StorageBuilder, TestBuilder},
 };
-use linera_execution::ResourceControlPolicy;
-use linera_storage::TestClock;
+use linera_execution::{Operation, ResourceControlPolicy, SystemOperation};
+use linera_storage::{Storage as _, TestClock};
 use tempfile::TempDir;
 use tokio::sync::{oneshot, Notify};
 use tokio_util::sync::CancellationToken;
@@ -715,6 +715,29 @@ async fn test_daily_claim_flow() -> anyhow::Result<()> {
         .expect("Daily claim should succeed after 25 hours");
     assert_eq!(outcome.chain_id, chain_id);
     assert_eq!(outcome.amount, daily_amount);
+
+    // The tokens go to the chain balance, not to the owner's account.
+    let certificate = env
+        .client
+        .storage_client()
+        .read_certificate(outcome.certificate_hash)
+        .await?
+        .expect("Certificate of the daily claim should be in storage");
+    let operations = certificate.block().body.operations().collect::<Vec<_>>();
+    let [Operation::System(operation)] = &*operations else {
+        panic!("Unexpected operations in the daily claim block: {operations:?}");
+    };
+    assert_eq!(
+        **operation,
+        SystemOperation::Transfer {
+            owner: AccountOwner::CHAIN,
+            recipient: Account {
+                chain_id,
+                owner: AccountOwner::CHAIN,
+            },
+            amount: daily_amount,
+        }
+    );
 
     // Step 6: Second daily claim in the same period should fail.
     let daily_duplicate = env.root.do_daily_claim(test_owner).await;


### PR DESCRIPTION
## Motivation

The two faucet claim paths credit different accounts. The initial claim opens the chain with
`OpenChainConfig { balance, .. }`, which becomes the new chain's balance, i.e. the
`AccountOwner::CHAIN` account. The daily claim, on the other hand, transfers to
`Account { chain_id, owner }`, i.e. the user's own account on that chain.

That asymmetry hurts users of delegated signing: blocks that are not authenticated by the owner
(e.g. signed by an autosigner on the user's behalf) can only pay fees out of the chain balance.
Once the initial chain balance is spent, such users are stuck even though their daily claims keep
accumulating in an account those blocks cannot draw from.

## Proposal

Send the daily claim to `AccountOwner::CHAIN` on the user's chain, so that both claim paths fund
the chain balance.

## Test Plan

CI, plus `test_daily_claim_flow` now reads the certificate produced by the daily claim and asserts
that the block's transfer targets the chain account.

## Release Plan

- These changes target `testnet_conway` directly; they require a redeployment of the faucet, and a
  separate port to `main`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
