### PR TITLE
docker: tell linera-infra to rebuild linera-utils when linera-client is published

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -324,3 +324,27 @@ jobs:
             "${SOURCES[@]}"
 
           docker buildx imagetools inspect "${REPO}:${GITHUB_SHA:0:7}"
+
+      # linera-infra's linera-utils image is linera-client plus the shell tooling
+      # its CronJobs need, so it is stale the moment this tag moves. Telling it
+      # to rebuild is what keeps the two in lockstep; linera-infra decides which
+      # of its tags (if any) tracks this branch.
+      - name: Ask linera-infra to rebuild linera-utils
+        env:
+          GH_TOKEN: ${{ secrets.LINERA_INFRA_DISPATCH_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::LINERA_INFRA_DISPATCH_TOKEN unset — linera-utils will lag until its nightly rebuild"
+            exit 0
+          fi
+          BRANCH_NAME="${HEAD_REF:-${REF_NAME}}"
+          # Send the BRANCH, not the tag: linera-infra maps branch -> image tag,
+          # so the mapping lives in the repo that owns those tags.
+          gh api -X POST repos/linera-io/linera-infra/dispatches \
+            -f event_type=linera-client-built \
+            -f "client_payload[branch]=${BRANCH_NAME}" \
+            -f "client_payload[commit]=${GITHUB_SHA}"
+          echo "notified linera-infra: linera-client:${BRANCH_NAME} rebuilt"


### PR DESCRIPTION
## Motivation

linera-infra publishes `linera-utils`: a thin wrapper that is `linera-client` plus the shell tooling its CronJobs script around it (`curl`, `bc`, `jq`). It is stale the moment this workflow republishes `linera-client`, and nothing tells it so.

The result is silent rot. `linera-utils:testnet-conway` sat at its **2026-03-03** build for five months while `linera-client:testnet_conway` kept moving with every merge to that branch — so CronJobs pointed at it were running a five-month-old CLI against current validators, with nothing anywhere reporting a problem.

This workflow already knows the exact moment the wrapper becomes stale: right after `merge-client-image` publishes the manifest list.

## Proposal

After the client manifest is published, POST a `repository_dispatch` to linera-infra with the branch that was just built.

Sending the **branch** rather than an image tag is deliberate: linera-infra owns the `linera-utils` tags and the branch→tag mapping, so this repo does not need to know that `testnet_conway` maps to `linera-utils:testnet-conway`. A branch we ship no wrapper tag for (any `devnet_*`) is simply a no-op on that side.

**Fails soft.** If `LINERA_INFRA_DISPATCH_TOKEN` is unset the step warns and exits 0, rather than failing a client build over a downstream notification. linera-infra has a daily scheduled rebuild as its backstop, so an unset or expired token costs freshness, not correctness — and says so in the log rather than passing silently.

Companion PR: linera-infra [#1776](https://github.com/linera-io/linera-infra/pull/1776), which adds the `repository_dispatch` trigger and the branch→tag matrix.

## ⚠️ Requires a secret

`LINERA_INFRA_DISPATCH_TOKEN` — a token with permission to POST `repos/linera-io/linera-infra/dispatches`. Until it exists, this step warns and no-ops on every run, and linera-infra falls back to its daily schedule. Nothing breaks in the meantime.

## Test Plan

`actionlint` reports nothing new on this file. The two findings it does report — the `linera-io-self-hosted-builder` runner label at line 17, and SC2129 at line 51 — are both pre-existing and untouched by this change, which lands at the end of the file.

The step is a single `gh api` POST guarded by an empty-token check; I verified the guard's shape locally (unset token → warning + exit 0) but the dispatch itself cannot be exercised without the secret and a real client build. Its first real run is the check that matters: linera-infra should show a `repository_dispatch` run of `build-linera-utils.yml` within minutes of the next merge to `main` or `testnet_conway`.

I have deliberately not requested or created the token; that is yours to add.

## Release Plan

- Nothing to do / These changes follow the usual deployment cycle.

## Links

- linera-infra [#1776](https://github.com/linera-io/linera-infra/pull/1776) — receives this dispatch
- linera-infra [#1754](https://github.com/linera-io/linera-infra/issues/1754) — the investigation that surfaced the staleness
