### PR TITLE
Let the caller choose which account a new chain's initial balance funds

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -358,6 +358,9 @@ Open (i.e. activate) a new chain deriving the UID from an existing one
 * `--initial-balance <BALANCE>` — The initial balance of the new chain. This is subtracted from the parent chain's balance
 
   Default value: `0`
+* `--balance-account <ACCOUNT>` — The account on the new chain credited with the initial balance. Defaults to the chain account, which is the only balance that pays fees for blocks the account itself does not authenticate
+
+  Default value: `0x00`
 * `--super-owner` — Whether to create a super owner for the new chain
 
 
@@ -390,6 +393,9 @@ If the wallet holds the key pair for exactly one of the new chain's owners, that
 * `--initial-balance <BALANCE>` — The initial balance of the new chain. This is subtracted from the parent chain's balance
 
   Default value: `0`
+* `--balance-account <ACCOUNT>` — The account on the new chain credited with the initial balance. Defaults to the chain account, which is the only balance that pays fees for blocks the account itself does not authenticate
+
+  Default value: `0x00`
 
 
 
@@ -1137,6 +1143,7 @@ Request a new chain from a faucet and add it to the wallet
 
 * `--faucet <FAUCET>` — The address of a faucet
 * `--set-default` — Whether this chain should become the default chain
+* `--fund-owner-account` — Whether to credit the claimed tokens to the new owner's account rather than to the chain account. Only blocks authenticated by that owner can then pay fees
 
 
 

--- a/examples/hex-game/src/contract.rs
+++ b/examples/hex-game/src/contract.rs
@@ -157,7 +157,9 @@ impl HexContract {
         );
         let app_id = self.runtime.application_id();
         let permissions = ApplicationPermissions::new_single(app_id.forget_abi());
-        let chain_id = self.runtime.open_chain(ownership, permissions, fee_budget);
+        let chain_id =
+            self.runtime
+                .open_chain(ownership, permissions, AccountOwner::CHAIN, fee_budget);
         for owner in &players {
             self.state
                 .game_chains

--- a/examples/rfq/src/contract.rs
+++ b/examples/rfq/src/contract.rs
@@ -333,7 +333,9 @@ impl RfqContract {
         );
         let app_id = self.runtime.application_id();
         let permissions = ApplicationPermissions::new_single(app_id.forget_abi());
-        let temp_chain_id = self.runtime.open_chain(ownership, permissions, fee_budget);
+        let temp_chain_id =
+            self.runtime
+                .open_chain(ownership, permissions, AccountOwner::CHAIN, fee_budget);
 
         // transfer tokens to the new chain
         let transfer = FungibleOperation::Transfer {

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -32,7 +32,8 @@ use crate::{
     crypto::{BcsHashable, CryptoError, CryptoHash},
     doc_scalar, hex_debug, http,
     identifiers::{
-        ApplicationId, BlobId, BlobType, ChainId, EventId, GenericApplicationId, ModuleId, StreamId,
+        AccountOwner, ApplicationId, BlobId, BlobType, ChainId, EventId, GenericApplicationId,
+        ModuleId, StreamId,
     },
     limited_writer::{LimitedWriter, LimitedWriterError},
     ownership::ChainOwnership,
@@ -1226,7 +1227,10 @@ pub struct InitialChainConfig {
     pub ownership: ChainOwnership,
     /// The epoch in which the chain is created.
     pub epoch: Epoch,
-    /// The initial chain balance.
+    /// The account on the new chain credited with `balance`. Use [`AccountOwner::CHAIN`] to
+    /// fund the chain account itself.
+    pub account: AccountOwner,
+    /// The initial balance of `account`.
     pub balance: Amount,
     /// The initial application permissions.
     pub application_permissions: ApplicationPermissions,

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -1334,6 +1334,7 @@ mod tests {
         let example_chain_config = InitialChainConfig {
             epoch: Epoch::ZERO,
             ownership: ChainOwnership::single(AccountOwner::Reserved(0)),
+            account: AccountOwner::CHAIN,
             balance: Amount::ZERO,
             application_permissions: Default::default(),
         };
@@ -1344,7 +1345,7 @@ mod tests {
         );
         assert_eq!(
             description.id().to_string(),
-            "372e43034b962ee04f8242bce87fa9cd405dd824a31b6673cef4d24b937d0de5"
+            "bfd664d8c9bee7196b6baee3190abdf8c42d936f720c8cf7e5c6f7557f75fbeb"
         );
     }
 

--- a/linera-chain/src/data_types/metadata.rs
+++ b/linera-chain/src/data_types/metadata.rs
@@ -160,7 +160,9 @@ pub struct ClaimOperationMetadata {
 /// Open chain operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
 pub struct OpenChainOperationMetadata {
-    /// The initial balance credited to the new chain.
+    /// The account on the new chain credited with the initial balance.
+    pub account: AccountOwner,
+    /// The initial balance credited to `account`.
     pub balance: Amount,
     /// The ownership configuration of the new chain.
     pub ownership: ChainOwnershipMetadata,
@@ -347,6 +349,7 @@ impl From<&SystemOperation> for SystemOperationMetadata {
             },
             SystemOperation::OpenChain(config) => SystemOperationMetadata {
                 open_chain: Some(OpenChainOperationMetadata {
+                    account: config.account,
                     balance: config.balance,
                     ownership: ChainOwnershipMetadata::from(&config.ownership),
                     application_permissions: ApplicationPermissionsMetadata::from(

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -93,6 +93,7 @@ impl TestEnvironment {
         let config = InitialChainConfig {
             ownership: ChainOwnership::single(AccountPublicKey::test_key(0).into()),
             epoch: Epoch::ZERO,
+            account: AccountOwner::CHAIN,
             balance: Amount::from_tokens(10),
             application_permissions: Default::default(),
         };

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -1306,6 +1306,7 @@ impl<Env: Environment> ClientContext<Env> {
             .map(|owner| {
                 let config = OpenChainConfig {
                     ownership: ChainOwnership::single_super(*owner),
+                    account: AccountOwner::CHAIN,
                     balance,
                     application_permissions: Default::default(),
                 };

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -937,7 +937,12 @@ async fn test_chain_listener_auto_assigns_on_new_chains() -> anyhow::Result<()> 
 
     let open = async |ownership: ChainOwnership| -> anyhow::Result<ChainId> {
         match client0
-            .open_chain(ownership, ApplicationPermissions::default(), Amount::ZERO)
+            .open_chain(
+                ownership,
+                ApplicationPermissions::default(),
+                AccountOwner::CHAIN,
+                Amount::ZERO,
+            )
             .await?
         {
             ClientOutcome::Committed((description, _)) => Ok(description.id()),

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2590,12 +2590,13 @@ impl<Env: Environment> ChainClient<Env> {
         .await
     }
 
-    /// Opens a new chain with a derived UID.
+    /// Opens a new chain with a derived UID, crediting `balance` to `account` on it.
     #[instrument(level = "trace", skip(self))]
     pub async fn open_chain(
         &self,
         ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
+        account: AccountOwner,
         balance: Amount,
     ) -> Result<ClientOutcome<(ChainDescription, ConfirmedBlockCertificate)>, Error> {
         // Check if we have a key for any owner before consuming ownership.
@@ -2608,6 +2609,7 @@ impl<Env: Environment> ChainClient<Env> {
         }
         let config = OpenChainConfig {
             ownership,
+            account,
             balance,
             application_permissions,
         };

--- a/linera-core/src/genesis_config.rs
+++ b/linera-core/src/genesis_config.rs
@@ -8,7 +8,7 @@ use linera_base::{
         Amount, Blob, ChainDescription, ChainOrigin, Epoch, InitialChainConfig, NetworkDescription,
         Timestamp,
     },
-    identifiers::ChainId,
+    identifiers::{AccountOwner, ChainId},
     ownership::ChainOwnership,
 };
 use linera_execution::committee::Committee;
@@ -38,6 +38,7 @@ fn make_chain(
     let origin = ChainOrigin::Root(index);
     let config = InitialChainConfig {
         application_permissions: Default::default(),
+        account: AccountOwner::CHAIN,
         balance,
         epoch: Epoch::ZERO,
         ownership: ChainOwnership::single(public_key.into()),

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -560,6 +560,7 @@ where
         .open_chain(
             ChainOwnership::single(new_public_key.into()),
             ApplicationPermissions::default(),
+            AccountOwner::CHAIN,
             Amount::ZERO,
         )
         .await
@@ -602,6 +603,7 @@ where
     let new_chain_config = InitialChainConfig {
         ownership: ChainOwnership::single(new_public_key.into()),
         epoch: Epoch::ZERO,
+        account: AccountOwner::CHAIN,
         balance: Amount::ZERO,
         application_permissions: Default::default(),
     };
@@ -633,6 +635,7 @@ where
         .open_chain(
             ChainOwnership::single(new_public_key.into()),
             ApplicationPermissions::default(),
+            AccountOwner::CHAIN,
             Amount::ZERO,
         )
         .await
@@ -711,7 +714,12 @@ where
     let ownership = ChainOwnership::single(new_public_key.into())
         .with_regular_owner(new_public_key.into(), 100);
     let (new_description, _creation_certificate) = sender
-        .open_chain(ownership, ApplicationPermissions::default(), Amount::ZERO)
+        .open_chain(
+            ownership,
+            ApplicationPermissions::default(),
+            AccountOwner::CHAIN,
+            Amount::ZERO,
+        )
         .await
         .unwrap_ok_committed();
     let new_id = new_description.id();
@@ -1698,6 +1706,61 @@ where
     Ok(())
 }
 
+/// A chain whose initial balance went to an owner's account has no chain balance: only blocks
+/// that owner authenticates can pay for fees there.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[test_log::test(tokio::test)]
+async fn test_open_chain_funding_an_owner_account<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut policy = ResourceControlPolicy::only_fuel();
+    policy.operation = Amount::from_micros(1); // Make blocks cost something.
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, signer)
+        .await?
+        .with_policy(policy);
+    // New chains use the admin chain to verify their creation certificate.
+    let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+
+    let new_public_key = builder.signer.generate_new();
+    let new_owner = AccountOwner::from(new_public_key);
+    let (new_description, _certificate) = sender
+        .open_chain(
+            ChainOwnership::single(new_owner),
+            ApplicationPermissions::default(),
+            new_owner,
+            Amount::from_tokens(1),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    let mut client = builder
+        .make_client(new_description.id(), None, BlockHeight::ZERO)
+        .await?;
+    client.set_preferred_owner(new_owner);
+    client.synchronize_from_validators().await?;
+
+    // The funds are in the owner's account, not in the chain's own account.
+    assert_eq!(client.local_balance().await?, Amount::ZERO);
+    assert_eq!(
+        client.local_owner_balance(new_owner).await?,
+        Amount::from_tokens(1)
+    );
+
+    // The owner can still produce blocks: fees come out of their own account.
+    client
+        .burn(new_owner, Amount::from_millis(500))
+        .await
+        .unwrap_ok_committed();
+    assert_eq!(client.local_balance().await?, Amount::ZERO);
+    assert!(client.local_owner_balance(new_owner).await? < Amount::from_millis(500));
+
+    Ok(())
+}
+
 /// The sender chain should be stored sparsely in the receiver's node: only blocks
 /// that sent messages to us should be downloaded, not the intermediate ones. When
 /// the sender is a non-root chain (so its `ChainDescription` blob isn't in the
@@ -1730,6 +1793,7 @@ where
     let (sender_description, _creation_certificate) = Box::pin(owner.open_chain(
         sender_ownership,
         ApplicationPermissions::default(),
+        AccountOwner::CHAIN,
         Amount::from_tokens(4),
     ))
     .await
@@ -3788,6 +3852,7 @@ where
         .open_chain(
             ChainOwnership::single(new_public_key.into()),
             ApplicationPermissions::default(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(10),
         )
         .await
@@ -4207,6 +4272,7 @@ where
         .open_chain(
             ChainOwnership::single(new_public_key.into()),
             ApplicationPermissions::default(),
+            AccountOwner::CHAIN,
             Amount::from_tokens(1),
         )
         .await

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -1057,6 +1057,7 @@ where
         let open_chain_config = InitialChainConfig {
             ownership: make_ownership(public_key.into()),
             epoch: Epoch(0),
+            account: AccountOwner::CHAIN,
             balance,
             application_permissions: ApplicationPermissions::default(),
         };

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -145,6 +145,7 @@ where
 
         let origin = ChainOrigin::Root(0);
         let config = InitialChainConfig {
+            account: AccountOwner::CHAIN,
             balance: amount,
             ownership: ChainOwnership::single(account_secret.public().into()),
             epoch: Epoch::ZERO,
@@ -273,6 +274,7 @@ where
         let config = InitialChainConfig {
             epoch: self.admin_description.config().epoch,
             ownership,
+            account: AccountOwner::CHAIN,
             balance,
             application_permissions: Default::default(),
         };
@@ -306,6 +308,7 @@ where
         let config = InitialChainConfig {
             epoch: self.admin_description.config().epoch,
             ownership: ChainOwnership::single(owner),
+            account: AccountOwner::CHAIN,
             balance,
             application_permissions: Default::default(),
         };
@@ -2860,6 +2863,7 @@ where
     let proposal0 = make_first_block(admin_chain_id)
         .with_operation(SystemOperation::OpenChain(OpenChainConfig {
             ownership: ChainOwnership::single(env.admin_public_key().into()),
+            account: AccountOwner::CHAIN,
             balance: Amount::ZERO,
             application_permissions: Default::default(),
         }))

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -418,23 +418,22 @@ where
             }
 
             OpenChain {
-                ownership,
-                balance,
+                config,
                 parent_id,
                 block_height,
-                application_permissions,
                 timestamp,
                 callback,
             } => {
-                let config = OpenChainConfig {
-                    ownership,
-                    balance,
-                    application_permissions,
-                };
                 let chain_id = self
                     .state
                     .system
-                    .open_chain(config, parent_id, block_height, timestamp, self.txn_tracker)
+                    .open_chain(
+                        *config,
+                        parent_id,
+                        block_height,
+                        timestamp,
+                        self.txn_tracker,
+                    )
                     .await?;
                 callback.respond(chain_id);
             }
@@ -1492,12 +1491,9 @@ pub enum ExecutionRequest {
     },
 
     OpenChain {
-        ownership: ChainOwnership,
-        #[debug(skip_if = Amount::is_zero)]
-        balance: Amount,
+        config: Box<OpenChainConfig>,
         parent_id: ChainId,
         block_height: BlockHeight,
-        application_permissions: ApplicationPermissions,
         timestamp: Timestamp,
         #[debug(skip)]
         callback: Sender<ChainId>,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1094,11 +1094,12 @@ pub trait ContractRuntime: BaseRuntime {
         query: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError>;
 
-    /// Opens a new chain.
+    /// Opens a new chain, crediting `balance` to `account` on it.
     fn open_chain(
         &mut self,
         ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
+        account: AccountOwner,
         balance: Amount,
     ) -> Result<ChainId, ExecutionError>;
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -30,7 +30,7 @@ use crate::{
     execution::UserAction,
     execution_state_actor::{ExecutionRequest, ExecutionStateSender},
     resources::ResourceController,
-    system::CreateApplicationResult,
+    system::{CreateApplicationResult, OpenChainConfig},
     util::{ReceiverExt, UnboundedSenderExt},
     ApplicationDescription, ApplicationId, BaseRuntime, ContractRuntime, DataBlobHash,
     ExecutionError, FinalizeContext, Message, MessageContext, MessageKind, ModuleId, Operation,
@@ -1570,6 +1570,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         &mut self,
         ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
+        account: AccountOwner,
         balance: Amount,
     ) -> Result<ChainId, ExecutionError> {
         let parent_id = self.inner().chain_id;
@@ -1577,16 +1578,21 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
 
         let timestamp = self.inner().user_context;
 
+        let config = Box::new(OpenChainConfig {
+            ownership,
+            account,
+            balance,
+            application_permissions,
+        });
+
         let chain_id = self
             .inner()
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::OpenChain {
-                ownership,
-                balance,
+                config,
                 parent_id,
                 block_height,
                 timestamp,
-                application_permissions,
                 callback,
             })?
             .recv_response()?;

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -216,7 +216,10 @@ impl EventSubscriptions {
 pub struct OpenChainConfig {
     /// The ownership configuration of the new chain.
     pub ownership: ChainOwnership,
-    /// The initial chain balance.
+    /// The account on the new chain credited with `balance`. Use [`AccountOwner::CHAIN`] to
+    /// fund the chain account itself.
+    pub account: AccountOwner,
+    /// The initial balance of `account`.
     pub balance: Amount,
     /// The initial application permissions.
     pub application_permissions: ApplicationPermissions,
@@ -228,6 +231,7 @@ impl OpenChainConfig {
     pub fn init_chain_config(&self, epoch: Epoch) -> InitialChainConfig {
         InitialChainConfig {
             application_permissions: self.application_permissions.clone(),
+            account: self.account,
             balance: self.balance,
             epoch,
             ownership: self.ownership.clone(),
@@ -957,6 +961,7 @@ where
         let InitialChainConfig {
             ownership,
             epoch,
+            account,
             balance,
             application_permissions,
         } = description.config().clone();
@@ -982,7 +987,10 @@ where
         self.committee_hash.set(Some(committee_hash));
         self.admin_chain_id.set(Some(admin_chain_id));
         self.ownership.set(ownership);
-        self.balance.set(balance);
+        if balance > Amount::ZERO {
+            // Crediting zero would create an empty account entry.
+            self.credit(&account, balance).await?;
+        }
         self.application_permissions.set(application_permissions);
         Ok(false)
     }

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -56,6 +56,7 @@ pub fn dummy_chain_description_with_ownership_and_balance(
     let origin = ChainOrigin::Root(index);
     let config = InitialChainConfig {
         application_permissions: Default::default(),
+        account: AccountOwner::CHAIN,
         balance,
         epoch: Epoch::ZERO,
         ownership,

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -66,15 +66,25 @@ impl SystemExecutionState {
     /// Creates a system execution state from a chain description, with dummy committees.
     pub fn new(description: ChainDescription) -> Self {
         let ownership = description.config().ownership.clone();
-        let balance = description.config().balance;
+        let account = description.config().account;
+        let initial_balance = description.config().balance;
         let epoch = description.config().epoch;
         let admin_chain_id = Some(dummy_chain_description(0).id());
+        let (balance, balances) = if account.is_chain() {
+            (initial_balance, BTreeMap::new())
+        } else {
+            (
+                Amount::ZERO,
+                BTreeMap::from_iter([(account, initial_balance)]),
+            )
+        };
         SystemExecutionState {
             epoch,
             description: Some(description),
             admin_chain_id,
             ownership,
             balance,
+            balances,
             committees: dummy_committees(),
             ..SystemExecutionState::default()
         }

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -96,6 +96,7 @@ async fn open_chain_message_index() {
     let ownership = ChainOwnership::single(owner);
     let config = OpenChainConfig {
         ownership,
+        account: AccountOwner::CHAIN,
         balance: Amount::ZERO,
         application_permissions: Default::default(),
     };

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -580,18 +580,20 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Opens a new chain, configuring it with the provided `chain_ownership`,
-    /// `application_permissions` and initial `balance` (debited from the current chain).
+    /// Opens a new chain, configuring it with the provided `chain_ownership` and
+    /// `application_permissions`, and crediting `balance` (debited from the current chain) to
+    /// `account` on the new chain.
     fn open_chain(
         caller: &mut Caller,
         chain_ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
+        account: AccountOwner,
         balance: Amount,
     ) -> Result<ChainId, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .open_chain(chain_ownership, application_permissions, balance)
+            .open_chain(chain_ownership, application_permissions, account, balance)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1137,9 +1137,23 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
     Ok(())
 }
 
-/// Tests the system API calls `open_chain` and `chain_ownership`.
+/// Tests the system API calls `open_chain` and `chain_ownership`, funding the new chain's own
+/// account.
 #[tokio::test]
 async fn test_open_chain() -> anyhow::Result<()> {
+    Box::pin(run_open_chain_test(AccountOwner::CHAIN)).await
+}
+
+/// Tests that `open_chain` can credit the initial balance to an owner's account instead of the
+/// new chain's own account.
+#[tokio::test]
+async fn test_open_chain_funding_an_owner_account() -> anyhow::Result<()> {
+    Box::pin(run_open_chain_test(AccountPublicKey::test_key(3).into())).await
+}
+
+/// Opens a child chain crediting `child_account` with one token, and checks the parent's debit
+/// as well as the new chain's state after initialization.
+async fn run_open_chain_test(child_account: AccountOwner) -> anyhow::Result<()> {
     let committee = Committee::make_simple(vec![(
         ValidatorPublicKey::test_key(0),
         AccountPublicKey::test_key(0),
@@ -1178,6 +1192,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
     };
     let child_application_permissions = ApplicationPermissions::new_single(application_id);
     let child_config = InitialChainConfig {
+        account: child_account,
         balance: Amount::ONE,
         ownership: child_ownership.clone(),
         application_permissions: child_application_permissions.clone(),
@@ -1193,8 +1208,12 @@ async fn test_open_chain() -> anyhow::Result<()> {
             let destination = Account::chain(dummy_chain_description(2).id());
             runtime.transfer(AccountOwner::CHAIN, destination, Amount::ONE)?;
             let application_permissions = child_application_permissions.clone();
-            let chain_id =
-                runtime.open_chain(child_ownership, application_permissions, Amount::ONE)?;
+            let chain_id = runtime.open_chain(
+                child_ownership,
+                application_permissions,
+                child_account,
+                Amount::ONE,
+            )?;
             assert_eq!(chain_id, child_id);
             Ok(vec![])
         }
@@ -1226,6 +1245,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
     let created_description: ChainDescription =
         bcs::from_bytes(new_blob.bytes()).expect("should deserialize a chain description");
     assert_eq!(created_description.config().balance, Amount::ONE);
+    assert_eq!(created_description.config().account, child_account);
     assert_eq!(created_description.config().ownership, child_ownership);
 
     // Initialize the child chain using the new blob.
@@ -1245,7 +1265,18 @@ async fn test_open_chain() -> anyhow::Result<()> {
         .initialize_chain(child_description.id())
         .await
         .expect("should initialize chain correctly");
-    assert_eq!(*child_view.system.balance.get(), Amount::ONE);
+    if child_account.is_chain() {
+        assert_eq!(*child_view.system.balance.get(), Amount::ONE);
+        assert!(child_view.system.balances.indices().await?.is_empty());
+    } else {
+        // The chain itself is left without funds: only blocks authenticated by `child_account`
+        // can pay fees on it.
+        assert_eq!(*child_view.system.balance.get(), Amount::ZERO);
+        assert_eq!(
+            child_view.system.balances.get(&child_account).await?,
+            Some(Amount::ONE)
+        );
+    }
     assert_eq!(*child_view.system.ownership.get().await?, child_ownership);
     assert_eq!(
         *child_view.system.committee_hash.get(),

--- a/linera-exporter/src/runloops/mod.rs
+++ b/linera-exporter/src/runloops/mod.rs
@@ -338,6 +338,7 @@ mod test {
             Blob, BlobContent, ChainDescription, ChainOrigin, Epoch, InitialChainConfig, Round,
             Timestamp,
         },
+        identifiers::AccountOwner,
         port::get_free_port,
     };
     use linera_chain::{
@@ -721,6 +722,7 @@ mod test {
                 InitialChainConfig {
                     ownership: Default::default(),
                     epoch: Default::default(),
+                    account: AccountOwner::CHAIN,
                     balance: Default::default(),
                     application_permissions: Default::default(),
                 },

--- a/linera-exporter/src/test_utils.rs
+++ b/linera-exporter/src/test_utils.rs
@@ -20,7 +20,7 @@ use linera_base::{
         Amount, Blob, BlockHeight, ChainDescription, ChainOrigin, Epoch, InitialChainConfig,
         OracleResponse, Round, Timestamp,
     },
-    identifiers::{BlobId, ChainId},
+    identifiers::{AccountOwner, BlobId, ChainId},
 };
 use linera_chain::{
     data_types::BlockExecutionOutcome,
@@ -500,6 +500,7 @@ pub(crate) async fn make_simple_state_with_blobs<S: Storage>(
         InitialChainConfig {
             ownership: Default::default(),
             epoch: Default::default(),
+            account: AccountOwner::CHAIN,
             balance: Default::default(),
             application_permissions: Default::default(),
         },

--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{Amount, ArithmeticError, ChainDescription, Timestamp},
-    identifiers::ChainId,
+    identifiers::{AccountOwner, ChainId},
 };
 use linera_client::config::GenesisConfig;
 use linera_execution::{committee::ValidatorState, Committee, ResourceControlPolicy};
@@ -72,6 +72,16 @@ pub struct InitialClaim {
     pub chain_id: ChainId,
     /// The block timestamp when the chain was created.
     pub timestamp: Timestamp,
+}
+
+/// Returns the `destination` argument to append to a claim mutation, which is omitted for the
+/// chain account so that queries stay compatible with faucets that predate the argument.
+fn destination_argument(destination: &AccountOwner) -> String {
+    if destination.is_chain() {
+        String::new()
+    } else {
+        format!(", destination: \"{destination}\"")
+    }
 }
 
 /// A faucet instance that can be queried.
@@ -173,27 +183,46 @@ impl Faucet {
         Ok(self.query::<Response>("query { version }").await?.version)
     }
 
-    /// Claims a new chain for the given owner, returning its chain description.
-    pub async fn claim(
+    /// Claims a new chain for the given owner, returning its chain description. The tokens are
+    /// credited to the new chain's own account.
+    pub async fn claim(&self, owner: &AccountOwner) -> Result<ChainDescription, Error> {
+        self.claim_to(owner, &AccountOwner::CHAIN).await
+    }
+
+    /// Claims a new chain for the given owner, crediting the tokens to `destination` on it.
+    ///
+    /// A chain funded only in an owner's account can pay fees just for the blocks that owner
+    /// authenticates.
+    pub async fn claim_to(
         &self,
-        owner: &linera_base::identifiers::AccountOwner,
+        owner: &AccountOwner,
+        destination: &AccountOwner,
     ) -> Result<ChainDescription, Error> {
         #[derive(serde::Deserialize)]
         struct Response {
             claim: ChainDescription,
         }
         Ok(self
-            .query::<Response>(format!("mutation {{ claim(owner: \"{owner}\") }}"))
+            .query::<Response>(format!(
+                "mutation {{ claim(owner: \"{owner}\"{}) }}",
+                destination_argument(destination)
+            ))
             .await?
             .claim)
     }
 
-    /// Claims daily tokens for the given owner.
+    /// Claims daily tokens for the given owner, credited to their chain's own account.
     /// The user must have already claimed a chain. Each user can claim once per
     /// 24-hour period.
-    pub async fn daily_claim(
+    pub async fn daily_claim(&self, owner: &AccountOwner) -> Result<ClaimOutcome, Error> {
+        self.daily_claim_to(owner, &AccountOwner::CHAIN).await
+    }
+
+    /// Claims daily tokens for the given owner, crediting them to `destination` on their chain.
+    pub async fn daily_claim_to(
         &self,
-        owner: &linera_base::identifiers::AccountOwner,
+        owner: &AccountOwner,
+        destination: &AccountOwner,
     ) -> Result<ClaimOutcome, Error> {
         #[derive(serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
@@ -202,16 +231,16 @@ impl Faucet {
         }
 
         Ok(self
-            .query::<Response>(format!("mutation {{ dailyClaim(owner: \"{owner}\") }}"))
+            .query::<Response>(format!(
+                "mutation {{ dailyClaim(owner: \"{owner}\"{}) }}",
+                destination_argument(destination)
+            ))
             .await?
             .daily_claim)
     }
 
     /// Returns the initial claim for the given owner, if any.
-    pub async fn initial_claim(
-        &self,
-        owner: &linera_base::identifiers::AccountOwner,
-    ) -> Result<Option<InitialClaim>, Error> {
+    pub async fn initial_claim(&self, owner: &AccountOwner) -> Result<Option<InitialClaim>, Error> {
         #[derive(serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct Response {
@@ -229,10 +258,7 @@ impl Faucet {
     /// Returns the earliest time at which the owner can make a daily claim.
     /// If the returned timestamp is in the past (or now), the user can claim immediately.
     /// Returns `None` if the user has not yet completed the initial claim.
-    pub async fn next_daily_claim(
-        &self,
-        owner: &linera_base::identifiers::AccountOwner,
-    ) -> Result<Option<Timestamp>, Error> {
+    pub async fn next_daily_claim(&self, owner: &AccountOwner) -> Result<Option<Timestamp>, Error> {
         #[derive(serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct Response {

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -268,6 +268,8 @@ struct PendingRequest {
     owner: AccountOwner,
     /// For daily claims, the existing chain to transfer tokens to.
     target_chain_id: Option<ChainId>,
+    /// The account on the user's chain to credit.
+    destination: AccountOwner,
     /// The amount of tokens to send.
     amount: Amount,
     /// For daily claims, the period number to store.
@@ -434,15 +436,31 @@ where
     S: Storage + Send + Sync + 'static,
 {
     /// Creates a new chain with the given authentication key, and transfers tokens to it.
-    async fn claim(&self, owner: AccountOwner) -> Result<ChainDescription, Error> {
-        record_claim_latency(self.do_claim(owner)).await
+    ///
+    /// The tokens are credited to `destination` on the new chain, defaulting to the chain
+    /// account itself. A chain funded only in an owner's account can pay fees just for the
+    /// blocks that owner authenticates.
+    async fn claim(
+        &self,
+        owner: AccountOwner,
+        destination: Option<AccountOwner>,
+    ) -> Result<ChainDescription, Error> {
+        record_claim_latency(self.do_claim(owner, destination.unwrap_or(AccountOwner::CHAIN))).await
     }
 
     /// Transfers a daily amount of tokens to the user's existing chain.
     /// The user must have already claimed a chain. Each user can claim once per 24-hour
     /// period, measured from their initial claim time.
-    async fn daily_claim(&self, owner: AccountOwner) -> Result<ClaimOutcome, Error> {
-        record_claim_latency(self.do_daily_claim(owner)).await
+    ///
+    /// The tokens are credited to `destination` on that chain, following the same rule as the
+    /// initial claim.
+    async fn daily_claim(
+        &self,
+        owner: AccountOwner,
+        destination: Option<AccountOwner>,
+    ) -> Result<ClaimOutcome, Error> {
+        record_claim_latency(self.do_daily_claim(owner, destination.unwrap_or(AccountOwner::CHAIN)))
+            .await
     }
 }
 
@@ -450,7 +468,11 @@ impl<S> MutationRoot<S>
 where
     S: Storage + Send + Sync + 'static,
 {
-    async fn do_claim(&self, owner: AccountOwner) -> Result<ChainDescription, Error> {
+    async fn do_claim(
+        &self,
+        owner: AccountOwner,
+        destination: AccountOwner,
+    ) -> Result<ChainDescription, Error> {
         // Check if this owner already has a chain.
         #[cfg(with_metrics)]
         let histogram = metrics::DATABASE_OPERATION_LATENCY.with_label_values(&["get_chain_id"]);
@@ -477,6 +499,7 @@ where
             requests.push_back(PendingRequest {
                 owner,
                 target_chain_id: None,
+                destination,
                 amount: self.initial_claim_amount,
                 daily_period: 0,
                 responder: tx,
@@ -519,7 +542,11 @@ where
         }
     }
 
-    async fn do_daily_claim(&self, owner: AccountOwner) -> Result<ClaimOutcome, Error> {
+    async fn do_daily_claim(
+        &self,
+        owner: AccountOwner,
+        destination: AccountOwner,
+    ) -> Result<ClaimOutcome, Error> {
         // Each early return below is a *refusal*, not a failure, and must be counted
         // under its own `result` label: these paths return before the queue round-trip
         // that increments `CLAIM_REQUESTS_TOTAL`, so without the explicit counters
@@ -561,6 +588,7 @@ where
         self.enqueue_daily_request(
             owner,
             initial_claim.chain_id,
+            destination,
             self.daily_claim_amount,
             period,
         )
@@ -571,6 +599,7 @@ where
         &self,
         owner: AccountOwner,
         target_chain_id: ChainId,
+        destination: AccountOwner,
         amount: Amount,
         daily_period: u64,
     ) -> Result<ClaimOutcome, Error> {
@@ -583,6 +612,7 @@ where
             requests.push_back(PendingRequest {
                 owner,
                 target_chain_id: Some(target_chain_id),
+                destination,
                 amount,
                 daily_period,
                 responder: tx,
@@ -904,13 +934,14 @@ where
                     owner: AccountOwner::CHAIN,
                     recipient: Account {
                         chain_id: target_chain_id,
-                        owner: request.owner,
+                        owner: request.destination,
                     },
                     amount: request.amount,
                 })
             } else {
                 let config = OpenChainConfig {
                     ownership: ChainOwnership::single(request.owner),
+                    account: request.destination,
                     balance: request.amount,
                     application_permissions: ApplicationPermissions::default(),
                 };

--- a/linera-faucet/server/src/tests.rs
+++ b/linera-faucet/server/src/tests.rs
@@ -9,7 +9,7 @@ use futures::lock::Mutex;
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash, InMemorySigner, TestString},
     data_types::{Amount, Epoch, Timestamp},
-    identifiers::{AccountOwner, ChainId},
+    identifiers::{Account, AccountOwner, ChainId},
 };
 use linera_client::chain_listener;
 use linera_core::{
@@ -17,8 +17,8 @@ use linera_core::{
     environment,
     test_utils::{MemoryStorageBuilder, StorageBuilder, TestBuilder},
 };
-use linera_execution::ResourceControlPolicy;
-use linera_storage::TestClock;
+use linera_execution::{Operation, ResourceControlPolicy, SystemOperation};
+use linera_storage::{Storage as _, TestClock};
 use tempfile::TempDir;
 use tokio::sync::{oneshot, Notify};
 use tokio_util::sync::CancellationToken;
@@ -259,7 +259,7 @@ async fn test_faucet_rate_limiting() -> anyhow::Result<()> {
     env.clock.set(Timestamp::from(999));
     let result1 = env
         .root
-        .do_claim(AccountPublicKey::test_key(0).into())
+        .do_claim(AccountPublicKey::test_key(0).into(), AccountOwner::CHAIN)
         .await;
     assert!(
         result1.is_err(),
@@ -270,14 +270,14 @@ async fn test_faucet_rate_limiting() -> anyhow::Result<()> {
     env.clock.set(Timestamp::from(1000));
     let result2 = env
         .root
-        .do_claim(AccountPublicKey::test_key(1).into())
+        .do_claim(AccountPublicKey::test_key(1).into(), AccountOwner::CHAIN)
         .await;
     assert!(result2.is_ok(), "First claim should succeed at time 1000");
 
     // Test: immediate second claim should fail (rate limit)
     let result3 = env
         .root
-        .do_claim(AccountPublicKey::test_key(2).into())
+        .do_claim(AccountPublicKey::test_key(2).into(), AccountOwner::CHAIN)
         .await;
     assert!(
         result3.is_err(),
@@ -288,20 +288,20 @@ async fn test_faucet_rate_limiting() -> anyhow::Result<()> {
     env.clock.set(Timestamp::from(3000));
     let result4 = env
         .root
-        .do_claim(AccountPublicKey::test_key(3).into())
+        .do_claim(AccountPublicKey::test_key(3).into(), AccountOwner::CHAIN)
         .await;
     assert!(result4.is_ok(), "Third claim should succeed at time 3000");
 
     let result5 = env
         .root
-        .do_claim(AccountPublicKey::test_key(4).into())
+        .do_claim(AccountPublicKey::test_key(4).into(), AccountOwner::CHAIN)
         .await;
     assert!(result5.is_ok(), "Fourth claim should succeed at time 3000");
 
     // Test: too many claims should eventually fail
     let result6 = env
         .root
-        .do_claim(AccountPublicKey::test_key(5).into())
+        .do_claim(AccountPublicKey::test_key(5).into(), AccountOwner::CHAIN)
         .await;
     assert!(
         result6.is_err(),
@@ -391,6 +391,7 @@ async fn test_batch_size_reduction_on_limit_errors() -> anyhow::Result<()> {
             pending_requests_guard.push_back(PendingRequest {
                 owner,
                 target_chain_id: None,
+                destination: AccountOwner::CHAIN,
                 amount: Amount::from_tokens(1),
                 daily_period: 0,
                 responder: tx,
@@ -428,21 +429,21 @@ async fn test_faucet_persistence() -> anyhow::Result<()> {
     // Claim chains for two different owners
     let chain_1 = env
         .root
-        .do_claim(test_owner_1)
+        .do_claim(test_owner_1, AccountOwner::CHAIN)
         .await
         .expect("First claim should succeed");
 
     env.clock.set(Timestamp::from(2000));
     let chain_2 = env
         .root
-        .do_claim(test_owner_2)
+        .do_claim(test_owner_2, AccountOwner::CHAIN)
         .await
         .expect("Second claim should succeed");
 
     // Verify that immediate re-claims return the same chains
     let chain_1_again = env
         .root
-        .do_claim(test_owner_1)
+        .do_claim(test_owner_1, AccountOwner::CHAIN)
         .await
         .expect("Re-claim should return existing chain");
     assert_eq!(
@@ -453,7 +454,7 @@ async fn test_faucet_persistence() -> anyhow::Result<()> {
 
     let chain_2_again = env
         .root
-        .do_claim(test_owner_2)
+        .do_claim(test_owner_2, AccountOwner::CHAIN)
         .await
         .expect("Re-claim should return existing chain");
     assert_eq!(
@@ -504,7 +505,7 @@ async fn test_faucet_persistence() -> anyhow::Result<()> {
 
     // Verify that the new instance returns the same chain IDs for the same owners
     let chain_1_after_restart = root_2
-        .do_claim(test_owner_1)
+        .do_claim(test_owner_1, AccountOwner::CHAIN)
         .await
         .expect("Should return existing chain after restart");
     assert_eq!(
@@ -514,7 +515,7 @@ async fn test_faucet_persistence() -> anyhow::Result<()> {
     );
 
     let chain_2_after_restart = root_2
-        .do_claim(test_owner_2)
+        .do_claim(test_owner_2, AccountOwner::CHAIN)
         .await
         .expect("Should return existing chain after restart");
     assert_eq!(
@@ -527,7 +528,7 @@ async fn test_faucet_persistence() -> anyhow::Result<()> {
     env.clock.set(Timestamp::from(3000));
     let test_owner_3 = AccountPublicKey::test_key(44).into();
     let chain_3 = root_2
-        .do_claim(test_owner_3)
+        .do_claim(test_owner_3, AccountOwner::CHAIN)
         .await
         .expect("New owner should be able to claim after restart");
 
@@ -566,14 +567,14 @@ async fn test_blockchain_sync_after_database_deletion() -> anyhow::Result<()> {
     // Claim chains for two different owners
     let chain_1 = env
         .root
-        .do_claim(test_owner_1)
+        .do_claim(test_owner_1, AccountOwner::CHAIN)
         .await
         .expect("First claim should succeed");
 
     env.clock.set(Timestamp::from(2000));
     let chain_2 = env
         .root
-        .do_claim(test_owner_2)
+        .do_claim(test_owner_2, AccountOwner::CHAIN)
         .await
         .expect("Second claim should succeed");
 
@@ -584,7 +585,7 @@ async fn test_blockchain_sync_after_database_deletion() -> anyhow::Result<()> {
     // Verify initial state works correctly
     let chain_1_again = env
         .root
-        .do_claim(test_owner_1)
+        .do_claim(test_owner_1, AccountOwner::CHAIN)
         .await
         .expect("Re-claim should return existing chain");
     assert_eq!(
@@ -612,7 +613,7 @@ async fn test_blockchain_sync_after_database_deletion() -> anyhow::Result<()> {
 
     // Test that the blockchain sync correctly restored the chain mappings
     let chain_1_after_sync = root_2
-        .do_claim(test_owner_1)
+        .do_claim(test_owner_1, AccountOwner::CHAIN)
         .await
         .expect("Should return existing chain after blockchain sync");
     assert_eq!(
@@ -622,7 +623,7 @@ async fn test_blockchain_sync_after_database_deletion() -> anyhow::Result<()> {
     );
 
     let chain_2_after_sync = root_2
-        .do_claim(test_owner_2)
+        .do_claim(test_owner_2, AccountOwner::CHAIN)
         .await
         .expect("Should return existing chain after blockchain sync");
     assert_eq!(
@@ -637,7 +638,7 @@ async fn test_blockchain_sync_after_database_deletion() -> anyhow::Result<()> {
     env.clock.set(Timestamp::from(3000));
     let test_owner_3 = AccountPublicKey::test_key(102).into();
     let chain_3 = root_2
-        .do_claim(test_owner_3)
+        .do_claim(test_owner_3, AccountOwner::CHAIN)
         .await
         .expect("New owner should be able to claim after sync");
 
@@ -655,7 +656,7 @@ async fn test_blockchain_sync_after_database_deletion() -> anyhow::Result<()> {
 
     // Verify that the new chain mapping is also persisted
     let chain_3_again = root_2
-        .do_claim(test_owner_3)
+        .do_claim(test_owner_3, AccountOwner::CHAIN)
         .await
         .expect("Re-claim should return the new chain");
     assert_eq!(
@@ -682,7 +683,10 @@ async fn test_daily_claim_flow() -> anyhow::Result<()> {
     let test_owner = AccountPublicKey::test_key(200).into();
 
     // Step 1: Daily claim should fail before initial claim.
-    let daily_before_initial = env.root.do_daily_claim(test_owner).await;
+    let daily_before_initial = env
+        .root
+        .do_daily_claim(test_owner, AccountOwner::CHAIN)
+        .await;
     assert!(
         daily_before_initial.is_err(),
         "Daily claim should fail without an initial chain claim"
@@ -691,13 +695,16 @@ async fn test_daily_claim_flow() -> anyhow::Result<()> {
     // Step 2: Do the initial claim to create a chain.
     let description = env
         .root
-        .do_claim(test_owner)
+        .do_claim(test_owner, AccountOwner::CHAIN)
         .await
         .expect("Initial claim should succeed");
     let chain_id = description.id();
 
     // Step 3: Daily claim should fail in period 0 (same period as initial claim).
-    let daily_same_period = env.root.do_daily_claim(test_owner).await;
+    let daily_same_period = env
+        .root
+        .do_daily_claim(test_owner, AccountOwner::CHAIN)
+        .await;
     assert!(
         daily_same_period.is_err(),
         "Daily claim should fail in the same period as initial claim"
@@ -710,14 +717,25 @@ async fn test_daily_claim_flow() -> anyhow::Result<()> {
     // Step 5: Daily claim should now succeed.
     let outcome = env
         .root
-        .do_daily_claim(test_owner)
+        .do_daily_claim(test_owner, AccountOwner::CHAIN)
         .await
         .expect("Daily claim should succeed after 25 hours");
     assert_eq!(outcome.chain_id, chain_id);
     assert_eq!(outcome.amount, daily_amount);
+    assert_eq!(
+        transfer_recipient(&env, outcome.certificate_hash).await?,
+        Account {
+            chain_id,
+            owner: AccountOwner::CHAIN,
+        },
+        "By default the daily claim credits the chain account"
+    );
 
     // Step 6: Second daily claim in the same period should fail.
-    let daily_duplicate = env.root.do_daily_claim(test_owner).await;
+    let daily_duplicate = env
+        .root
+        .do_daily_claim(test_owner, AccountOwner::CHAIN)
+        .await;
     assert!(
         daily_duplicate.is_err(),
         "Second daily claim in same period should fail"
@@ -729,11 +747,75 @@ async fn test_daily_claim_flow() -> anyhow::Result<()> {
 
     let outcome_2 = env
         .root
-        .do_daily_claim(test_owner)
+        .do_daily_claim(test_owner, AccountOwner::CHAIN)
         .await
         .expect("Daily claim should succeed in period 2");
     assert_eq!(outcome_2.chain_id, chain_id);
     assert_eq!(outcome_2.amount, daily_amount);
+
+    handle.stop().await
+}
+
+/// Returns the recipient of the single transfer operation in the block with the given hash.
+async fn transfer_recipient(
+    env: &FaucetTestEnv,
+    certificate_hash: CryptoHash,
+) -> anyhow::Result<Account> {
+    let certificate = env
+        .client
+        .storage_client()
+        .read_certificate(certificate_hash)
+        .await?
+        .expect("Certificate of the claim should be in storage");
+    let operations = certificate.block().body.operations().collect::<Vec<_>>();
+    let [Operation::System(operation)] = &*operations else {
+        panic!("Unexpected operations in the claim block: {operations:?}");
+    };
+    let SystemOperation::Transfer { recipient, .. } = **operation else {
+        panic!("Unexpected operation in the claim block: {operation:?}");
+    };
+    Ok(recipient)
+}
+
+#[test_log::test(tokio::test)]
+async fn test_claims_honor_the_destination() -> anyhow::Result<()> {
+    // Both claim paths must credit the account the caller asked for.
+
+    let daily_amount = Amount::from_millis(500);
+    let mut config = FaucetTestConfig::new(100);
+    config.batch_config.max_batch_size = 10;
+    config.daily_claim_amount = daily_amount;
+    let batch_config = config.batch_config.clone();
+    let env = FaucetTestEnv::new(config).await?;
+    let handle = env.spawn_processor(batch_config);
+
+    let test_owner: AccountOwner = AccountPublicKey::test_key(201).into();
+    let destination: AccountOwner = AccountPublicKey::test_key(202).into();
+
+    // The initial claim funds the requested account on the new chain.
+    let description = env
+        .root
+        .do_claim(test_owner, destination)
+        .await
+        .expect("Initial claim should succeed");
+    assert_eq!(description.config().account, destination);
+    assert_eq!(description.config().balance, env.root.initial_claim_amount);
+
+    // The daily claim transfers to the same account on that chain.
+    let twenty_five_hours = 25 * 60 * 60 * 1_000_000u64;
+    env.clock.set(Timestamp::from(twenty_five_hours));
+    let outcome = env
+        .root
+        .do_daily_claim(test_owner, destination)
+        .await
+        .expect("Daily claim should succeed after 25 hours");
+    assert_eq!(
+        transfer_recipient(&env, outcome.certificate_hash).await?,
+        Account {
+            chain_id: description.id(),
+            owner: destination,
+        }
+    );
 
     handle.stop().await
 }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -590,6 +590,8 @@ InitialChainConfig:
         TYPENAME: ChainOwnership
     - epoch:
         TYPENAME: Epoch
+    - account:
+        TYPENAME: AccountOwner
     - balance:
         TYPENAME: Amount
     - application_permissions:
@@ -881,6 +883,8 @@ OpenChainConfig:
   STRUCT:
     - ownership:
         TYPENAME: ChainOwnership
+    - account:
+        TYPENAME: AccountOwner
     - balance:
         TYPENAME: Amount
     - application_permissions:

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -365,17 +365,21 @@ where
         serde_json::from_slice(&response).expect("Failed to deserialize service response")
     }
 
-    /// Opens a new chain, configuring it with the provided `chain_ownership`,
-    /// `application_permissions` and initial `balance` (debited from the current chain).
+    /// Opens a new chain, configuring it with the provided `chain_ownership` and
+    /// `application_permissions`, and crediting `balance` (debited from the current chain) to
+    /// `account` on the new chain. Use [`AccountOwner::CHAIN`] to fund the new chain's own
+    /// account, which is the only balance that pays fees for blocks it does not authenticate.
     pub fn open_chain(
         &mut self,
         chain_ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
+        account: AccountOwner,
         balance: Amount,
     ) -> ChainId {
         let chain_id = contract_wit::open_chain(
             &chain_ownership.into(),
             &application_permissions.into(),
+            account.into(),
             balance.into(),
         );
         chain_id.into()

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -84,7 +84,13 @@ where
     expected_read_data_blob_requests: VecDeque<(DataBlobHash, Vec<u8>)>,
     expected_assert_data_blob_exists_requests: VecDeque<(DataBlobHash, Option<()>)>,
     expected_has_empty_storage_requests: VecDeque<(ApplicationId, bool)>,
-    expected_open_chain_calls: VecDeque<(ChainOwnership, ApplicationPermissions, Amount, ChainId)>,
+    expected_open_chain_calls: VecDeque<(
+        ChainOwnership,
+        ApplicationPermissions,
+        AccountOwner,
+        Amount,
+        ChainId,
+    )>,
     expected_publish_module_calls: VecDeque<ExpectedPublishModuleCall>,
     expected_create_application_calls: VecDeque<ExpectedCreateApplicationCall>,
     expected_create_data_blob_calls: VecDeque<ExpectedCreateDataBlobCall>,
@@ -867,31 +873,42 @@ where
         &mut self,
         ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
+        account: AccountOwner,
         balance: Amount,
         chain_id: ChainId,
     ) {
         self.expected_open_chain_calls.push_back((
             ownership,
             application_permissions,
+            account,
             balance,
             chain_id,
         ));
     }
 
-    /// Opens a new chain, configuring it with the provided `chain_ownership`,
-    /// `application_permissions` and initial `balance` (debited from the current chain).
+    /// Opens a new chain, configuring it with the provided `chain_ownership` and
+    /// `application_permissions`, and crediting `balance` (debited from the current chain) to
+    /// `account` on the new chain.
     pub fn open_chain(
         &mut self,
         ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
+        account: AccountOwner,
         balance: Amount,
     ) -> ChainId {
-        let (expected_ownership, expected_permissions, expected_balance, chain_id) = self
+        let (
+            expected_ownership,
+            expected_permissions,
+            expected_account,
+            expected_balance,
+            chain_id,
+        ) = self
             .expected_open_chain_calls
             .pop_front()
             .expect("Unexpected open_chain call");
         assert_eq!(&ownership, &expected_ownership);
         assert_eq!(&application_permissions, &expected_permissions);
+        assert_eq!(account, expected_account);
         assert_eq!(balance, expected_balance);
         chain_id
     }

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -101,6 +101,7 @@ impl TestValidator {
         let new_chain_config = InitialChainConfig {
             ownership: ChainOwnership::single(key_pair.public().into()),
             epoch,
+            account: AccountOwner::CHAIN,
             balance: Amount::from_tokens(1_000_000),
             application_permissions: ApplicationPermissions::default(),
         };
@@ -319,6 +320,7 @@ impl TestValidator {
 
         let open_chain_config = OpenChainConfig {
             ownership: ChainOwnership::single(owner),
+            account: AccountOwner::CHAIN,
             balance: Amount::from_tokens(10),
             application_permissions: ApplicationPermissions::default(),
         };

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -11,7 +11,7 @@ interface contract-runtime-api {
     claim: func(source: account, destination: account, amount: amount);
     approve: func(owner: account-owner, spender: account-owner, amount: amount);
     transfer-from: func(owner: account-owner, spender: account-owner, destination: account, amount: amount);
-    open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> chain-id;
+    open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, account: account-owner, balance: amount) -> chain-id;
     close-chain: func() -> result<tuple<>, manage-chain-error>;
     change-ownership: func(ownership: chain-ownership) -> result<tuple<>, manage-chain-error>;
     change-application-permissions: func(application-permissions: application-permissions) -> result<tuple<>, manage-chain-error>;

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -394,6 +394,7 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
                 amount
               }
               openChain {
+                account
                 balance
                 ownership {
                   ownershipJson
@@ -573,6 +574,7 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
                 amount
               }
               openChain {
+                account
                 balance
                 ownership {
                   ownershipJson

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -1068,7 +1068,11 @@ type MutationRoot {
 		"""
 		The balance of the chain being created. Zero if `None`.
 		"""
-		balance: Amount
+		balance: Amount,
+		"""
+		The account on the new chain credited with the balance. The chain account itself if `None`.
+		"""
+		account: AccountOwner
 	): ChainId!
 	"""
 	Creates a new multi-owner chain.
@@ -1098,6 +1102,10 @@ type MutationRoot {
 		The balance of the chain. Zero if `None`
 		"""
 		balance: Amount,
+		"""
+		The account on the new chain credited with the balance. The chain account itself if `None`.
+		"""
+		account: AccountOwner,
 		"""
 		The duration of the fast round, in milliseconds; default: no timeout
 		"""
@@ -1302,7 +1310,11 @@ Open chain operation metadata.
 """
 type OpenChainOperationMetadata {
 	"""
-	The initial balance credited to the new chain.
+	The account on the new chain credited with the initial balance.
+	"""
+	account: AccountOwner!
+	"""
+	The initial balance credited to `account`.
 	"""
 	balance: Amount!
 	"""

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -243,6 +243,7 @@ mod from {
 
                 Ok(SystemOperation::OpenChain(OpenChainConfig {
                     ownership,
+                    account: open_chain.account,
                     balance: open_chain.balance,
                     application_permissions,
                 }))

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -381,6 +381,12 @@ pub enum ClientCommand {
         #[arg(long = "initial-balance", default_value = "0")]
         balance: Amount,
 
+        /// The account on the new chain credited with the initial balance. Defaults to the
+        /// chain account, which is the only balance that pays fees for blocks the account
+        /// itself does not authenticate.
+        #[arg(long = "balance-account", default_value = "0x00")]
+        account: AccountOwner,
+
         /// Whether to create a super owner for the new chain.
         #[arg(long)]
         super_owner: bool,
@@ -408,6 +414,12 @@ pub enum ClientCommand {
         /// balance.
         #[arg(long = "initial-balance", default_value = "0")]
         balance: Amount,
+
+        /// The account on the new chain credited with the initial balance. Defaults to the
+        /// chain account, which is the only balance that pays fees for blocks the account
+        /// itself does not authenticate.
+        #[arg(long = "balance-account", default_value = "0x00")]
+        account: AccountOwner,
     },
 
     /// Display who owns the chain, and how the owners work together proposing blocks.
@@ -1350,6 +1362,11 @@ pub enum WalletCommand {
         /// Whether this chain should become the default chain.
         #[arg(long)]
         set_default: bool,
+
+        /// Whether to credit the claimed tokens to the new owner's account rather than to the
+        /// chain account. Only blocks authenticated by that owner can then pay fees.
+        #[arg(long)]
+        fund_owner_account: bool,
     },
 
     /// Export the genesis configuration to a JSON file.

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -204,6 +204,7 @@ impl Runnable for Job {
                 chain_id,
                 owner,
                 balance,
+                account,
                 super_owner,
             } => {
                 let new_owner = match owner {
@@ -228,7 +229,12 @@ impl Runnable for Job {
                         let chain_client = chain_client.clone();
                         async move {
                             chain_client
-                                .open_chain(ownership, ApplicationPermissions::default(), balance)
+                                .open_chain(
+                                    ownership,
+                                    ApplicationPermissions::default(),
+                                    account,
+                                    balance,
+                                )
                                 .await
                         }
                     })
@@ -254,6 +260,7 @@ impl Runnable for Job {
             OpenMultiOwnerChain {
                 chain_id,
                 balance,
+                account,
                 ownership_config,
                 application_permissions_config,
             } => {
@@ -277,7 +284,7 @@ impl Runnable for Job {
                         let chain_client = chain_client.clone();
                         async move {
                             chain_client
-                                .open_chain(ownership, application_permissions, balance)
+                                .open_chain(ownership, application_permissions, account, balance)
                                 .await
                         }
                     })
@@ -1801,6 +1808,7 @@ impl Runnable for Job {
             Wallet(WalletCommand::RequestChain {
                 faucet: faucet_url,
                 set_default,
+                fund_owner_account,
             }) => {
                 let start_time = Instant::now();
                 let owner: AccountOwner = keystore.generate_key().await?.into();
@@ -1810,7 +1818,14 @@ impl Runnable for Job {
                      {faucet_url}",
                 );
 
-                let description = cli_wrappers::Faucet::new(faucet_url).claim(&owner).await?;
+                let destination = if fund_owner_account {
+                    owner
+                } else {
+                    AccountOwner::CHAIN
+                };
+                let description = cli_wrappers::Faucet::new(faucet_url)
+                    .claim_to(&owner, &destination)
+                    .await?;
 
                 ensure!(
                     description.config().ownership.is_owner(&owner),

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -444,15 +444,26 @@ where
         #[graphql(desc = "The owner of the new chain.")] owner: AccountOwner,
         #[graphql(desc = "The balance of the chain being created. Zero if `None`.")]
         balance: Option<Amount>,
+        #[graphql(
+            desc = "The account on the new chain credited with the balance. The chain account \
+                    itself if `None`."
+        )]
+        account: Option<AccountOwner>,
     ) -> Result<ChainId, Error> {
         let ownership = ChainOwnership::single(owner);
         let balance = balance.unwrap_or(Amount::ZERO);
+        let account = account.unwrap_or(AccountOwner::CHAIN);
         let description = self
             .apply_client_command(&chain_id, move |client| {
                 let ownership = ownership.clone();
                 async move {
                     let result = client
-                        .open_chain(ownership, ApplicationPermissions::default(), balance)
+                        .open_chain(
+                            ownership,
+                            ApplicationPermissions::default(),
+                            account,
+                            balance,
+                        )
                         .await
                         .map_err(Error::from)
                         .map(|outcome| outcome.map(|(chain_id, _)| chain_id));
@@ -474,6 +485,11 @@ where
         #[graphql(desc = "The weights of the owners")] weights: Option<Vec<u64>>,
         #[graphql(desc = "The number of multi-leader rounds")] multi_leader_rounds: Option<u32>,
         #[graphql(desc = "The balance of the chain. Zero if `None`")] balance: Option<Amount>,
+        #[graphql(
+            desc = "The account on the new chain credited with the balance. The chain account \
+                    itself if `None`."
+        )]
+        account: Option<AccountOwner>,
         #[graphql(desc = "The duration of the fast round, in milliseconds; default: no timeout")]
         fast_round_ms: Option<u64>,
         #[graphql(
@@ -518,13 +534,14 @@ where
         };
         let ownership = ChainOwnership::multiple(owners, multi_leader_rounds, timeout_config);
         let balance = balance.unwrap_or(Amount::ZERO);
+        let account = account.unwrap_or(AccountOwner::CHAIN);
         let description = self
             .apply_client_command(&chain_id, move |client| {
                 let ownership = ownership.clone();
                 let application_permissions = application_permissions.clone().unwrap_or_default();
                 async move {
                     let result = client
-                        .open_chain(ownership, application_permissions, balance)
+                        .open_chain(ownership, application_permissions, account, balance)
                         .await
                         .map_err(Error::from)
                         .map(|outcome| outcome.map(|(chain_id, _)| chain_id));

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -680,7 +680,7 @@ mod tests {
             Amount, ApplicationPermissions, Blob, BlockHeight, ChainDescription, ChainOrigin,
             Epoch, InitialChainConfig, NetworkDescription, Round, Timestamp,
         },
-        identifiers::{BlobId, BlobType, ChainId, EventId, StreamId},
+        identifiers::{AccountOwner, BlobId, BlobType, ChainId, EventId, StreamId},
         ownership::ChainOwnership,
     };
     use linera_chain::{
@@ -723,6 +723,7 @@ mod tests {
             InitialChainConfig {
                 ownership: ChainOwnership::single(AccountPublicKey::test_key(0).into()),
                 epoch: Epoch::ZERO,
+                account: AccountOwner::CHAIN,
                 balance: Amount::ZERO,
                 application_permissions: ApplicationPermissions::default(),
             },


### PR DESCRIPTION
## Motivation

Chain creation could only ever fund one account: `OpenChainConfig { balance }` becomes the new
chain's own balance (`initialize_chain`). Transfers, on the other hand, can target any account. The
faucet inherited that asymmetry — its initial claim funded the chain account, its daily claim the
user's account — and the second half of that is a trap: fees are drawn from the chain balance and
then only from the account of `block.authenticated_owner` (`linera-execution/src/resources.rs`), so
tokens sitting in a user's account cannot pay for blocks signed on their behalf by a delegated
signer. `transfer` is asymmetric the same way (chain → owner needs any owner's signature,
owner → chain needs that exact owner's), so the user cannot move the funds themselves either.

Rather than hard-coding a destination in the faucet, the destination becomes an explicit choice by
the caller, on both paths.

## Proposal

`InitialChainConfig` (and `OpenChainConfig`) name the single account that receives the initial
balance:

```rust
pub struct InitialChainConfig {
    pub ownership: ChainOwnership,
    pub epoch: Epoch,
    /// The account on the new chain credited with `balance`.
    pub account: AccountOwner,
    pub balance: Amount,
    pub application_permissions: ApplicationPermissions,
}
```

`AccountOwner::CHAIN` (`0x00`) funds the chain account, i.e. today's behavior, and is the default at
every layer. `initialize_chain` now credits that account through the existing `credit` helper, so a
non-`CHAIN` destination is funded atomically at creation, without a message.

Threaded through:
- the app-facing syscall — `open-chain: func(chain-ownership, application-permissions, account, balance)`
  in the WIT, `linera-sdk` runtime and test runtime, and the two example contracts that call it;
- `ChainClient::open_chain`, the node service's `openChain` / `openMultiOwnerChain` mutations (new
  optional `account` argument), and `linera open-chain` / `open-multi-owner-chain`
  (`--balance-account`, default `0x00`);
- the faucet: both `claim` and `dailyClaim` take an optional `destination`, defaulting to the chain
  account. This also makes `main`'s default match the fix in #6711. The destination is an
  `AccountOwner`, not an `Account`: the chain stays pinned to the owner's registered chain, so
  one-chain-per-owner rate limiting is unaffected.
- `linera wallet request-chain --fund-owner-account` claims into the owner the command generates.

The faucet client keeps `claim`/`daily_claim` (chain account) and adds `claim_to`/`daily_claim_to`,
which omit the `destination` argument when it is the chain account so a new client still works
against already-deployed faucets.

Also boxes the `ExecutionRequest::OpenChain` payload: the extra field pushed several futures past
`future-size-threshold`, and carrying `Box<OpenChainConfig>` shrinks the request enum below where it
started instead of papering over it at each call site.

## Test Plan

CI, plus:
- `linera-execution`: `test_open_chain` is parameterized over the funded account; the new
  `test_open_chain_funding_an_owner_account` case checks the description records the account, the
  chain balance stays zero, and the owner's account holds the funds after initialization.
- `linera-core`: `test_open_chain_funding_an_owner_account` runs with a non-zero fee policy and
  confirms the sharp edge behaves — a chain funded only in an owner's account has no chain balance
  but that owner can still produce blocks, paying fees from their own account.
- `linera-faucet-server`: `test_claims_honor_the_destination` covers both claim paths with a
  non-default destination, and `test_daily_claim_flow` now asserts the default credits the chain
  account.
- Regenerated the two CI-checked snapshots (`service_schema.graphql`, `CLI.md`).

## Release Plan

- Backporting is not possible: `InitialChainConfig` is part of the chain description, so chain IDs
  change. This needs a new `devnet` deployment and an SDK release, and the WIT change means
  contracts must be recompiled.

## Links

- #6711 — the narrow fix on `testnet_conway`, whose behavior is this change's default.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
