### PR TITLE
Name the task-set methods in the panic policy now that both exist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,13 +119,14 @@ happens next is decided entirely by whoever joins that task. Choose deliberately
 
 * **Prefer crashing over running degraded.** When a task's death silently disables a
   subsystem — a cross-chain message forwarder, a notification fan-out, a chain listener —
-  the process should exit and be restarted rather than keep serving without it. Whoever
-  joins such a task must re-raise its panic rather than discard it.
+  the process should exit and be restarted rather than keep serving without it. Await such
+  tasks with `JoinSetExt::await_all_tasks`, which re-raises the panic.
 
 * **Except for work that is scoped to one request or one chain.** Handling a single RPC,
   or executing a block for a single chain, must not be able to take the process down: a
   panic reachable from user input would otherwise be a way for one crafted message to stop
-  every validator at once. Contain those panics, log them, and let the caller retry.
+  every validator at once. Contain those panics and let the caller retry, using
+  `JoinSetExt::await_all_tasks_logging_panics` for sets of such tasks.
 
 * **Never swallow a panic silently.** `catch_unwind` is acceptable at a boundary where the
   containment is the point, but log at `error!` and say in a comment why continuing is


### PR DESCRIPTION
## Motivation

The **Panics** section added in #6660 states the crash-vs-contain rule without naming the
methods that implement it. That was deliberate at the time: the two `JoinSetExt` methods came
from #6661, so naming them in #6660 would have been a forward reference to an API that did not
exist yet — as ndr-ds pointed out in review.

Both have since landed, so the section can say which method to reach for.

## Proposal

Name `JoinSetExt::await_all_tasks` and `JoinSetExt::await_all_tasks_logging_panics` in the two
bullets that describe when to crash and when to contain. Documentation only.

## Test Plan

Not applicable — no code changes. Both methods exist on `main`
(`linera-core/src/join_set_ext.rs`), so neither reference dangles.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Follow-up to #6660, closing out a review comment there.
- The methods themselves come from #6661.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
