### PR TITLE
[testnet] Expose an owner account's balance to the web client

### DIFF
--- a/web/@linera/client/src/chain/mod.rs
+++ b/web/@linera/client/src/chain/mod.rs
@@ -133,7 +133,11 @@ impl Chain {
     /// If the chain couldn't be established.
     #[wasm_bindgen(js_name = ownerBalance)]
     pub async fn owner_balance(&self, owner: AccountOwner) -> JsResult<String> {
-        Ok(self.chain_client.query_owner_balance(owner).await?.to_string())
+        Ok(self
+            .chain_client
+            .query_owner_balance(owner)
+            .await?
+            .to_string())
     }
 
     /// Gets the identity of the default chain.

--- a/web/@linera/client/src/chain/mod.rs
+++ b/web/@linera/client/src/chain/mod.rs
@@ -121,6 +121,21 @@ impl Chain {
         Ok(self.chain_client.query_balance().await?.to_string())
     }
 
+    /// Gets the balance of `owner`'s account on this chain.
+    ///
+    /// This is the account a cross-chain transfer addressed to
+    /// `Account { chain_id, owner }` credits, and is distinct from
+    /// [`balance`](Self::balance), which reports the chain account. Block fees
+    /// are paid from the chain account plus the account of whoever signed the
+    /// block, so the two together are what a signer can actually spend.
+    ///
+    /// # Errors
+    /// If the chain couldn't be established.
+    #[wasm_bindgen(js_name = ownerBalance)]
+    pub async fn owner_balance(&self, owner: AccountOwner) -> JsResult<String> {
+        Ok(self.chain_client.query_owner_balance(owner).await?.to_string())
+    }
+
     /// Gets the identity of the default chain.
     ///
     /// # Errors

--- a/web/@linera/client/tests/Chain.test.ts
+++ b/web/@linera/client/tests/Chain.test.ts
@@ -19,7 +19,7 @@ async function freshChain() {
   // The chain was just claimed, so pull its state into the local node before the tests
   // read from it (balance, ownership, round are all local reads).
   await chain.synchronize();
-  return { chain, owner };
+  return { chain, chainId, owner };
 }
 
 test("nextRoundInfo reports a well-formed multi-leader round for a fresh chain", async () => {
@@ -61,6 +61,20 @@ test("ownerWeight reads owner weights", async () => {
   // Re-adding an existing owner overwrites its weight.
   await chain.addOwner(owner, { weight: 250 });
   expect(await chain.ownerWeight(owner)).toBe(250);
+}, 150000);
+
+test("ownerBalance reads the owner account, which is not the chain balance", async () => {
+  const { chain, chainId, owner } = await freshChain();
+
+  // The faucet funds the chain account. The owner's account on that same chain
+  // is a different pot, and starts empty.
+  expect(Number(await chain.balance())).toBeGreaterThan(0);
+  expect(Number(await chain.ownerBalance(owner))).toBe(0);
+
+  // A transfer addressed to `{ chain_id, owner }` lands in the owner account,
+  // and only `ownerBalance` can see it.
+  await chain.transfer({ recipient: { chain_id: chainId, owner }, amount: 1 });
+  expect(Number(await chain.ownerBalance(owner))).toBe(1);
 }, 150000);
 
 test("clearPendingProposal is a no-op when nothing is pending", async () => {


### PR DESCRIPTION
## Motivation

`@linera/client` can read the chain account but not an owner's account. `Chain::balance()`
delegates to `query_balance()`, which is hardcoded to `AccountOwner::CHAIN` and ignores the
handle's owner, so `client.chain(id, { owner })` still reports the chain balance. There is
no binding for `query_owner_balance`, even though `linera-core` already compiles it for the
web target.

That matters because those are two different pots and block fees draw on both: fees come out
of `chain_balance` plus the account of whoever signed the block. A web client that can only
see one of them cannot tell what a signer is actually able to spend.

Nor is there a way around it in the browser. The GraphQL resolvers for
`SystemExecutionStateView` — `balance`, `balances { entry(key:) }` — live in
`linera-execution/src/graphql.rs`, which is `#[cfg(with_graphql)]`, and `build.rs` defines
`with_graphql: { not(web) }`. They are not compiled into the web build at all. The query root
that mounts them (`chain(chainId:)`) is in `linera-service/src/node_service.rs`, a binary
crate never built for wasm. So the only way to read an owner balance from JS today is to run
a node service alongside the browser, which defeats the point.

This came out of debugging pm-app users who ran out of gas: the faucet's daily claim credited
`Account { chain_id, owner: <wallet> }` while their blocks were signed by a per-chain
autosigner, so the grants piled up in an account no block could spend from. One chain had
1,700 native tokens stranded that way. The client-side workaround has to guess the size of
the pot with a descending ladder of trial transfers, because it cannot read it — and it
recovers only the largest rung that fits, leaving the rest behind.

## Proposal

Add `ownerBalance(owner)` next to `balance()`, delegating to the existing
`ChainClient::query_owner_balance`:

```rust
#[wasm_bindgen(js_name = ownerBalance)]
pub async fn owner_balance(&self, owner: AccountOwner) -> JsResult<String> {
    Ok(self.chain_client.query_owner_balance(owner).await?.to_string())
}
```

It matches `balance()`'s semantics (staging the pending inbox, same `String` return) and adds
no dependency: `query_owner_balance` is already built for web, and `AccountOwner` already
crosses the wasm boundary as a parameter of `isOwner` and `ownerWeight`.

## Test Plan

- `cargo check --lib --target wasm32-unknown-unknown` and `cargo clippy --lib --target
  wasm32-unknown-unknown` from `web/@linera/client` (so `web/.cargo/config.toml` supplies
  `--cfg=web_sys_unstable_apis`): clean, no findings in `chain/mod.rs`.
- Adds a `Chain.test.ts` case, following the existing faucet-backed pattern, that pins the
  distinction the binding exists for: a fresh faucet chain has a funded chain account and an
  empty owner account, and a transfer addressed to `{ chain_id, owner }` is visible through
  `ownerBalance` and not through `balance`. The `freshChain()` helper now also returns
  `chainId`; the other tests are unaffected.

## Release Plan

- These changes should be released in a new SDK.

## Links

- Same change on `main`: #6717
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
