### PR TITLE
Raise CI timeouts for ethereum-tests and linera-sdk-tests-fixtures

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -175,7 +175,7 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v6.0.2
@@ -241,7 +241,7 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
     - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Motivation

Two jobs in the `Rust` workflow have intermittently been reported as `cancelled` on `main` even though every one of their steps is green. That appearance is exactly what a `timeout-minutes` breach looks like: GitHub gives the job conclusion `cancelled` (not `failure`), and every step that completed before the wall keeps its `success` status. The actual verdict shows up only in the check-run annotations:

```
$ gh api repos/linera-io/linera-protocol/check-runs/95560919217/annotations \
    --jq '.[] | select(.annotation_level=="failure") | .message'
The job has exceeded the maximum execution time of 30m0s
```

Two occurrences so far:

| Run | Job | Limit | Actual |
| --- | --- | --- | --- |
| [32086740945](https://github.com/linera-io/linera-protocol/actions/runs/32086740945) | `ethereum-tests` | 30m | 31m26s |
| [31766254527](https://github.com/linera-io/linera-protocol/actions/runs/31766254527) | `linera-sdk-tests-fixtures` | 10m | 10m33s |

The root cause is calibration, not a flaky test. Both jobs are provisioned at ~95% of their timeout budget at p90, so a breach is the expected tail rather than a rare accident. Measured across the last 100 completed `Rust` runs, successful jobs only:

```
JOB                                    LIMIT      p50      p90      max   p90/LIMIT
ethereum-tests                           30m    27.7m   28.77m   29.78m        96%
linera-sdk-tests-fixtures                10m     8.1m    9.50m    9.75m        95%
lint-cargo-clippy                        20m    13.8m   14.63m   14.90m        73%   <- next worst
```

The slowest *successful* `ethereum-tests` run cleared the wall by 13 seconds, and ~20% of runs finish within 90s of it.

Two aggravating factors worth recording:

- **`timeout-minutes` also covers post/cleanup steps.** In run 32086740945 the tests themselves all passed, finishing at 29m03s; the job then blew the 30m wall while the `setup-rust-toolchain` post cache-save ran for 137s. Across the sample that post step is p50 29s, p90 40s, max 170s, so the effective budget for real work is the limit minus a variable multi-minute tail.
- **On PR runs a timeout-cancel is indistinguishable from a `cancel-in-progress` concurrency cancel**, which is why this was only noticed on `main`. For `push` events the concurrency group expression falls through to `github.run_id` (unique per run), so push runs can never be superseded — a cancelled push run is always something else. I checked all 242 cancelled jobs across the 24 cancelled PR runs in the sample: every one was a genuine concurrency cancel, none were timeouts.

## Proposal

Raise the two limits to roughly 1.5x the observed p90, so they act as runaway guards rather than performance budgets:

- `ethereum-tests`: 30m → 45m
- `linera-sdk-tests-fixtures`: 10m → 15m

No other job is changed. This does not make CI any slower: a timeout only fires on the pathological tail, so the new values cost nothing on healthy runs and simply stop cancelling runs whose tests have actually passed.

## Test Plan

**This PR's own CI deliberately does not exercise the two jobs.** The `changed-files` gate uses `predicate-quantifier: 'every'` with `'!.github/workflows/**'` among its filters, so a workflow-only PR resolves `should-run` to `false` and every gated job is skipped. Confirmed on this PR: `ethereum-tests` and `linera-sdk-tests-fixtures` both report `skipping`. That is intended behaviour, as the filter's own comment says:

> Workflow-only PRs don't need heavy code tests; merge to main validates the workflow itself by running it for real.

So verification here is necessarily static plus post-merge:

1. The workflow still parses and carries the intended values:

```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/rust.yml')); \
    print(len(d['jobs']), d['jobs']['ethereum-tests']['timeout-minutes'], \
          d['jobs']['linera-sdk-tests-fixtures']['timeout-minutes'])"
21 45 15
```

2. The diff is two value-only changes on existing keys; no other job is touched.

3. Post-merge, the first `main` push runs both jobs for real. Confirm no `cancelled` conclusion and check the headroom:

```bash
gh api "repos/linera-io/linera-protocol/actions/runs/<run_id>/jobs?per_page=100" \
  --jq '.jobs[] | select(.name=="ethereum-tests" or .name=="linera-sdk-tests-fixtures")
        | "\(.name) \(.conclusion) \((.completed_at|fromdateiso8601)-(.started_at|fromdateiso8601))s"'
```

The measurements in the Motivation are reproducible with the public Actions API — no repo checkout needed:

```bash
# 1. Collect the last 100 completed Rust runs
gh api "repos/linera-io/linera-protocol/actions/workflows/rust.yml/runs?per_page=100&status=completed" \
  --jq '.workflow_runs[] | "\(.id) \(.head_branch) \(.event) \(.conclusion)"' > runs.txt

# 2. Per-job durations for successful jobs
: > alljobs.txt
while read rid branch event concl; do
  gh api "repos/linera-io/linera-protocol/actions/runs/$rid/jobs?per_page=100" \
    --jq '.jobs[] | select(.conclusion=="success") | "\(.name) \((.completed_at|fromdateiso8601)-(.started_at|fromdateiso8601))"' >> alljobs.txt
done < runs.txt

# 3. p90 vs configured limit, per job
awk '/^  [a-zA-Z0-9_-]+:[[:space:]]*$/ {gsub(/[: ]/,"",$0); job=$0} /^    timeout-minutes:/ {print job, $2}' \
  .github/workflows/rust.yml > limits.txt
while read job lim; do
  grep "^$job " alljobs.txt | awk '{print $2}' | sort -n \
    | awk -v j="$job" -v l="$lim" '{a[NR]=$1} END {if(NR>=5) printf "%-44s %4dm p90=%6.2fm  %3.0f%%\n", j, l, a[int(NR*0.9)]/60, 100*a[int(NR*0.9)]/(l*60)}'
done < limits.txt | sort -k4 -rn
```

To confirm a given cancelled job was a timeout rather than a cancel, read its annotations:

```bash
gh api repos/linera-io/linera-protocol/check-runs/<job_id>/annotations \
  --jq '.[] | select(.annotation_level=="failure") | .message'
```

Workflow file still parses after the edit:

```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/rust.yml')); print(len(d['jobs']))"
21
```

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

Follow-ups this PR deliberately does **not** do, to keep the change reviewable:

- `ethereum-tests` is the real outlier at ~28 minutes. Splitting it would be the durable fix rather than a bigger budget: in run 32086740945 the `Run Ethereum tests` step took 16m48s and `Run REVM test` took 8m36s, so as two jobs they would run in parallel and roughly halve the wall-clock instead of being stacked under one limit.
- `lint-cargo-machete` is at 68% of its limit by ratio, but that is a 2m limit with a 99s max observed — only ~21s of absolute headroom. It has not breached in the sample, so I left it alone, but it is the next candidate if it starts flapping.

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
