### PR TITLE
[testnet_conway] Raise CI timeouts for ethereum-tests, linera-sdk-tests-fixtures and check-outdated-cli-md

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,7 +206,7 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v6.0.2
@@ -255,7 +255,7 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v6.0.2
@@ -297,7 +297,7 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
     - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Motivation

Backport of #6718 to `testnet_conway`, plus one conway-specific fix that the cherry-pick would not have carried.

A job that exceeds `timeout-minutes` is reported by GitHub with conclusion `cancelled` (not `failure`), and every step that finished before the wall keeps its `success` status — so the failure mode looks like "CI succeeded but was cancelled". The verdict is only visible in the check-run annotations:

```
gh api repos/linera-io/linera-protocol/check-runs/<job_id>/annotations \
  --jq '.[] | select(.annotation_level=="failure") | .message'
```

`testnet_conway` still carries the pre-#6718 limits, and I measured this branch's own last 100 `Rust` runs rather than assuming `main`'s numbers transfer. Successful jobs only:

```
JOB                          LIMIT     p50      p90      max   p90/LIMIT
ethereum-tests                 30m   27.5m   28.42m   28.93m       95%
check-outdated-cli-md          10m    9.1m    9.43m    9.82m       94%
linera-sdk-tests-fixtures      10m    8.0m    8.28m    8.80m       83%
lint-cargo-clippy              20m   14.8m   15.70m   18.03m       78%
```

Two things worth calling out:

- **`ethereum-tests` has the same exposure here as on `main`** — 95% of budget at p90, with 64 seconds of headroom at max.
- **`check-outdated-cli-md` is conway-only drift.** `main` already runs this job at 15m; conway is still at 10m and sits at 94% of budget with **11 seconds** of observed headroom — the thinnest margin on either branch. A literal cherry-pick of #6718 would have left it untouched, which is why it is included here.

`timeout-minutes` also covers post/cleanup steps, so the effective budget for real work is the limit minus a variable cache-save tail (measured on `main` at p50 29s, p90 40s, max 170s).

## Proposal

Raise three limits to roughly 1.5x observed p90, so they act as runaway guards rather than performance budgets:

- `ethereum-tests`: 30m → 45m (matches `main` after #6718)
- `linera-sdk-tests-fixtures`: 10m → 15m (matches `main` after #6718)
- `check-outdated-cli-md`: 10m → 15m (aligns conway with the value `main` already uses)

This costs nothing on healthy runs — a timeout only fires on the pathological tail.

## Deliberately NOT changed

`testnet_conway` has had three genuine timeout breaches, on jobs this PR leaves alone:

```
default-features-and-witty-integration-test   exceeded 40m0s   (p90 21.38m = 53% of budget)
storage-service-tests                         exceeded 40m0s   (p90 25.92m = 65% of budget)
bridge-tests                                  exceeded 25m0s   (p90 14.78m = 59% of budget)
```

These are the opposite of a calibration problem. A job whose p90 sits at 53% of its limit does not drift past it — it hangs. Those timeouts worked correctly and caught a runaway, so raising them would only delay detection of a real hang. They warrant an investigation, not a bigger budget.

The distinction this PR relies on: `ethereum-tests` overran a limit it normally consumes 95% of (calibration), while `storage-service-tests` overran one it normally consumes 65% of (hang). Same symptom, opposite fixes.

## Test Plan

**This PR's own CI does not exercise the affected jobs, by design.** The `changed-files` gate on this branch uses `predicate-quantifier: 'every'` with `'!.github/workflows/**'`, so a commit touching only `.github/workflows/**` resolves `should-run` to `false` and every gated job skips. This applies to the `push` event too, so the merge run will skip them as well — the change is first exercised by the next merge to `testnet_conway` that also touches code.

Static verification:

```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/rust.yml')); j=d['jobs']; \
    print(len(j), j['ethereum-tests']['timeout-minutes'], \
          j['linera-sdk-tests-fixtures']['timeout-minutes'], \
          j['check-outdated-cli-md']['timeout-minutes'])"
23 45 15 15
```

The diff is three value-only changes on existing keys; no other job is touched.

Post-merge, on the first `testnet_conway` push that touches code:

```bash
gh api "repos/linera-io/linera-protocol/actions/runs/<run_id>/jobs?per_page=100" \
  --jq '.jobs[] | select(.name=="ethereum-tests" or .name=="check-outdated-cli-md" or .name=="linera-sdk-tests-fixtures")
        | "\(.name) \(.conclusion) \((.completed_at|fromdateiso8601)-(.started_at|fromdateiso8601))s"'
```

The branch measurements above are reproducible against the public Actions API:

```bash
gh api "repos/linera-io/linera-protocol/actions/workflows/rust.yml/runs?branch=testnet_conway&per_page=100&status=completed" \
  --jq '.workflow_runs[] | "\(.id)"' > runs.txt
: > jobs.txt
while read rid; do
  gh api "repos/linera-io/linera-protocol/actions/runs/$rid/jobs?per_page=100" \
    --jq '.jobs[] | select(.conclusion=="success") | "\(.name) \((.completed_at|fromdateiso8601)-(.started_at|fromdateiso8601))"' >> jobs.txt
done < runs.txt
```

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

This PR targets `testnet_conway` directly as the backport of #6718; no further propagation is needed. The other `devnet_*` / `testnet_*` branches are inactive (next-newest commit is 2026-06-24, devnets are ~1 year stale), so they are not backport targets.

## Links

- Forward-port on `main`: #6718
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
