### PR TITLE
[testnet_conway] Skip bridge-check for workflow-only changes

### DIFF
--- a/.github/workflows/bridge-check.yml
+++ b/.github/workflows/bridge-check.yml
@@ -27,7 +27,33 @@ permissions:
   contents: read
 
 jobs:
+  # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
+  changed-files:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.files-changed.outputs.paths }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Filter paths
+        uses: dorny/paths-filter@v4.0.1
+        id: files-changed
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            paths:
+              - '!docker/**'
+              - '!docker_scylla/**'
+              - '!configuration/**'
+              - '!CONTRIBUTING.md'
+              - '!INSTALL.md'
+              - '!docs/**'
+              - '!mdbook/**'
+              - '!.github/workflows/**'
   bridge-check:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## Motivation

On `testnet_conway`, a pull request that touches **only** `.github/workflows/**` still runs the full `Bridge check` workflow: five `cargo check` invocations, including two `wasm32-unknown-unknown` targets and a separate workspace, on a 30-minute budget.

Observed on #6719, a three-line change to timeout values in `rust.yml`:

```
bridge-check   in_progress   https://github.com/linera-io/linera-protocol/actions/runs/32154573260
  5 cargo check linera-bridge (default)          completed/success
  6 cargo check linera-bridge (relay)            in_progress
  7 cargo check evm-bridge contract (wasm32)     pending
  8 cargo check wrapped-fungible (wasm32)        pending
  9 cargo check bridge e2e (separate workspace)  pending
```

This is branch drift, not a new regression. `main`'s copy of `bridge-check.yml` already carries the `changed-files` gate and correctly **skipped** this job on the equivalent `main` PR (#6718); conway's copy never received it. Conway's `bridge-check.yml` has no `changed-files` job at all — only the native `paths-ignore` list (`docs/**`, `mdbook/**`, `kubernetes/**`, `docker/dashboards/**`), which does not cover `.github/workflows/**`.

Extending that `paths-ignore` list is **not** the right fix, for the reason `main` already documents in the same file:

> paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.

Conway's `bridge-check.yml` has a `merge_group:` trigger too, so it needs the same custom filter `main` uses.

## Proposal

Port `main`'s `changed-files` gate to conway's `bridge-check.yml`:

- add the `changed-files` job using `dorny/paths-filter` with `predicate-quantifier: 'every'`
- add `needs: changed-files` and `if: needs.changed-files.outputs.should-run == 'true'` to `bridge-check`

The filter list matches **conway's own `rust.yml`** rather than `main`'s, so the two workflows on this branch agree with each other (conway's list includes `docker_scylla/**`, which `main`'s does not).

Nothing else changes: the `bridge-check` job keeps its 30-minute timeout and all 8 steps.

## Scope

Deliberately narrow. Conway also has `indexer.yml` and `lint-check-all-features.yml` ungated where `main` gates them, but neither triggered on the workflow-only PR that surfaced this, so neither is currently wasting CI. They can be aligned separately if they ever start firing.

## Test Plan

Static verification of the edited workflow:

```
$ python3 -c "
import yaml
j = yaml.safe_load(open('.github/workflows/bridge-check.yml'))['jobs']
print(list(j))
print(j['bridge-check'].get('needs'), '|', j['bridge-check'].get('if'))
print('.github/workflows/** in filter:', '.github/workflows/**' in j['changed-files']['steps'][1]['with']['filters'])
print('timeout:', j['bridge-check']['timeout-minutes'], 'steps:', len(j['bridge-check']['steps']))"
['changed-files', 'bridge-check']
changed-files | needs.changed-files.outputs.should-run == 'true'
.github/workflows/** in filter: True
timeout: 30 steps: 8
```

Behavioural check, directly on this PR: this PR itself touches only `.github/workflows/**`, so it is its own test case. With the gate in place, `bridge-check` should report `skipping` here, where it ran a full compile on #6719. That is the one useful property of a workflow-only change to a gating workflow — unlike a timeout change, this one *is* observable on its own PR.

To confirm the gate does not over-skip, the next conway PR that touches Rust code should show `bridge-check` running normally.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

Targets `testnet_conway` only; `main` already has this gate.

## Links

- Surfaced by: #6719
- Equivalent `main` behaviour: #6718 (where `bridge-check` correctly skipped)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
