### PR TITLE
Stop wrapping the ScyllaDB store in ValueSplittingDatabase

### DIFF
--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -70,10 +70,6 @@ const MAX_OPERATION_SIZE: usize = 16 * 1024 * 1024;
 
 /// A batch is issued as one unlogged batch whose statements all share the partition key,
 /// so ScyllaDB merges them into a single mutation weighed against `MAX_OPERATION_SIZE`.
-/// The batch size limits below only account for the keys and the values, while each
-/// statement additionally carries its clustering key framing, cell metadata and write
-/// timestamp. Reserving this much per statement keeps a batch of up to `MAX_BATCH_SIZE`
-/// statements under the limit.
 const BATCH_STATEMENT_OVERHEAD: usize = 256;
 
 /// So, we set up the maximal size of 16 MiB minus 10 KiB for the keys and minus the

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -55,7 +55,6 @@ use crate::{
         DirectWritableKeyValueStore, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore,
         WithError,
     },
-    value_splitting::{ValueSplittingDatabase, ValueSplittingError},
 };
 
 /// Fundamental constant in ScyllaDB: The maximum size of a multi keys query
@@ -1301,26 +1300,25 @@ impl TestKeyValueDatabase for JournalingKeyValueDatabase<ScyllaDbDatabaseInterna
     }
 }
 
-/// The `ScyllaDbDatabase` composed type with metrics
+/// The `ScyllaDbDatabase` composed type with metrics.
+///
+/// Values are stored as-is, so a single value must not exceed
+/// `VISIBLE_MAX_VALUE_SIZE`.
 #[cfg(with_metrics)]
 pub type ScyllaDbDatabase = MeteredDatabase<
-    LruCachingDatabase<
-        MeteredDatabase<
-            ValueSplittingDatabase<
-                MeteredDatabase<JournalingKeyValueDatabase<ScyllaDbDatabaseInternal>>,
-            >,
-        >,
-    >,
+    LruCachingDatabase<MeteredDatabase<JournalingKeyValueDatabase<ScyllaDbDatabaseInternal>>>,
 >;
 
-/// The `ScyllaDbDatabase` composed type
+/// The `ScyllaDbDatabase` composed type.
+///
+/// Values are stored as-is, so a single value must not exceed
+/// `VISIBLE_MAX_VALUE_SIZE`.
 #[cfg(not(with_metrics))]
-pub type ScyllaDbDatabase = LruCachingDatabase<
-    ValueSplittingDatabase<JournalingKeyValueDatabase<ScyllaDbDatabaseInternal>>,
->;
+pub type ScyllaDbDatabase =
+    LruCachingDatabase<JournalingKeyValueDatabase<ScyllaDbDatabaseInternal>>;
 
 /// The `ScyllaDbStoreConfig` input type
 pub type ScyllaDbStoreConfig = LruCachingConfig<ScyllaDbStoreInternalConfig>;
 
 /// The combined error type for the `ScyllaDbDatabase`.
-pub type ScyllaDbStoreError = ValueSplittingError<JournalingError<ScyllaDbStoreInternalError>>;
+pub type ScyllaDbStoreError = JournalingError<ScyllaDbStoreInternalError>;

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -1313,19 +1313,13 @@ impl TestKeyValueDatabase for JournalingKeyValueDatabase<ScyllaDbDatabaseInterna
     }
 }
 
-/// The `ScyllaDbDatabase` composed type with metrics.
-///
-/// Values are stored as-is, so a single value must not exceed
-/// `VISIBLE_MAX_VALUE_SIZE`.
+/// The `ScyllaDbDatabase` composed type with metrics
 #[cfg(with_metrics)]
 pub type ScyllaDbDatabase = MeteredDatabase<
     LruCachingDatabase<MeteredDatabase<JournalingKeyValueDatabase<ScyllaDbDatabaseInternal>>>,
 >;
 
-/// The `ScyllaDbDatabase` composed type.
-///
-/// Values are stored as-is, so a single value must not exceed
-/// `VISIBLE_MAX_VALUE_SIZE`.
+/// The `ScyllaDbDatabase` composed type
 #[cfg(not(with_metrics))]
 pub type ScyllaDbDatabase =
     LruCachingDatabase<JournalingKeyValueDatabase<ScyllaDbDatabaseInternal>>;

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -91,8 +91,8 @@ sa::const_assert!(
 /// The `RAW_MAX_VALUE_SIZE` is the maximum size on the ScyllaDB storage.
 /// However, the value being written can also be the serialization of a `SimpleUnorderedBatch`
 /// Therefore the actual `MAX_VALUE_SIZE` is lower.
-/// At the maximum the key size is 1024 bytes (see below) and we pack just one entry.
-/// So if the key has 1024 bytes this gets us the inequality
+/// At the maximum the key size is `MAX_KEY_SIZE` bytes and we pack just one entry.
+/// So if the key has 10240 bytes this gets us the inequality
 /// `1 + 1 + 1 + serialized_size(MAX_KEY_SIZE)? + serialized_size(x)? <= RAW_MAX_VALUE_SIZE`.
 /// and so this simplifies to `1 + 1 + 1 + (2 + 10240) + (4 + x) <= RAW_MAX_VALUE_SIZE`
 /// Note on the above formula:
@@ -100,7 +100,7 @@ sa::const_assert!(
 /// * We write `1 + 1 + 1`  because the `UnorderedBatch` has three entries.
 ///
 /// This gets us to a maximal value of 15476727.
-const VISIBLE_MAX_VALUE_SIZE: usize = RAW_MAX_VALUE_SIZE
+const MAX_VALUE_SIZE: usize = RAW_MAX_VALUE_SIZE
     - MAX_KEY_SIZE
     - get_uleb128_size(RAW_MAX_VALUE_SIZE)
     - get_uleb128_size(MAX_KEY_SIZE)
@@ -923,7 +923,7 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
 impl DirectWritableKeyValueStore for ScyllaDbStoreInternal {
     const MAX_BATCH_SIZE: usize = MAX_BATCH_SIZE;
     const MAX_BATCH_TOTAL_SIZE: usize = MAX_BATCH_TOTAL_SIZE;
-    const MAX_VALUE_SIZE: usize = VISIBLE_MAX_VALUE_SIZE;
+    const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
 
     // ScyllaDB cannot take a `crate::batch::Batch` directly. Indeed, if a delete is
     // followed by a write, then the delete takes priority. See the sentence "The first

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -40,6 +40,7 @@ use scylla::{
     value::CqlValue,
 };
 use serde::{Deserialize, Serialize};
+use static_assertions as sa;
 use thiserror::Error;
 
 #[cfg(with_metrics)]
@@ -65,12 +66,34 @@ const MAX_MULTI_KEYS: usize = 100 - 1;
 /// https://www.scylladb.com/2019/03/27/best-practices-for-scylla-applications/
 /// "There is a hard limit at 16 MiB, and nothing bigger than that can arrive at once
 ///  at the database at any particular time"
-/// So, we set up the maximal size of 16 MiB - 10 KiB for the values and 10 KiB for the keys
-/// We also arbitrarily decrease the size by 4000 bytes because an amount of size is
-/// taken internally by the database.
-const RAW_MAX_VALUE_SIZE: usize = 16 * 1024 * 1024 - 10 * 1024 - 4000;
+const MAX_OPERATION_SIZE: usize = 16 * 1024 * 1024;
+
+/// The constant 14000 is an empirical constant that was found to be necessary
+/// to make the ScyllaDB system work. We have not been able to find this or
+/// a similar constant in the source code or the documentation.
+/// An experimental approach gets us that 14796 is the latest value that is
+/// correct.
+const MAX_BATCH_SIZE: usize = 5000;
+
+/// A batch is issued as one unlogged batch whose statements all share the partition key,
+/// so ScyllaDB merges them into a single mutation weighed against `MAX_OPERATION_SIZE`.
+/// The batch size limits below only account for the keys and the values, while each
+/// statement additionally carries its clustering key framing, cell metadata and write
+/// timestamp. Reserving this much per statement keeps a batch of up to `MAX_BATCH_SIZE`
+/// statements under the limit.
+const BATCH_STATEMENT_OVERHEAD: usize = 256;
+
+/// So, we set up the maximal size of 16 MiB minus 10 KiB for the keys and minus the
+/// per-statement reserve for the values.
+const RAW_MAX_VALUE_SIZE: usize =
+    MAX_OPERATION_SIZE - MAX_KEY_SIZE - MAX_BATCH_SIZE * BATCH_STATEMENT_OVERHEAD;
 const MAX_KEY_SIZE: usize = 10 * 1024;
 const MAX_BATCH_TOTAL_SIZE: usize = RAW_MAX_VALUE_SIZE + MAX_KEY_SIZE;
+
+// A full batch and its per-statement reserve must fit in a single ScyllaDB operation.
+sa::const_assert!(
+    MAX_BATCH_TOTAL_SIZE + MAX_BATCH_SIZE * BATCH_STATEMENT_OVERHEAD <= MAX_OPERATION_SIZE
+);
 
 /// The `RAW_MAX_VALUE_SIZE` is the maximum size on the ScyllaDB storage.
 /// However, the value being written can also be the serialization of a `SimpleUnorderedBatch`
@@ -83,19 +106,12 @@ const MAX_BATCH_TOTAL_SIZE: usize = RAW_MAX_VALUE_SIZE + MAX_KEY_SIZE;
 /// * We write 4 because `get_uleb128_size(RAW_MAX_VALUE_SIZE) = 4)`
 /// * We write `1 + 1 + 1`  because the `UnorderedBatch` has three entries.
 ///
-/// This gets us to a maximal value of 16752727.
+/// This gets us to a maximal value of 15476727.
 const VISIBLE_MAX_VALUE_SIZE: usize = RAW_MAX_VALUE_SIZE
     - MAX_KEY_SIZE
     - get_uleb128_size(RAW_MAX_VALUE_SIZE)
     - get_uleb128_size(MAX_KEY_SIZE)
     - 3;
-
-/// The constant 14000 is an empirical constant that was found to be necessary
-/// to make the ScyllaDB system work. We have not been able to find this or
-/// a similar constant in the source code or the documentation.
-/// An experimental approach gets us that 14796 is the latest value that is
-/// correct.
-const MAX_BATCH_SIZE: usize = 5000;
 
 /// The keyspace to use for the ScyllaDB database.
 const KEYSPACE: &str = "kv";

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -68,13 +68,6 @@ const MAX_MULTI_KEYS: usize = 100 - 1;
 ///  at the database at any particular time"
 const MAX_OPERATION_SIZE: usize = 16 * 1024 * 1024;
 
-/// The constant 14000 is an empirical constant that was found to be necessary
-/// to make the ScyllaDB system work. We have not been able to find this or
-/// a similar constant in the source code or the documentation.
-/// An experimental approach gets us that 14796 is the latest value that is
-/// correct.
-const MAX_BATCH_SIZE: usize = 5000;
-
 /// A batch is issued as one unlogged batch whose statements all share the partition key,
 /// so ScyllaDB merges them into a single mutation weighed against `MAX_OPERATION_SIZE`.
 /// The batch size limits below only account for the keys and the values, while each
@@ -112,6 +105,10 @@ const VISIBLE_MAX_VALUE_SIZE: usize = RAW_MAX_VALUE_SIZE
     - get_uleb128_size(RAW_MAX_VALUE_SIZE)
     - get_uleb128_size(MAX_KEY_SIZE)
     - 3;
+
+/// The maximal number of statements in a single batch. ScyllaDB rejects batches of more
+/// than 14796 statements; this stays well below that.
+const MAX_BATCH_SIZE: usize = 5000;
 
 /// The keyspace to use for the ScyllaDB database.
 const KEYSPACE: &str = "kv";


### PR DESCRIPTION
## Motivation

`ScyllaDbDatabase` wraps its store in `ValueSplittingDatabase`, which splits values larger
than `MAX_VALUE_SIZE` across several keys. It never engages: `ResourceControlPolicy::testnet()`
caps every quantity that can become a single stored value far below that threshold (the
largest, `maximum_block_proposal_size`, is 13 MB against 15,476,727), and the big
`ChainStateView` aggregates are stored per-entry rather than as one blob.

Confirmed on testnet-conway (2026-08-18): `linera_value_split_count` — a `LazyLock` counter
registered on first use (#5891, #6703) — does not exist as a metric name anywhere over the
full ~3-week Prometheus retention, while `linera_journal_fastpath_count` from the same PR is
present on all 32 shard series. Loki has no `"Splitting large value"` hit in 30 days.

Meanwhile every operation pays for it: 4 bytes on every key, a 4-byte prefix plus a full copy
of every value read (`value[4..].to_vec()`), and reassembly bookkeeping in both prefix scans.

## Proposal

Drop the wrapper:

```
before: [Metered] LruCaching [Metered] ValueSplitting [Metered] Journaling ScyllaDbInternal
after:  [Metered] LruCaching [Metered] Journaling ScyllaDbInternal
```

and simplify `ScyllaDbStoreError` to `JournalingError<ScyllaDbStoreInternalError>`.
`ValueSplittingDatabase` itself stays, still used by RocksDB until #6724.

**A second commit fixes a pre-existing sizing bug this exposes.** Every statement in a batch
shares the partition key, so ScyllaDB coalesces the batch into a single mutation weighed
against its 16 MiB limit. `write_journal` packs a transaction until one more operation would
exceed `MAX_BATCH_TOTAL_SIZE` (`16 MiB - 4000`), so every large journaled write lands ~4 KB
below the hard limit, with that cushion absorbing all per-statement overhead that
`transaction_size += block_size + key_len` never counts. Shrinking entries by 8 bytes fits 32
statements where 30 fit before, and `scylla_db_tombstone_triggering_test` went red twice while
`main` and #6724 stayed green. The reserve is now sized by statement count:

```rust
const RAW_MAX_VALUE_SIZE: usize =
    MAX_OPERATION_SIZE - MAX_KEY_SIZE - MAX_BATCH_SIZE * BATCH_STATEMENT_OVERHEAD;
```

with a `const_assert!` pinning the invariant. This costs ~7.6% of the maximum atomic batch
(16,773,216 to 15,497,216). The bug is present on `main` and `testnet_conway` today but is
latent — `linera_journal_slowpath_count` is absent fleet-wide, so the journaling slow path has
never executed in production — so I have not marked it for backport. It splits into its own PR
cleanly if you would rather review it separately.

The remaining commits are tidy-ups in the same block: `VISIBLE_MAX_VALUE_SIZE` is renamed to
`MAX_VALUE_SIZE` (what `rocks_db.rs` already calls it), and two stale comments are corrected —
a `MAX_BATCH_SIZE` of 14000 that no longer exists, and a key size of 1024 contradicting the
formula beneath it.

### Consequences

- **Storage format changes.** `main` is not deployed, so no migration path is provided.
- **`MAX_VALUE_SIZE` is now real** (15,476,727) instead of `usize::MAX`; a larger value now
  fails with `ValueTooLong` rather than being silently split. `MAX_KEY_SIZE` widens back to 10240.
- **`ScyllaDbStoreError` loses** the `MissingSegment` / `NoCountAvailable` / `TooShortKey`
  variants. `must_reload_view` is unchanged, and the one downstream user,
  `linera_indexer::common::IndexerError`, converts via `#[from]`.
- **One metric family is renamed**, since metering derives names from the wrapper chain:
  `linera_lru_caching_value_splitting_journaling_scylladb_internal_*` becomes
  `linera_lru_caching_journaling_scylladb_internal_*`. The inner
  `linera_journaling_scylladb_internal_*` family is unchanged.

## Test Plan

CI: `linera-views/**` triggers `.github/workflows/scylladb.yml`, which runs the suite against a
real `scylladb/scylla:6.1`. `scylla_db_tombstone_triggering_test` and
`test_scylla_db_big_write_read` both pass.

Locally: `cargo clippy --locked --all-targets --all-features --workspace`,
`cargo clippy --locked --no-default-features`,
`cargo clippy -p linera-indexer --features scylladb --all-targets -- -D warnings`,
`cargo test -p linera-views --features metrics`, and nightly `cargo fmt --check`.

Note that CI passing shows the 256-byte reserve is sufficient, not exact: the true
per-statement overhead lies above the ~126 B that failed and at or below 256 B.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6724 — the same removal for the RocksDB stack.
- #5891 added the `value_split_count` counter; #6703 explains why an absent metric means the
  code path never executed.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
