### PR TITLE
Stop wrapping the RocksDB store in ValueSplittingDatabase

### DIFF
--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -40,7 +40,6 @@ use crate::{
         KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore, WithError,
         WritableKeyValueStore,
     },
-    value_splitting::{ValueSplittingDatabase, ValueSplittingError},
 };
 
 /// The prefixes being used in the system
@@ -1097,21 +1096,22 @@ impl KeyValueStoreError for RocksDbStoreInternalError {
 }
 
 /// The composed error type for the `RocksDbStore`
-pub type RocksDbStoreError = ValueSplittingError<RocksDbStoreInternalError>;
+pub type RocksDbStoreError = RocksDbStoreInternalError;
 
 /// The composed config type for the `RocksDbStore`
 pub type RocksDbStoreConfig = LruCachingConfig<RocksDbStoreInternalConfig>;
 
-/// The `RocksDbDatabase` composed type with metrics
+/// The `RocksDbDatabase` composed type with metrics.
+///
+/// Values are stored as-is, so a single value must not exceed `MAX_VALUE_SIZE`.
 #[cfg(with_metrics)]
-pub type RocksDbDatabase = MeteredDatabase<
-    LruCachingDatabase<
-        MeteredDatabase<ValueSplittingDatabase<MeteredDatabase<RocksDbDatabaseInternal>>>,
-    >,
->;
-/// The `RocksDbDatabase` composed type
+pub type RocksDbDatabase =
+    MeteredDatabase<LruCachingDatabase<MeteredDatabase<RocksDbDatabaseInternal>>>;
+/// The `RocksDbDatabase` composed type.
+///
+/// Values are stored as-is, so a single value must not exceed `MAX_VALUE_SIZE`.
 #[cfg(not(with_metrics))]
-pub type RocksDbDatabase = LruCachingDatabase<ValueSplittingDatabase<RocksDbDatabaseInternal>>;
+pub type RocksDbDatabase = LruCachingDatabase<RocksDbDatabaseInternal>;
 
 #[cfg(with_testing)]
 impl crate::backends::DatabaseBackup for RocksDbDatabaseInternal {

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -1101,15 +1101,11 @@ pub type RocksDbStoreError = RocksDbStoreInternalError;
 /// The composed config type for the `RocksDbStore`
 pub type RocksDbStoreConfig = LruCachingConfig<RocksDbStoreInternalConfig>;
 
-/// The `RocksDbDatabase` composed type with metrics.
-///
-/// Values are stored as-is, so a single value must not exceed `MAX_VALUE_SIZE`.
+/// The `RocksDbDatabase` composed type with metrics
 #[cfg(with_metrics)]
 pub type RocksDbDatabase =
     MeteredDatabase<LruCachingDatabase<MeteredDatabase<RocksDbDatabaseInternal>>>;
-/// The `RocksDbDatabase` composed type.
-///
-/// Values are stored as-is, so a single value must not exceed `MAX_VALUE_SIZE`.
+/// The `RocksDbDatabase` composed type
 #[cfg(not(with_metrics))]
 pub type RocksDbDatabase = LruCachingDatabase<RocksDbDatabaseInternal>;
 


### PR DESCRIPTION
## Motivation

Companion to #6723, which removes `ValueSplittingDatabase` from the ScyllaDB stack. The
same wrapper sits in the RocksDB stack, and there the case for removing it is stronger.

`ValueSplittingDatabase` stores values larger than the backend's `MAX_VALUE_SIZE` by
chopping them into segments across several keys. For RocksDB that threshold is
`MAX_VALUE_SIZE = 3 * 1024 * 1024 * 1024 - 400` (`rocks_db.rs:52`), i.e. 3,221,225,072
bytes — roughly 192x ScyllaDB's 16,752,727.

### The splitting path is unreachable by two orders of magnitude

`ResourceControlPolicy::testnet()` sets `maximum_bytes_written_per_block` to 10 MB, so a
single block cannot write 3 GiB *in total*, let alone into one value. Every other
relevant cap (`maximum_block_size` 1 MB, `maximum_blob_size` 1 MB,
`maximum_bytecode_size` 10 MB, `maximum_block_proposal_size` 13 MB) is far below as well,
and the large aggregates in `ChainStateView` are stored per-entry rather than as a single
blob. See #6723 for the full breakdown.

The threshold is also unenforced: unlike `ScyllaDbStoreInternal`, `RocksDbStoreInternal`
has no `check_value_size` — only a key-length check at `rocks_db.rs:130`. `MAX_VALUE_SIZE`
is advertised but never checked, so removing the wrapper introduces no new error path.

### Confirmed empirically, on RocksDB-backed production processes

`testnet_conway` carries a `WARN` log and a `linera_value_split_count` counter on the
split branch (#5891, in every release since v0.15.16). The counter is a process-global
`LazyLock` in `linera-views`, so it covers whichever backend a process uses.

Checked on 2026-08-18 against the production Grafana:

- RocksDB-backed processes are present in the fleet — the
  `linera_lru_caching_value_splitting_rocksdb_internal_*` metering family is exposed by
  `pm-infra-worker-1..12` (several `-rpc`) in `pm-infra-backend`, by `pm-infra-faucet`,
  and by `linera-faucet` in the `testnet-conway` and `bench-2026-08-18` namespaces.
- Those binaries do contain the counter: pm-app pins linera-protocol at `17e1861a0e`
  (SDK v0.15.21 prep, on `testnet_conway`), which has `b8e14a9218` as an ancestor.
- **`linera_value_split_count` does not exist as a metric name at all** across the whole
  Prometheus retention window (~15-20 days). Linera metrics are `LazyLock` statics
  registered on first use (see #6703), so an absent name means the `.inc()` never ran.
  Those same processes' other `linera-views` metrics do reach Prometheus — that is how
  the RocksDB-backed jobs were identified — so this is not a scrape gap.
- **Loki:** zero hits for `"Splitting large value"` across all clusters over 30 days.

Coverage caveat: Prometheus retention is ~3 weeks, so this is "never recently", not
"never since genesis".

### What the wrapper costs when it does nothing

- 4 bytes of segment index appended to **every key** and a 4-byte count prefixed to
  **every value**, on disk.
- A key clone plus `extend` on every `read_value_bytes` / `contains_key` /
  `read_multi_values_bytes` / `write_batch` entry.
- A **full copy of every value read**: `value[4..].to_vec()` in `read_value_bytes`.
- Per-entry index decoding and re-assembly bookkeeping in `find_keys_by_prefix` and
  `find_key_values_by_prefix`.
- `MAX_KEY_SIZE` reduced by 4.

## Proposal

Drop `ValueSplittingDatabase` from the `RocksDbDatabase` stack:

```
before: [Metered] LruCaching [Metered] ValueSplitting [Metered] RocksDbInternal
after:  [Metered] LruCaching [Metered] RocksDbInternal
```

and simplify `RocksDbStoreError` from `ValueSplittingError<RocksDbStoreInternalError>` to
`RocksDbStoreInternalError`.

`ValueSplittingDatabase` itself is deliberately left in place. With #6723 it has no
remaining backend user, but it stays available as a documented generic wrapper
(`linera-views/DESIGN.md`) and is still exercised by `create_value_splitting_memory_store`
in `store_tests.rs`.

### Consequences

- **Existing RocksDB databases become unreadable, silently.** This is the part worth
  scrutiny. Keys lose their 4-byte suffix and values lose their 4-byte count prefix, so
  new code looking up `key` will not find data written at `key||00000000`: reads return
  `None` and prefix scans hand back keys with 4 stray bytes and values carrying the count
  prefix. The store looks *empty or malformed* rather than raising an error.

  RocksDB is the **default** storage for the `linera` CLI —
  `~/.config/linera/wallet.db`, see `linera-service/src/cli/common_options.rs:81-92` — and
  also backs `linera-storage-service`'s `rocksdb` mode. Anyone tracking `main` must delete
  their existing store; there is no migration. Since `main` is not a deployed branch this
  is a development-workflow cost, but it is a larger blast radius than the ScyllaDB change
  in #6723 and should not be backported without a deliberate wipe plan.
- **`MAX_VALUE_SIZE` is now honest.** The store advertises 3 GiB - 400 instead of
  `usize::MAX`. Nothing enforced it before and nothing enforces it now, so the practical
  ceiling is RocksDB's own (values must fit a 32-bit length). `MAX_KEY_SIZE` widens back
  by 4 bytes.
- **Public error type changes.** `RocksDbStoreError` is now `RocksDbStoreInternalError`;
  the `MissingSegment` / `NoCountAvailable` / `TooShortKey` variants leave the RocksDB
  error surface. The single downstream user,
  `linera_indexer::common::IndexerError::RocksDbError`, converts via `#[from]` and is
  unaffected.
- **Two metric families are renamed**, since metering derives names from the wrapper
  chain: `linera_lru_caching_value_splitting_rocksdb_internal_*` becomes
  `linera_lru_caching_rocksdb_internal_*`, and the intermediate
  `linera_value_splitting_rocksdb_internal_*` layer disappears. The innermost
  `linera_rocksdb_internal_*` family is unchanged. The pm-infra worker and faucet
  dashboards use the outer name and will need updating when this reaches a deployed
  branch.

## Test Plan

Unlike #6723, this one is fully exercisable locally — RocksDB is embedded, so no server
is needed.

- `cargo test -p linera-views --features rocksdb,metrics` — 387 passing, 0 failing.
  Includes every RocksDB-backed case: `test_rocks_db_big_write_read` (values up to 5 MB,
  20 MB total per prefix), `rocks_db_tombstone_triggering_test`, `test_reads_rocks_db`,
  `test_rocks_db_writes_from_blank`, `test_rocks_db_writes_from_state`,
  `test_views_in_rocks_db`, `test_queue_operations_with_rocks_db_context`, and the
  `namespace_admin_test_cases::rocksdbdatabase` / `root_key_admin_test_cases::rocksdbdatabase`
  admin suites.
- `cargo test -p linera-storage --features rocksdb` — passing.
- `cargo clippy --locked --all-targets --all-features --workspace` — clean.
- `cargo clippy -p linera-indexer --features rocksdb --all-targets -- -D warnings` — clean.
- `cargo check -p linera-views --features rocksdb` and `--features rocksdb,metrics`.
- `cargo +nightly-2026-05-11 fmt --all -- --check`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

Explicitly **not** a backport candidate: see the silent-invalidation note above.

## Links

- #6723 — the same removal for the ScyllaDB stack, with the full policy-cap analysis.
- #5891 added the `value_split_count` counter and the `WARN` used for the measurement above.
- #6703 explains the `LazyLock` registration semantics that make "metric absent" equivalent
  to "code path never executed".
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
