### PR TITLE
Split the unexpected-quorum error into a divergent-execution and a stale-round case

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -331,9 +331,7 @@ pub enum Error {
     #[error(
         "Chain {chain_id} height {height}: a quorum of validators voted for a different \
          execution of our proposal in {round}. Their {kind:?} value hashes to {hash}, ours \
-         to {expected_hash}. The block they agreed on is valid; what differs is our local \
-         prediction of its execution outcome, so this client's chain state has drifted from \
-         the network's. Retrying will fail the same way until it is resynchronized."
+         to {expected_hash}."
     )]
     DivergentExecution {
         chain_id: ChainId,
@@ -346,7 +344,7 @@ pub enum Error {
 
     #[error(
         "Chain {chain_id} height {height}: a quorum of validators voted in {round}, but we \
-         proposed in {expected_round}; our view of the current round is stale."
+         proposed in {expected_round}."
     )]
     StaleQuorumRound {
         chain_id: ChainId,

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -40,8 +40,8 @@ use linera_chain::{
     },
     manager::LockingBlock,
     types::{
-        Block, ConfirmedBlock, ConfirmedBlockCertificate, Timeout, TimeoutCertificate,
-        ValidatedBlock,
+        Block, CertificateKind, ConfirmedBlock, ConfirmedBlockCertificate, Timeout,
+        TimeoutCertificate, ValidatedBlock,
     },
     ChainError, ChainExecutionContext,
 };
@@ -329,13 +329,29 @@ pub enum Error {
     BcsError(#[from] bcs::Error),
 
     #[error(
-        "Unexpected quorum: validators voted for block hash {hash} in {round}, \
-         expected block hash {expected_hash} in {expected_round}"
+        "Chain {chain_id} height {height}: a quorum of validators voted for a different \
+         execution of our proposal in {round}. Their {kind:?} value hashes to {hash}, ours \
+         to {expected_hash}. The block they agreed on is valid; what differs is our local \
+         prediction of its execution outcome, so this client's chain state has drifted from \
+         the network's. Retrying will fail the same way until it is resynchronized."
     )]
-    UnexpectedQuorum {
-        hash: CryptoHash,
+    DivergentExecution {
+        chain_id: ChainId,
+        height: BlockHeight,
         round: Round,
+        kind: CertificateKind,
+        hash: CryptoHash,
         expected_hash: CryptoHash,
+    },
+
+    #[error(
+        "Chain {chain_id} height {height}: a quorum of validators voted in {round}, but we \
+         proposed in {expected_round}; our view of the current round is stale."
+    )]
+    StaleQuorumRound {
+        chain_id: ChainId,
+        height: BlockHeight,
+        round: Round,
         expected_round: Round,
     },
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1562,12 +1562,23 @@ impl<Env: Environment> Client<Env> {
             }
         };
         ensure!(
-            (votes_hash, votes_round) == (value.hash(), action.round()),
-            chain_client::Error::UnexpectedQuorum {
-                hash: votes_hash,
+            votes_round == action.round(),
+            chain_client::Error::StaleQuorumRound {
+                chain_id: value.chain_id(),
+                height: value.height(),
                 round: votes_round,
-                expected_hash: value.hash(),
                 expected_round: action.round(),
+            }
+        );
+        ensure!(
+            votes_hash == value.hash(),
+            chain_client::Error::DivergentExecution {
+                chain_id: value.chain_id(),
+                height: value.height(),
+                round: votes_round,
+                kind: T::KIND,
+                hash: votes_hash,
+                expected_hash: value.hash(),
             }
         );
         // Certificate is valid because


### PR DESCRIPTION
## Motivation

A user hit this while proposing a block from the web wallet:

```
chain client error: Unexpected quorum: validators voted for block hash e11b4411…6aa61 in
multi-leader round 1, expected block hash 380cac45…4fce1 in multi-leader round 1
```

Diagnosing it took far longer than it should have, entirely because of the message:

- **It blames the wrong party.** "Unexpected quorum" reads as a validator or consensus fault.
  The quorum was well-formed; the client's own prediction was the outlier. That framing sends
  triage towards double-voting and stale confirm-votes first.
- **"block hash" is inaccurate.** Both values are `ValidatedBlock` hashes. Looking either one up
  returns `Missing confirmed block: …`, which reads like data loss rather than a category error.
- **It conflates two unrelated failures.** `round != expected_round` is a stale view of the
  current round. Same round with different hashes means the validators executed our proposal and
  got a different outcome than we predicted locally. Different causes, different fixes, one
  message that describes neither.
- **No locator.** No chain ID, no height. On a wallet with several chains and six-figure block
  heights there is nothing to search on.

## Proposal

Split `UnexpectedQuorum` into two variants and give each the context that is already in scope at
the raise site — no extra queries, no behaviour change:

- `StaleQuorumRound { chain_id, height, round, expected_round }`
- `DivergentExecution { chain_id, height, round, kind, hash, expected_hash }`

`chain_id`/`height` come from the `T: CertificateValue` bound; `kind` is `T::KIND`.

The divergent-execution error rendered with the values from the report above:

> Chain 2354ab9c…50c3 height 104525: a quorum of validators voted for a different execution of
> our proposal in multi-leader round 1. Their Validated value hashes to e11b4411…6aa61, ours to
> 380cac45…4fce1.

Scope note: this is the message only. The client still discards the quorum it collected rather
than reconciling with it, which is a separate change.

## Test Plan

CI. `cargo clippy -p linera-core --all-targets --locked` and `cargo fmt --check` on the pinned
nightly are clean. No test referenced the old variant — the only two occurrences in the tree were
the definition and the single raise site.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
