### PR TITLE
linera-core: export executed blocks to the committee from the chain workers, relayed through the proxy (front-port of #6639)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -326,6 +326,9 @@ jobs:
     - name: Run the storage-service tests
       run: |
         cargo test --features storage-service,opentelemetry -- storage_service --nocapture
+    - name: Run the block export integration test
+      run: |
+        cargo test -p linera-service --test block_export_tests --features storage-service,metrics -- --ignored --nocapture
 
   check-wit-files:
     needs: changed-files

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -387,6 +387,13 @@ where
     /// they have never been filtered — a pre-existing database entry (migration), or a validator
     /// that tracks all chains and never filters.
     pub outbox_index_tracked_hash: RegisterView<C, Option<CryptoHash>>,
+
+    // A lower bound, not an exact record: progress is reported asynchronously, so a crash loses
+    // whatever was not folded in. Deliberate — a re-sent block the destination already has is
+    // skipped on an integer compare, whereas under-sending would leave a permanent gap.
+    /// The highest block of this chain pushed to each other committee validator. A validator with
+    /// no entry is queried before its first push; ones that leave the committee are pruned.
+    pub exported_heights: RegisterView<C, NonCanonicalBTreeMap<ValidatorPublicKey, BlockHeight>>,
 }
 
 /// Block-chaining state.

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -40,6 +40,9 @@ pub struct ChainWorkerConfig {
     /// cross-chain message. When exceeded, the bundles are split into multiple requests.
     /// Defaults to `usize::MAX` (no chunking).
     pub cross_chain_message_chunk_limit: usize,
+    /// How often, at most, export progress is folded into the persisted `exported_heights` of an
+    /// active chain — the fold rewrites the whole register.
+    pub exported_heights_fold_interval: linera_base::time::Duration,
     /// Maximum number of cross-chain requests coalesced into a single batch by the
     /// per-chain driver. Smaller values bound the worst-case write-lock hold time at
     /// the cost of more lock acquisitions; larger values amortize lock and storage
@@ -94,6 +97,7 @@ impl Default for ChainWorkerConfig {
             block_cache_size: 5000,
             execution_state_cache_size: 10_000,
             cross_chain_message_chunk_limit: usize::MAX,
+            exported_heights_fold_interval: linera_base::time::Duration::from_secs(5),
             cross_chain_batch_size_limit: 1000,
             allow_revert_confirm: false,
             reset_on_corrupted_chain_state: None,

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -68,9 +68,7 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
+pub(crate) mod metrics {
     use linera_base::prometheus_util::{
         exponential_bucket_interval, exponential_bucket_latencies, register_histogram,
         register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
@@ -78,151 +76,123 @@ mod metrics {
     };
     use prometheus::{Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 
-    /// Sends refused for a reason about one chain rather than the destination — most often a
-    /// committee the destination has not learned yet. Self-healing, so a rising rate is the
-    /// signal, not the count: one that stays flat and non-zero means a destination is stuck on
-    /// some chain and nothing is repairing it.
-    pub static CHAIN_SCOPED_BACKOFFS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
+    linera_base::declare_metrics! {
+        /// Sends refused for a reason about one chain rather than the destination — most often a
+        /// committee the destination has not learned yet. Self-healing, so a rising rate is the
+        /// signal, not the count: one that stays flat and non-zero means a destination is stuck on
+        /// some chain and nothing is repairing it.
+        pub static CHAIN_SCOPED_BACKOFFS: IntCounterVec = register_int_counter_vec(
             "block_export_chain_scoped_backoffs",
             "Sends deferred because a destination cannot accept a particular chain yet",
             &["validator"],
-        )
-    });
+        );
 
-    /// Chains the queue is tracking: those with a destination still behind, plus recently
-    /// converged ones inside the retention window. A destination that is down holds every chain
-    /// that produced a block during the outage here — that is the work-list its catch-up needs,
-    /// and this is how an operator sees it growing.
-    pub static TRACKED_CHAINS: LazyLock<IntGauge> = LazyLock::new(|| {
-        register_int_gauge(
+        /// Chains the queue is tracking: those with a destination still behind, plus recently
+        /// converged ones inside the retention window. A destination that is down holds every chain
+        /// that produced a block during the outage here — that is the work-list its catch-up needs,
+        /// and this is how an operator sees it growing.
+        pub static TRACKED_CHAINS: IntGauge = register_int_gauge(
             "block_export_tracked_chains",
             "Chains the export queue is tracking for catch-up",
-        )
-    });
+        );
 
-    /// Blocks waiting in the export queue.
-    pub static QUEUE_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
-        register_int_gauge(
+        /// Blocks waiting in the export queue.
+        pub static QUEUE_SIZE: IntGauge = register_int_gauge(
             "block_export_queue_size",
             "Blocks queued for export in this process",
-        )
-    });
+        );
 
-    /// Blob payload bytes held by queued blocks, since a block count alone hides the memory a
-    /// backlog of large blobs pins.
-    pub static QUEUE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
-        register_int_gauge(
+        /// Blob payload bytes held by queued blocks, since a block count alone hides the memory a
+        /// backlog of large blobs pins.
+        pub static QUEUE_BYTES: IntGauge = register_int_gauge(
             "block_export_queue_bytes",
             "Blob bytes held by blocks queued for export in this process",
-        )
-    });
+        );
 
-    /// Blocks dropped because the queue was full. Each is repaired by a later catch-up round, so
-    /// this counting up means latency, not loss.
-    pub static DROPPED_BLOCKS: LazyLock<IntCounter> = LazyLock::new(|| {
-        register_int_counter(
+        /// Blocks dropped because the queue was full. Each is repaired by a later catch-up round, so
+        /// this counting up means latency, not loss.
+        pub static DROPPED_BLOCKS: IntCounter = register_int_counter(
             "block_export_dropped_blocks",
             "Blocks dropped from a full export queue, to be re-sent from storage",
-        )
-    });
+        );
 
-    /// Time from a block being queued to its sends being scheduled.
-    pub static EXPORT_LATENCY: LazyLock<Histogram> = LazyLock::new(|| {
-        register_histogram(
+        /// Time from a block being queued to its sends being scheduled.
+        pub static EXPORT_LATENCY: Histogram = register_histogram(
             "block_export_latency",
             "Time (ms) a block waits in the export queue before its sends are scheduled",
             exponential_bucket_latencies(60_000.0),
-        )
-    });
+        );
 
-    /// Time for one push to one destination, including any catch-up it triggered.
-    pub static SEND_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
+        /// Time for one push to one destination, including any catch-up it triggered.
+        pub static SEND_LATENCY: HistogramVec = register_histogram_vec(
             "block_export_send_latency",
             "Time (ms) to push one block to one destination validator",
             &["validator"],
             exponential_bucket_latencies(60_000.0),
-        )
-    });
+        );
 
-    /// How many concurrent sends each destination is currently allowed.
-    pub static DESTINATION_WINDOW: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-        register_int_gauge_vec(
+        /// How many concurrent sends each destination is currently allowed.
+        pub static DESTINATION_WINDOW: IntGaugeVec = register_int_gauge_vec(
             "block_export_destination_window",
             "AIMD in-flight window per destination validator",
             &["validator"],
-        )
-    });
+        );
 
-    /// Destinations currently resolved. Zero with export enabled means the committee could not
-    /// be loaded or no address resolved — on a dashboard that is otherwise indistinguishable
-    /// from a healthy validator with nothing to send.
-    pub static DESTINATIONS: LazyLock<IntGauge> = LazyLock::new(|| {
-        register_int_gauge(
+        /// Destinations currently resolved. Zero with export enabled means the committee could not
+        /// be loaded or no address resolved — on a dashboard that is otherwise indistinguishable
+        /// from a healthy validator with nothing to send.
+        pub static DESTINATIONS: IntGauge = register_int_gauge(
             "block_export_destinations",
             "Committee members this validator is currently exporting to",
-        )
-    });
+        );
 
-    /// Lagging (chain, destination) *pairs*, which is what the queue's memory tracks — a chain
-    /// behind on ten destinations costs ten times one behind on one.
-    pub static LAGGING_PAIRS: LazyLock<IntGauge> = LazyLock::new(|| {
-        register_int_gauge(
+        /// Lagging (chain, destination) *pairs*, which is what the queue's memory tracks — a chain
+        /// behind on ten destinations costs ten times one behind on one.
+        pub static LAGGING_PAIRS: IntGauge = register_int_gauge(
             "block_export_lagging_pairs",
             "Chain-destination pairs currently behind, summed over destinations",
-        )
-    });
+        );
 
-    /// Blocks this validator still owes each destination, summed over every chain it is behind
-    /// on. The aggregate backlog, which is what "is that validator caught up" actually asks.
-    pub static BLOCKS_OWED: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-        register_int_gauge_vec(
+        /// Blocks this validator still owes each destination, summed over every chain it is behind
+        /// on. The aggregate backlog, which is what "is that validator caught up" actually asks.
+        pub static BLOCKS_OWED: IntGaugeVec = register_int_gauge_vec(
             "block_export_blocks_owed",
             "Blocks still to send to a destination validator, summed over all chains",
             &["validator"],
-        )
-    });
+        );
 
-    /// The furthest behind any single chain is for a destination. A quantile over chains would
-    /// need a per-pair observation, measured at 150 ms per sweep at a million pairs against
-    /// 2 ms for this; and the maximum is the tail a quantile would hide anyway.
-    pub static MAX_CHAIN_GAP: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-        register_int_gauge_vec(
+        /// The furthest behind any single chain is for a destination. A quantile over chains would
+        /// need a per-pair observation, measured at 150 ms per sweep at a million pairs against
+        /// 2 ms for this; and the maximum is the tail a quantile would hide anyway.
+        pub static MAX_CHAIN_GAP: IntGaugeVec = register_int_gauge_vec(
             "block_export_max_chain_gap",
             "Blocks the furthest-behind chain owes a destination validator",
             &["validator"],
-        )
-    });
+        );
 
-    /// The queue-wide in-flight budget, halved whenever our own storage fails a read.
-    pub static TOTAL_WINDOW: LazyLock<IntGauge> = LazyLock::new(|| {
-        register_int_gauge(
+        /// The queue-wide in-flight budget, halved whenever our own storage fails a read.
+        pub static TOTAL_WINDOW: IntGauge = register_int_gauge(
             "block_export_total_window",
             "Concurrent sends allowed across all destinations (AIMD on local storage failures)",
-        )
-    });
+        );
 
-    /// Sends the destination actually answered, as opposed to attempts: `SEND_LATENCY` counts
-    /// every completion, failures included, so success rate needs its own counter.
-    pub static SENDS_SUCCEEDED: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
+        /// Sends the destination actually answered, as opposed to attempts: `SEND_LATENCY` counts
+        /// every completion, failures included, so success rate needs its own counter.
+        pub static SENDS_SUCCEEDED: IntCounterVec = register_int_counter_vec(
             "block_export_sends_succeeded",
             "Export sends acknowledged by the destination validator",
             &["validator"],
-        )
-    });
+        );
 
-    /// How many blocks the destination was behind when we pushed to it: zero whenever the block
-    /// was contiguous there, and the size of the gap we had to fill otherwise.
-    pub static DESTINATION_LAG: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
+        /// How many blocks the destination was behind when we pushed to it: zero whenever the block
+        /// was contiguous there, and the size of the gap we had to fill otherwise.
+        pub static DESTINATION_LAG: HistogramVec = register_histogram_vec(
             "block_export_destination_lag",
             "Blocks a destination validator was missing when a block was pushed to it",
             &["validator"],
             exponential_bucket_interval(1.0, 10_000_000.0),
-        )
-    });
+        );
+    }
 }
 
 /// Configuration for pushing executed blocks to the other committee validators.
@@ -495,7 +465,7 @@ impl BlockExportHandle {
                 #[cfg(with_metrics)]
                 {
                     metrics::QUEUE_SIZE.inc();
-                    metrics::QUEUE_BYTES.add(blob_bytes as i64);
+                    metrics::QUEUE_BYTES.add(i64::try_from(blob_bytes).unwrap_or(i64::MAX));
                 }
             }
             Err(mpsc::error::TrySendError::Full(block)) => {
@@ -1002,7 +972,8 @@ where
         // would die every tick-only duty (drop repair, backoff expiry, the committee scan, the
         // convergence sweep).
         let interval = self.config.idle_catch_up_interval;
-        let tick_delta = TimeDelta::from_micros(interval.as_micros() as u64);
+        let tick_delta =
+            TimeDelta::from_micros(u64::try_from(interval.as_micros()).unwrap_or(u64::MAX));
         let mut next_tick = self
             .storage
             .clock()
@@ -1073,7 +1044,7 @@ where
         #[cfg(with_metrics)]
         {
             metrics::QUEUE_SIZE.dec();
-            metrics::QUEUE_BYTES.sub(block.blob_bytes as i64);
+            metrics::QUEUE_BYTES.sub(i64::try_from(block.blob_bytes).unwrap_or(i64::MAX));
             metrics::EXPORT_LATENCY
                 .finish_measurement(block.queued_at.elapsed().as_secs_f64() * 1000.0);
         }
@@ -1204,7 +1175,7 @@ where
                 );
                 self.total_window = (self.total_window / 2).max(1);
                 #[cfg(with_metrics)]
-                metrics::TOTAL_WINDOW.set(self.total_window as i64);
+                metrics::TOTAL_WINDOW.set(i64::try_from(self.total_window).unwrap_or(i64::MAX));
             }
             SendOutcome::DestinationScoped(error) => {
                 warn!(
@@ -1235,7 +1206,7 @@ where
         #[cfg(with_metrics)]
         metrics::DESTINATION_WINDOW
             .with_label_values(&[&dest.address])
-            .set(dest.window as i64);
+            .set(i64::try_from(dest.window).unwrap_or(i64::MAX));
 
         if let Some(record) = self.chains.get_mut(&chain_id) {
             record.last_activity = now;
@@ -1450,15 +1421,15 @@ where
 
         #[cfg(with_metrics)]
         {
-            metrics::TRACKED_CHAINS.set(self.chains.len() as i64);
-            metrics::DESTINATIONS.set(self.destinations.len() as i64);
+            metrics::TRACKED_CHAINS.set(i64::try_from(self.chains.len()).unwrap_or(i64::MAX));
+            metrics::DESTINATIONS.set(i64::try_from(self.destinations.len()).unwrap_or(i64::MAX));
             let lagging_pairs = self
                 .destinations
                 .values()
                 .map(|dest| dest.lagging.len())
                 .sum::<usize>();
-            metrics::LAGGING_PAIRS.set(lagging_pairs as i64);
-            metrics::TOTAL_WINDOW.set(self.total_window as i64);
+            metrics::LAGGING_PAIRS.set(i64::try_from(lagging_pairs).unwrap_or(i64::MAX));
+            metrics::TOTAL_WINDOW.set(i64::try_from(self.total_window).unwrap_or(i64::MAX));
             if self.ticks_until_census == 0 {
                 self.ticks_until_census = TICKS_PER_BACKLOG_CENSUS;
                 self.publish_backlog();
@@ -1724,10 +1695,10 @@ where
             // value would read as a permanent debt after the peer caught up.
             metrics::BLOCKS_OWED
                 .with_label_values(&[&dest.address])
-                .set(owed as i64);
+                .set(i64::try_from(owed).unwrap_or(i64::MAX));
             metrics::MAX_CHAIN_GAP
                 .with_label_values(&[&dest.address])
-                .set(worst as i64);
+                .set(i64::try_from(worst).unwrap_or(i64::MAX));
             remaining = remaining.saturating_sub(examined);
         }
     }
@@ -1755,7 +1726,8 @@ where
             .progress
             .lock()
             .expect("progress mutex is never poisoned");
-        let index = progress.validators.len() as DestIndex;
+        let index = DestIndex::try_from(progress.validators.len())
+            .expect("a committee cannot hold four billion validators");
         progress.validators.push(validator);
         self.dest_indices.insert(validator, index);
         index
@@ -1959,7 +1931,7 @@ fn backoff_delay(attempt: u32, config: &BlockExportConfig) -> TimeDelta {
         .retry_delay
         .saturating_mul(1u32.checked_shl(attempt).unwrap_or(u32::MAX))
         .min(config.max_retry_delay);
-    TimeDelta::from_micros(delay.as_micros() as u64)
+    TimeDelta::from_micros(u64::try_from(delay.as_micros()).unwrap_or(u64::MAX))
 }
 
 /// Sends this validator's blocks to one other validator, reading everything it needs from
@@ -2039,7 +2011,8 @@ where
             .0
             .min(next_height.0.saturating_add(max_blocks));
         let heights = (next_height.0..last).map(BlockHeight).collect::<Vec<_>>();
-        for chunk in heights.chunks(self.certificate_upload_batch_size as usize) {
+        let batch = usize::try_from(self.certificate_upload_batch_size).unwrap_or(usize::MAX);
+        for chunk in heights.chunks(batch) {
             let certificates = self
                 .storage
                 .read_certificates_by_heights(chain_id, chunk)
@@ -2525,7 +2498,10 @@ mod tests {
                     validator,
                     ..test_dest_state()
                 };
-                (index as DestIndex, dest)
+                (
+                    DestIndex::try_from(index).expect("test committees are small"),
+                    dest,
+                )
             })
             .collect()
     }

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -1,0 +1,2575 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pushing executed blocks to the other validators in the committee.
+//!
+//! One queue task per server process. Chain workers hand it every block they execute —
+//! certificate and blobs, both already in memory — and it pushes them to the rest of the
+//! committee. This is the dissemination that makes each validator a complete replica; consensus
+//! alone only guarantees that a quorum holds any given block.
+//!
+//! One task per *process* rather than per chain worker, for two reasons. Nothing on this path may
+//! touch a chain worker — a task that does resets the worker's keep-alive clock and keeps it
+//! resident forever — so everything here reads storage only. And destination state must be
+//! shared: with per-chain tasks, one unreachable validator is discovered, retried, and backed off
+//! independently by every chain, which at scale is thousands of connection attempts against a
+//! peer that may already be struggling. Here each destination has one connection, one backoff,
+//! and one AIMD window that all chains share: a success widens the window additively, a
+//! transport failure halves it, so the total in-flight load on a struggling peer shrinks
+//! exponentially while it struggles and recovers once it stops.
+//!
+//! Failures are scoped by what they say. A timeout or transport error is about the
+//! *destination*, so it halves the window and backs the destination off (and re-resolves its
+//! node, which rotates to the next proxy when the transport is relayed). An error like
+//! `EventsNotFound` is about one *chain* — the destination lacks the committee that signed the
+//! certificate — so it backs off only that chain-destination pair: the admin chain's own export
+//! is what will fix it, and must not be throttled by it.
+//!
+//! The queue is bounded, and a full queue drops the block rather than blocking the worker.
+//! Dropping is safe because it is *repaired*: the queue tracks each chain's tip against what
+//! every destination acknowledged, and closes any gap from storage during idle rounds. Per-chain
+//! height ordering is preserved by allowing at most one in-flight send per chain-destination
+//! pair.
+//!
+//! Chains converge and are forgotten: a record exists only while some destination is behind, so
+//! memory is bounded by lagging chains, not by every chain the process ever served. Note what
+//! that means during an outage — a destination that is down keeps every chain that produced a
+//! block while it was gone, because that set *is* the work-list its catch-up needs. That is
+//! bounded by the chains that were active, and [`metrics::TRACKED_CHAINS`] exposes it. The
+//! work-list therefore covers chains seen since the process started — a validator that needs the
+//! full history of a chain that never produces blocks again is out of scope here.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    iter,
+    sync::{Arc, Mutex},
+};
+
+use futures::{stream::FuturesUnordered, FutureExt as _, StreamExt as _};
+#[cfg(with_metrics)]
+use linera_base::prometheus_util::MeasureLatency as _;
+use linera_base::{
+    crypto::ValidatorPublicKey,
+    data_types::{Blob, BlockHeight, Epoch, TimeDelta, Timestamp},
+    identifiers::{BlobId, ChainId, StreamId},
+    time::{timer::timeout, Duration},
+};
+use linera_chain::types::ConfirmedBlockCertificate;
+use linera_execution::{committee::Committee, system::EPOCH_STREAM_NAME};
+use linera_storage::{Arc as CacheArc, Clock as _, Storage};
+use tokio::sync::mpsc;
+use tracing::{debug, instrument, warn};
+
+use crate::{
+    client::chain_client,
+    data_types::ChainInfoQuery,
+    node::{CrossChainMessageDelivery, NodeError, ValidatorNode, ValidatorNodeProvider},
+    remote_node::RemoteNode,
+};
+
+#[cfg(with_metrics)]
+mod metrics {
+    use std::sync::LazyLock;
+
+    use linera_base::prometheus_util::{
+        exponential_bucket_interval, exponential_bucket_latencies, register_histogram,
+        register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
+        register_int_gauge_vec,
+    };
+    use prometheus::{Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
+
+    /// Sends refused for a reason about one chain rather than the destination — most often a
+    /// committee the destination has not learned yet. Self-healing, so a rising rate is the
+    /// signal, not the count: one that stays flat and non-zero means a destination is stuck on
+    /// some chain and nothing is repairing it.
+    pub static CHAIN_SCOPED_BACKOFFS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "block_export_chain_scoped_backoffs",
+            "Sends deferred because a destination cannot accept a particular chain yet",
+            &["validator"],
+        )
+    });
+
+    /// Chains the queue is tracking: those with a destination still behind, plus recently
+    /// converged ones inside the retention window. A destination that is down holds every chain
+    /// that produced a block during the outage here — that is the work-list its catch-up needs,
+    /// and this is how an operator sees it growing.
+    pub static TRACKED_CHAINS: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge(
+            "block_export_tracked_chains",
+            "Chains the export queue is tracking for catch-up",
+        )
+    });
+
+    /// Blocks waiting in the export queue.
+    pub static QUEUE_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge(
+            "block_export_queue_size",
+            "Blocks queued for export in this process",
+        )
+    });
+
+    /// Blob payload bytes held by queued blocks, since a block count alone hides the memory a
+    /// backlog of large blobs pins.
+    pub static QUEUE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge(
+            "block_export_queue_bytes",
+            "Blob bytes held by blocks queued for export in this process",
+        )
+    });
+
+    /// Blocks dropped because the queue was full. Each is repaired by a later catch-up round, so
+    /// this counting up means latency, not loss.
+    pub static DROPPED_BLOCKS: LazyLock<IntCounter> = LazyLock::new(|| {
+        register_int_counter(
+            "block_export_dropped_blocks",
+            "Blocks dropped from a full export queue, to be re-sent from storage",
+        )
+    });
+
+    /// Time from a block being queued to its sends being scheduled.
+    pub static EXPORT_LATENCY: LazyLock<Histogram> = LazyLock::new(|| {
+        register_histogram(
+            "block_export_latency",
+            "Time (ms) a block waits in the export queue before its sends are scheduled",
+            exponential_bucket_latencies(60_000.0),
+        )
+    });
+
+    /// Time for one push to one destination, including any catch-up it triggered.
+    pub static SEND_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "block_export_send_latency",
+            "Time (ms) to push one block to one destination validator",
+            &["validator"],
+            exponential_bucket_latencies(60_000.0),
+        )
+    });
+
+    /// How many concurrent sends each destination is currently allowed.
+    pub static DESTINATION_WINDOW: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+        register_int_gauge_vec(
+            "block_export_destination_window",
+            "AIMD in-flight window per destination validator",
+            &["validator"],
+        )
+    });
+
+    /// Destinations currently resolved. Zero with export enabled means the committee could not
+    /// be loaded or no address resolved — on a dashboard that is otherwise indistinguishable
+    /// from a healthy validator with nothing to send.
+    pub static DESTINATIONS: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge(
+            "block_export_destinations",
+            "Committee members this validator is currently exporting to",
+        )
+    });
+
+    /// Lagging (chain, destination) *pairs*, which is what the queue's memory tracks — a chain
+    /// behind on ten destinations costs ten times one behind on one.
+    pub static LAGGING_PAIRS: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge(
+            "block_export_lagging_pairs",
+            "Chain-destination pairs currently behind, summed over destinations",
+        )
+    });
+
+    /// Blocks this validator still owes each destination, summed over every chain it is behind
+    /// on. The aggregate backlog, which is what "is that validator caught up" actually asks.
+    pub static BLOCKS_OWED: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+        register_int_gauge_vec(
+            "block_export_blocks_owed",
+            "Blocks still to send to a destination validator, summed over all chains",
+            &["validator"],
+        )
+    });
+
+    /// The furthest behind any single chain is for a destination. A quantile over chains would
+    /// need a per-pair observation, measured at 150 ms per sweep at a million pairs against
+    /// 2 ms for this; and the maximum is the tail a quantile would hide anyway.
+    pub static MAX_CHAIN_GAP: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+        register_int_gauge_vec(
+            "block_export_max_chain_gap",
+            "Blocks the furthest-behind chain owes a destination validator",
+            &["validator"],
+        )
+    });
+
+    /// The queue-wide in-flight budget, halved whenever our own storage fails a read.
+    pub static TOTAL_WINDOW: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge(
+            "block_export_total_window",
+            "Concurrent sends allowed across all destinations (AIMD on local storage failures)",
+        )
+    });
+
+    /// Sends the destination actually answered, as opposed to attempts: `SEND_LATENCY` counts
+    /// every completion, failures included, so success rate needs its own counter.
+    pub static SENDS_SUCCEEDED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "block_export_sends_succeeded",
+            "Export sends acknowledged by the destination validator",
+            &["validator"],
+        )
+    });
+
+    /// How many blocks the destination was behind when we pushed to it: zero whenever the block
+    /// was contiguous there, and the size of the gap we had to fill otherwise.
+    pub static DESTINATION_LAG: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "block_export_destination_lag",
+            "Blocks a destination validator was missing when a block was pushed to it",
+            &["validator"],
+            exponential_bucket_interval(1.0, 10_000_000.0),
+        )
+    });
+}
+
+/// Configuration for pushing executed blocks to the other committee validators.
+#[derive(Clone, Debug)]
+pub struct BlockExportConfig {
+    /// How many certificates are read from storage per catch-up read. Smaller than the
+    /// client's 500: a chunk lives inside one send job, and `max_catch_up_blocks` bounds the
+    /// round anyway.
+    pub certificate_upload_batch_size: u64,
+    /// How many blocks the export queue holds before dropping new ones for catch-up to repair.
+    pub queue_size: usize,
+    /// The most blob payload bytes queued blocks may pin before new ones are dropped for
+    /// catch-up to repair — a block count alone lets 1024 blob-heavy blocks pin gigabytes.
+    pub queue_bytes: usize,
+    /// The most concurrent sends one destination is ever allowed — the AIMD window's ceiling.
+    pub max_in_flight_per_destination: usize,
+    /// The most concurrent sends across *all* destinations. Each one can be reading up to
+    /// `max_catch_up_blocks` certificates, so without this the aggregate read concurrency is
+    /// the per-destination window times the committee size, and nothing shrinks it when our own
+    /// storage is the bottleneck.
+    pub max_in_flight_total: usize,
+    /// How long a destination is skipped after a failed push, doubling up to `max_retry_delay`.
+    /// Coarser than the transport's per-request retries: those decide whether one call is worth
+    /// repeating, this decides whether the destination is worth attempting at all right now.
+    pub retry_delay: Duration,
+    /// The longest a failing destination is skipped for.
+    pub max_retry_delay: Duration,
+    /// How long the queue waits for a new block before spending a round catching up destinations
+    /// that are behind. With `max_catch_up_blocks` this sets the backfill rate, so tune them
+    /// together.
+    pub idle_catch_up_interval: Duration,
+    /// How many missing blocks are pushed to one destination per round. Deliberately small: it
+    /// bounds what a live block may wait behind, and a validator that just joined reports height
+    /// 0, so its catch-up is otherwise arbitrarily large.
+    pub max_catch_up_blocks: u64,
+    /// How long a converged chain's record is kept before being forgotten. Long enough for the
+    /// chain's worker to fold the final heights into `exported_heights` on its next save; after
+    /// it, a lost cursor costs one query to rebuild.
+    pub converged_chain_retention: Duration,
+}
+
+impl BlockExportConfig {
+    /// Rejects values that would make export misbehave rather than merely perform badly. Checked
+    /// at startup, so a typo fails fast instead of surfacing as a panic, a spinning task, or gaps
+    /// that are never repaired.
+    pub fn check(&self) -> Result<(), String> {
+        if self.certificate_upload_batch_size == 0 {
+            // `slice::chunks(0)` panics.
+            return Err("block export batch size must be greater than zero".into());
+        }
+        if self.queue_size == 0 {
+            // Every block would be dropped and export would run on catch-up alone.
+            return Err("block export queue size must be greater than zero".into());
+        }
+        if self.queue_bytes == 0 {
+            // Every block carrying any blob would be dropped.
+            return Err("block export queue byte budget must be greater than zero".into());
+        }
+        if self.max_in_flight_per_destination == 0 {
+            // No destination could ever be sent anything.
+            return Err("block export in-flight ceiling must be greater than zero".into());
+        }
+        if self.max_in_flight_total == 0 {
+            // The queue-wide budget would admit nothing, so no send would ever start.
+            return Err("block export total in-flight budget must be greater than zero".into());
+        }
+        if self.max_in_flight_total < self.max_in_flight_per_destination {
+            // One destination could never reach its own ceiling, and the AIMD window would
+            // advertise a capacity the queue refuses to grant.
+            return Err(
+                "block export total in-flight budget must be at least the per-destination ceiling"
+                    .into(),
+            );
+        }
+        if self.max_catch_up_blocks == 0 {
+            // Every gap would stay open forever, silently.
+            return Err("block export catch-up bound must be greater than zero".into());
+        }
+        if self.idle_catch_up_interval.is_zero() {
+            // The idle timer would fire continuously, turning the task into a busy loop.
+            return Err("block export idle interval must be greater than zero".into());
+        }
+        if self.retry_delay.is_zero() {
+            // A failing destination would be retried without pause.
+            return Err("block export retry delay must be greater than zero".into());
+        }
+        if self.max_retry_delay.is_zero() {
+            // The cap would clamp every computed backoff to zero, same busy retry as above.
+            return Err("block export max retry delay must be greater than zero".into());
+        }
+        if self.retry_delay > self.max_retry_delay {
+            // The very first backoff would already exceed its own ceiling.
+            return Err("block export retry delay must not exceed the max retry delay".into());
+        }
+        if self.converged_chain_retention.is_zero() {
+            // The progress of a converged chain would be dropped before its worker folds it in.
+            return Err("block export converged-chain retention must be greater than zero".into());
+        }
+        Ok(())
+    }
+}
+
+impl Default for BlockExportConfig {
+    fn default() -> Self {
+        BlockExportConfig {
+            certificate_upload_batch_size: 100,
+            queue_size: 1024,
+            queue_bytes: 256 * 1024 * 1024,
+            max_in_flight_per_destination: 8,
+            max_in_flight_total: 64,
+            retry_delay: Duration::from_secs(1),
+            max_retry_delay: Duration::from_secs(60),
+            idle_catch_up_interval: Duration::from_millis(200),
+            max_catch_up_blocks: 200,
+            converged_chain_retention: Duration::from_secs(300),
+        }
+    }
+}
+
+/// A block a chain worker has executed, on its way to the other validators.
+struct ExportedBlock {
+    certificate: CacheArc<ConfirmedBlockCertificate>,
+    /// The block's required blobs, so that a destination missing them — which is always the case
+    /// for a blob this very block publishes — is served without a read from storage. Held as the
+    /// storage cache's pointers, so queued blocks share the allocations rather than copying them.
+    blobs: Vec<CacheArc<Blob>>,
+    /// The chain's epoch *after* the block was applied — a hint that lets the queue load a newer
+    /// committee from storage, so a validator joining in this block is exported to immediately.
+    epoch: Epoch,
+    /// The persisted `exported_heights` of the chain, seeding missing cursors so a restart
+    /// re-sends at most one block per destination instead of a history.
+    exported_heights: BTreeMap<ValidatorPublicKey, BlockHeight>,
+    /// Blob payload bytes, counted at enqueue so the dequeue releases the same amount of the
+    /// byte budget.
+    blob_bytes: usize,
+    #[cfg(with_metrics)]
+    /// Wall clock, not the storage clock: this only feeds the queue-latency histogram, and a
+    /// simulated clock would report time that no operator waited.
+    queued_at: linera_base::time::Instant,
+}
+
+/// The chain workers' end of the export queue: hands blocks over and reads back progress.
+pub struct BlockExportHandle {
+    blocks: mpsc::Sender<ExportedBlock>,
+    progress: SharedProgress,
+    tips: SharedTips,
+    /// Blob payload bytes currently pinned by queued blocks, enforced against
+    /// [`BlockExportConfig::queue_bytes`].
+    queued_bytes: Arc<std::sync::atomic::AtomicUsize>,
+    queue_bytes_budget: usize,
+}
+
+impl Clone for BlockExportHandle {
+    fn clone(&self) -> Self {
+        BlockExportHandle {
+            blocks: self.blocks.clone(),
+            progress: self.progress.clone(),
+            tips: self.tips.clone(),
+            queued_bytes: self.queued_bytes.clone(),
+            queue_bytes_budget: self.queue_bytes_budget,
+        }
+    }
+}
+
+/// A destination's dense index, assigned once per public key and never reused.
+///
+/// All per-chain state is keyed by this rather than by `ValidatorPublicKey`, which is 88 bytes
+/// and whose `Ord` re-encodes the curve point on *every comparison* — measured at 36 ns, against
+/// about 1 ns for an integer. Per-chain state is the one place that cost is multiplied by the
+/// number of chains a down destination leaves behind.
+type DestIndex = u32;
+
+/// The highest height each destination has acknowledged, per chain, written by the queue task
+/// and folded into each chain's `exported_heights` by its worker on save. Entries are removed
+/// when a chain converges, so this holds lagging chains only.
+#[derive(Default)]
+struct ProgressMap {
+    /// What the indices below refer to. Append-only: an index keeps its meaning for the life of
+    /// the process, so a validator that leaves and rejoins cannot inherit another's cursors.
+    validators: Vec<ValidatorPublicKey>,
+    heights: HashMap<ChainId, Vec<(DestIndex, BlockHeight)>>,
+}
+
+impl ProgressMap {
+    /// Drops the given chains, and returns a burst's peak-sized table for the caller to free
+    /// *outside* the mutex.
+    ///
+    /// `remove` never shrinks, so a drained burst would otherwise pin its peak allocation
+    /// forever. The obvious `shrink_to_fit` is not usable here: it frees the peak-sized bucket
+    /// array in place, and this runs under the mutex every chain worker takes per executed block
+    /// — whose hold `MAX_FORGET_PER_SWEEP` exists to bound. Rebuilding the few survivors into a
+    /// fitted map costs within that budget; handing the old table back moves the
+    /// peak-proportional free off the lock.
+    fn forget_chains(
+        &mut self,
+        forgotten: &[ChainId],
+    ) -> Option<HashMap<ChainId, Vec<(DestIndex, BlockHeight)>>> {
+        for chain_id in forgotten {
+            self.heights.remove(chain_id);
+        }
+        if self.heights.len() <= MAX_FORGET_PER_SWEEP
+            && self.heights.capacity() > self.heights.len().saturating_mul(4)
+        {
+            let survivors = self.heights.drain().collect();
+            return Some(std::mem::replace(&mut self.heights, survivors));
+        }
+        None
+    }
+}
+
+type SharedProgress = Arc<Mutex<ProgressMap>>;
+
+/// The height after each chain's newest announced block. Written on every `export` call before
+/// the queue is tried, so a block the full queue drops still raises the repair target the tick
+/// measures destinations against.
+type SharedTips = Arc<Mutex<HashMap<ChainId, BlockHeight>>>;
+
+impl BlockExportHandle {
+    /// Queues a block for export and returns immediately. A full queue drops the block — never
+    /// blocks the worker — and the tip announced below is what lets catch-up re-send it from
+    /// storage. `exported_heights` seeds the chain's cursors on its first block this process.
+    pub(crate) fn export(
+        &self,
+        certificate: CacheArc<ConfirmedBlockCertificate>,
+        blobs: Vec<CacheArc<Blob>>,
+        epoch: Epoch,
+        exported_heights: BTreeMap<ValidatorPublicKey, BlockHeight>,
+    ) {
+        // Announced before the queue is tried: a dropped block must still raise the repair
+        // target, or a chain whose *last* block was dropped would never be repaired at all.
+        {
+            let header = &certificate.block().header;
+            let tip = header.height.try_add_one().unwrap_or(BlockHeight::MAX);
+            let mut tips = self.tips.lock().expect("tips mutex is never poisoned");
+            let entry = tips.entry(header.chain_id).or_insert(tip);
+            *entry = (*entry).max(tip);
+        }
+        let blob_bytes = blobs.iter().map(|blob| blob.bytes().len()).sum::<usize>();
+        // The byte budget is enforced, not merely measured: a block count alone would let a few
+        // blob-heavy blocks pin memory far past the cache's own bounds. Reserved *before* the
+        // send: incrementing after `try_send` would let the queue task's decrement run first and
+        // wrap the counter, spuriously exhausting the budget for every concurrent caller.
+        let prior = self
+            .queued_bytes
+            .fetch_add(blob_bytes, std::sync::atomic::Ordering::Relaxed);
+        if prior.saturating_add(blob_bytes) > self.queue_bytes_budget {
+            self.queued_bytes
+                .fetch_sub(blob_bytes, std::sync::atomic::Ordering::Relaxed);
+            debug!(
+                chain_id = %certificate.block().header.chain_id,
+                height = %certificate.block().header.height,
+                queued = prior, blob_bytes,
+                "Export queue byte budget exhausted; dropping the block for catch-up to re-send",
+            );
+            #[cfg(with_metrics)]
+            metrics::DROPPED_BLOCKS.inc();
+            return;
+        }
+        let block = ExportedBlock {
+            certificate,
+            blobs,
+            epoch,
+            exported_heights,
+            blob_bytes,
+            #[cfg(with_metrics)]
+            queued_at: linera_base::time::Instant::now(),
+        };
+        match self.blocks.try_send(block) {
+            Ok(()) => {
+                #[cfg(with_metrics)]
+                {
+                    metrics::QUEUE_SIZE.inc();
+                    metrics::QUEUE_BYTES.add(blob_bytes as i64);
+                }
+            }
+            Err(mpsc::error::TrySendError::Full(block)) => {
+                self.queued_bytes
+                    .fetch_sub(blob_bytes, std::sync::atomic::Ordering::Relaxed);
+                debug!(
+                    chain_id = %block.certificate.block().header.chain_id,
+                    height = %block.certificate.block().header.height,
+                    "Export queue full; dropping the block for catch-up to re-send",
+                );
+                #[cfg(with_metrics)]
+                metrics::DROPPED_BLOCKS.inc();
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.queued_bytes
+                    .fetch_sub(blob_bytes, std::sync::atomic::Ordering::Relaxed);
+                warn!("Block export queue stopped unexpectedly; blocks are no longer exported");
+            }
+        }
+    }
+
+    /// Returns how far each validator has been exported to on `chain_id`, restricted to
+    /// `committee` so that validators which left it are pruned.
+    pub(crate) fn progress(
+        &self,
+        chain_id: ChainId,
+        committee: &Committee,
+    ) -> BTreeMap<ValidatorPublicKey, BlockHeight> {
+        let progress = self
+            .progress
+            .lock()
+            .expect("progress mutex is never poisoned");
+        let Some(chain_progress) = progress.heights.get(&chain_id) else {
+            return BTreeMap::new();
+        };
+        chain_progress
+            .iter()
+            .filter_map(|(index, height)| {
+                let validator = progress.validators.get(*index as usize)?;
+                committee
+                    .validators()
+                    .contains_key(validator)
+                    .then_some((*validator, *height))
+            })
+            .collect()
+    }
+}
+
+/// Spawns the process-wide export queue task and returns the handle chain workers push to.
+///
+/// The task runs until every clone of the returned handle is dropped, and reads only from
+/// `storage` — never through a chain worker, whose TTL a touch would reset.
+pub fn spawn_block_export_queue<S, P>(
+    storage: S,
+    node_provider: Arc<P>,
+    config: BlockExportConfig,
+    own_public_key: Option<ValidatorPublicKey>,
+) -> BlockExportHandle
+where
+    S: Storage + Clone + Send + Sync + 'static,
+    P: ValidatorNodeProvider + Send + Sync + 'static,
+    P::Node: Send + Sync,
+{
+    // Enforced here rather than only at the CLI: every constructor, tests included, must go
+    // through it, and an invalid config panics at startup instead of mid-export.
+    if let Err(message) = config.check() {
+        panic!("invalid block export configuration: {message}");
+    }
+    let (blocks, receiver) = mpsc::channel(config.queue_size);
+    let progress: SharedProgress = Arc::default();
+    let tips: SharedTips = Arc::default();
+    let queued_bytes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let queue_bytes_budget = config.queue_bytes;
+    let max_in_flight_total = config.max_in_flight_total;
+
+    let task = BlockExportQueue {
+        storage,
+        node_provider,
+        config,
+        own_public_key,
+        latest_epoch: None,
+        committee: None,
+        committee_dirty: false,
+        admin_chain_id: None,
+        ticks_until_scan: 0,
+        ticks_until_sweep: TICKS_PER_CONVERGENCE_SWEEP,
+        #[cfg(with_metrics)]
+        ticks_until_census: 0,
+        drain_cursor: None,
+        chains: HashMap::new(),
+        destinations: BTreeMap::new(),
+        dest_indices: BTreeMap::new(),
+        next_generation: 0,
+        total_window: max_in_flight_total,
+        announced_epoch: None,
+        scan_attempted_for: None,
+        destinations_changed: false,
+        queued_bytes: queued_bytes.clone(),
+        progress: progress.clone(),
+        tips: tips.clone(),
+        draining: false,
+    };
+    linera_base::Task::spawn(task.run(receiver)).forget();
+
+    BlockExportHandle {
+        blocks,
+        progress,
+        tips,
+        queued_bytes,
+        queue_bytes_budget,
+    }
+}
+
+/// What we know of one chain: its tip, and each destination's position below it. Kept while some
+/// destination is behind, and for a grace window after convergence so the chain's worker can
+/// still fold the final heights into its state; then forgotten.
+struct ChainRecord {
+    /// The height after the chain's last known block: what a destination must reach to be
+    /// caught up.
+    tip: BlockHeight,
+    /// When this chain last saw a block or a completed send, for the convergence sweep.
+    last_activity: Timestamp,
+    /// Sorted by index, so lookups binary-search integers. A flat vector rather than a map
+    /// because this is allocated per tracked chain: a `BTreeMap` pays for an eleven-slot leaf
+    /// whatever the committee size.
+    dests: Vec<(DestIndex, ChainDest)>,
+}
+
+impl ChainRecord {
+    /// Starts a record with a cursor for every current destination.
+    ///
+    /// Seeding here rather than at the call sites is what makes the empty-cursor state
+    /// unrepresentable: a record with no cursors is invisible to the requeue loop and trivially
+    /// "converged" to the sweep, so such a chain would be abandoned in silence. One creation
+    /// path used to miss the seeding, and nothing in the suite could see it.
+    fn new<N>(
+        now: Timestamp,
+        destinations: &BTreeMap<DestIndex, DestState<N>>,
+        exported_heights: &BTreeMap<ValidatorPublicKey, BlockHeight>,
+    ) -> Self {
+        ChainRecord {
+            tip: BlockHeight::ZERO,
+            last_activity: now,
+            // Already in index order, which is the order `dests` must keep.
+            dests: destinations
+                .iter()
+                .map(|(index, dest)| {
+                    // Seeded here rather than by a later fill: a cursor pre-populated as `None`
+                    // and then only `or_insert`-ed would silently swallow the persisted height,
+                    // leaving `exported_heights` write-only and costing a query per destination
+                    // on every restart.
+                    let next_height = exported_heights
+                        .get(&dest.validator)
+                        .and_then(|height| height.try_add_one().ok());
+                    (
+                        *index,
+                        ChainDest {
+                            next_height,
+                            ..ChainDest::default()
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    fn dest(&self, index: DestIndex) -> Option<&ChainDest> {
+        let at = self
+            .dests
+            .binary_search_by_key(&index, |(at, _)| *at)
+            .ok()?;
+        Some(&self.dests[at].1)
+    }
+
+    fn dest_mut(&mut self, index: DestIndex) -> Option<&mut ChainDest> {
+        let at = self
+            .dests
+            .binary_search_by_key(&index, |(at, _)| *at)
+            .ok()?;
+        Some(&mut self.dests[at].1)
+    }
+
+    /// The cursor for `index`, created empty if this record does not have one yet.
+    fn dest_entry(&mut self, index: DestIndex) -> &mut ChainDest {
+        let at = match self.dests.binary_search_by_key(&index, |(at, _)| *at) {
+            Ok(at) => at,
+            Err(at) => {
+                self.dests.insert(at, (index, ChainDest::default()));
+                at
+            }
+        };
+        &mut self.dests[at].1
+    }
+}
+
+impl ChainRecord {
+    /// Fills in every cursor this record does not have from the chain's persisted heights.
+    ///
+    /// Applied on every block rather than at record creation, and idempotent. Tying the seeding
+    /// to creation has failed twice — the tick creates records too, from a tip announced before
+    /// its block was dequeued, and it has no heights to seed with; an `or_insert` then cannot
+    /// correct a cursor that already exists as `None`.
+    ///
+    /// Safe for a cursor a failure cleared, too: the persisted height is a lower bound, so the
+    /// worst case is re-offering blocks the destination already holds, and its reply corrects
+    /// the cursor in either direction.
+    fn seed_missing_cursors<N>(
+        &mut self,
+        destinations: &BTreeMap<DestIndex, DestState<N>>,
+        exported_heights: &BTreeMap<ValidatorPublicKey, BlockHeight>,
+    ) {
+        for (index, dest) in destinations {
+            let chain_dest = self.dest_entry(*index);
+            // Guard first: this runs per block, and in the steady state every cursor is set, so
+            // the pubkey lookup would be pure waste.
+            if chain_dest.next_height.is_none() && chain_dest.in_flight.is_none() {
+                chain_dest.next_height = exported_heights
+                    .get(&dest.validator)
+                    .and_then(|height| height.try_add_one().ok());
+            }
+        }
+    }
+}
+
+/// One chain's cursor at one destination.
+#[derive(Default)]
+struct ChainDest {
+    /// The next height the destination needs, or `None` when we have to ask it — before the
+    /// first push, and after any failed one.
+    next_height: Option<BlockHeight>,
+    /// The destination generation of the send currently running for this pair, if any. Carrying
+    /// the generation is what stops a stale job's completion from clearing a *newer* job's flag
+    /// and breaking the one-send-per-pair ordering invariant.
+    in_flight: Option<u64>,
+    /// Backoff for *chain-scoped* failures — the destination is healthy but cannot accept this
+    /// chain yet, e.g. it lacks the committee and the admin chain's export has not reached it.
+    retry_at: Option<Timestamp>,
+    failures: u32,
+    /// How many times this destination has reported a *lower* height than it had. Counted apart
+    /// from `failures` because an advance clears those, and a peer alternating advance with
+    /// regression would otherwise reset its own penalty on every second answer and never
+    /// escalate. Fits in `ChainDest`'s existing padding.
+    regressions: u32,
+}
+
+impl ChainDest {
+    /// Folds in a height the destination reported, returning the height to record as
+    /// acknowledged, if any.
+    ///
+    /// The validator is authoritative about its own height in *both* directions: only one send
+    /// per pair is ever in flight and stale generations are filtered out, so a lower report is
+    /// not a race. One restored from a backup reports lower, and refusing to believe it would
+    /// leave that gap unrepaired for good — we would think it caught up and never re-send what
+    /// it lost. Believing it is therefore required; paying for it is what stops a peer from
+    /// lying its way into an unthrottled re-send loop.
+    fn record_reached(
+        &mut self,
+        reported: BlockHeight,
+        tip: BlockHeight,
+        now: Timestamp,
+        config: &BlockExportConfig,
+    ) -> Option<BlockHeight> {
+        // Clamped once, here, so the cursor, the counters and the acknowledgement all read the
+        // same height. A destination legitimately runs ahead of us — the client broadcasts to
+        // everyone — but the value is *its* claim, and storing a claim above our tip satisfies
+        // none of the "behind" predicates that schedule work, while satisfying every
+        // "converged" one. Since only a completed send can rewrite the cursor, and no send is
+        // ever scheduled for a pair that looks converged, an over-report would strand that pair
+        // for the life of the process. Clamped, it is self-correcting: the pair re-enters the
+        // work set as soon as our own tip passes the clamp.
+        let reported = reported.min(tip);
+        let previous = self.next_height;
+        let advanced = previous.is_none_or(|height| reported > height);
+        let regressed = previous.is_some_and(|height| reported < height);
+        self.next_height = Some(reported);
+        if advanced {
+            self.failures = 0;
+            self.retry_at = None;
+        } else if regressed {
+            // Escalates on the regression count, which an advance does not clear: a genuine
+            // restore regresses once and pays one delay, an oscillating peer pays double each
+            // time it lies.
+            let attempt = self.failures.max(self.regressions);
+            self.retry_at = Some(now.saturating_add(backoff_delay(attempt, config)));
+            self.regressions = self.regressions.saturating_add(1);
+        } else if reported < tip {
+            // Answered but moved nothing — a gap our storage cannot fill — so back this pair
+            // off rather than spinning on it.
+            back_off(&mut self.failures, &mut self.retry_at, now, config);
+            return None;
+        } else {
+            return None;
+        }
+        reported.try_sub_one().ok()
+    }
+}
+
+/// One destination validator: its connection and the health state every chain shares.
+struct DestState<N> {
+    node: N,
+    /// Kept here because per-chain state refers to this destination by index, not by key.
+    validator: ValidatorPublicKey,
+    address: String,
+    /// Bumped whenever this state is rebuilt, so a send started against a previous incarnation
+    /// cannot corrupt the new one's accounting when it completes.
+    generation: u64,
+    /// Sends currently running against this destination, over all chains.
+    in_flight: usize,
+    /// How many concurrent sends the AIMD control currently allows: +1 per success up to the
+    /// configured ceiling, halved per transport failure down to 1.
+    window: usize,
+    /// Backoff for *destination-scoped* failures: transport errors and timeouts.
+    retry_at: Option<Timestamp>,
+    failures: u32,
+    /// Chains this destination is behind on, maintained as pairs fall behind and converge
+    /// rather than rediscovered by scanning every chain each tick — that scan was O(tracked
+    /// chains x destinations) at 5 Hz, which at a million lagging chains took longer than the
+    /// tick interval itself and starved the queue of everything else.
+    ///
+    /// Membership *is* the "needs work" flag, so there is no separate `queued` bit to fall out
+    /// of step with it.
+    lagging: BTreeSet<ChainId>,
+    /// Where the next drain resumes in `lagging`. Without it the set's ordering hands the window
+    /// to the same lowest chain ids every time and starves the rest of the backlog — the
+    /// fairness the previous FIFO had for free.
+    lagging_cursor: Option<ChainId>,
+}
+
+impl<N> DestState<N> {
+    /// The chains to consider this round, resuming where the last one stopped and wrapping around.
+    ///
+    /// The rotation is the point: `lagging` is ordered, so walking it from the start every tick
+    /// would hand the window to the same lowest chain ids forever and starve the rest.
+    fn drain_candidates(&self, budget: usize) -> Vec<ChainId> {
+        match self.lagging_cursor {
+            Some(cursor) => self
+                .lagging
+                .range(cursor..)
+                .chain(self.lagging.iter().take_while(|id| **id < cursor))
+                .copied()
+                .take(budget)
+                .collect(),
+            None => self.lagging.iter().copied().take(budget).collect(),
+        }
+    }
+
+    /// Moves the cursor past the last chain considered, so the next round advances.
+    ///
+    /// A round that considered nothing — a saturated destination breaks before looking at its
+    /// first candidate — leaves the cursor alone. Clearing it there restarts the next drain at
+    /// the lowest chain id, which is the starvation the cursor exists to prevent, and a busy
+    /// destination is saturated on almost every tick.
+    fn advance_cursor(&mut self, last_considered: Option<ChainId>) {
+        let Some(last) = last_considered else {
+            return;
+        };
+        self.lagging_cursor = self.lagging.range(last..).nth(1).copied();
+    }
+}
+
+/// How one send ended, scoped to what the error tells us about.
+enum SendOutcome {
+    /// The validator answered; its reported next height.
+    Reached(BlockHeight),
+    /// The failure is about this chain on this destination, not about the destination.
+    ChainScoped(Box<chain_client::Error>),
+    /// The failure is about the destination itself.
+    DestinationScoped(Box<chain_client::Error>),
+    /// Our own storage failed. Nobody's health signal but ours.
+    LocalScoped(Box<chain_client::Error>),
+}
+
+/// The body of the process-wide export queue task.
+struct BlockExportQueue<S, P>
+where
+    S: Storage,
+    P: ValidatorNodeProvider,
+{
+    storage: S,
+    node_provider: Arc<P>,
+    config: BlockExportConfig,
+    own_public_key: Option<ValidatorPublicKey>,
+    /// The newest committee seen, from exported blocks and from scanning storage forward. Used
+    /// for the destination set of every chain: a chain's own committee cannot announce a
+    /// newcomer, and current committee members need every chain regardless of its epoch.
+    latest_epoch: Option<Epoch>,
+    committee: Option<Arc<Committee>>,
+    /// Set when `committee` changed and the destination set has not been rebuilt yet, so the
+    /// rebuild runs per committee change rather than per block.
+    committee_dirty: bool,
+    /// The admin chain, read from the network description once, for the silent epoch probe.
+    admin_chain_id: Option<ChainId>,
+    /// Ticks until the next storage scan for a committee no block has carried yet.
+    ticks_until_scan: u32,
+    /// Ticks until the next sweep of converged chains.
+    ticks_until_sweep: u32,
+    /// Ticks until the next backlog census.
+    #[cfg(with_metrics)]
+    ticks_until_census: u32,
+    /// Which destination the queue-wide budget is offered to first, rotated every tick.
+    drain_cursor: Option<DestIndex>,
+    chains: HashMap<ChainId, ChainRecord>,
+    destinations: BTreeMap<DestIndex, DestState<P::Node>>,
+    /// Every validator ever registered as a destination, and the index its per-chain state uses.
+    /// Never pruned, so a validator that rejoins reuses its index rather than taking a departed
+    /// one's.
+    dest_indices: BTreeMap<ValidatorPublicKey, DestIndex>,
+    /// The last destination generation handed out; never reused within this queue's lifetime.
+    next_generation: u64,
+    /// Concurrent sends allowed across all destinations right now: halved when our own storage
+    /// fails a read, restored one slot per success up to `max_in_flight_total`. A destination's
+    /// own window bounds what one peer can consume; this bounds what the queue as a whole asks
+    /// of storage.
+    total_window: usize,
+    /// The newest epoch any exported block has announced; the tick loads its committee when it
+    /// is ahead of `latest_epoch`.
+    announced_epoch: Option<Epoch>,
+    /// The announcement the eager scan last acted on, so one that fails to load is retried on
+    /// the normal cadence rather than on every tick.
+    scan_attempted_for: Option<Epoch>,
+    /// Set when `sync_destinations` changed the set, so the per-record cursor fill runs once
+    /// per change instead of once per tick.
+    destinations_changed: bool,
+    /// Blob bytes pinned by queued blocks, shared with every handle for budget enforcement.
+    queued_bytes: Arc<std::sync::atomic::AtomicUsize>,
+    progress: SharedProgress,
+    /// The highest height each chain has announced, written by every `export` call — including
+    /// ones the full queue dropped — so a dropped block still moves the repair target.
+    tips: SharedTips,
+    /// True once every handle is dropped: completions may finish, nothing new starts.
+    draining: bool,
+}
+
+/// How many ticks apart the queue probes storage for committees no block has announced.
+const TICKS_PER_COMMITTEE_SCAN: u32 = 10;
+
+/// How many times the window a single drain may look past before giving up for this tick, so a
+/// backlog of ineligible entries cannot turn the drain back into a full scan.
+const LAGGING_SCAN_FACTOR: usize = 4;
+
+/// How many ticks apart converged chains are swept. The window they are held for is minutes, so
+/// this only decides how promptly the memory comes back.
+const TICKS_PER_CONVERGENCE_SWEEP: u32 = 25;
+
+/// How many ticks apart the backlog census runs. Slower than the sweep because it costs the size
+/// of the real backlog and answers a dashboard question, not a scheduling one.
+#[cfg(with_metrics)]
+const TICKS_PER_BACKLOG_CENSUS: u32 = 300;
+
+/// Destinations in the order the queue-wide budget is offered to them, resuming past `cursor`
+/// and wrapping. Rotating matters because the budget is shared: served in index order every
+/// time, the first `max_in_flight_total / max_in_flight_per_destination` destinations absorb all
+/// of it and the rest never get a catch-up slot.
+fn rotated_order(indices: &[DestIndex], cursor: Option<DestIndex>) -> Vec<DestIndex> {
+    match cursor {
+        Some(at) => indices
+            .iter()
+            .copied()
+            .skip_while(|index| *index < at)
+            .chain(indices.iter().copied().take_while(|index| *index < at))
+            .collect(),
+        None => indices.to_vec(),
+    }
+}
+
+/// Where the next round starts: past the destination this one served first.
+fn next_drain_cursor(indices: &[DestIndex], served_first: Option<DestIndex>) -> Option<DestIndex> {
+    let first = served_first?;
+    indices.iter().copied().find(|index| *index > first)
+}
+
+/// The most (chain, destination) pairs one census walks. Each is a random lookup into the chain
+/// map plus a search of its cursors — measured at roughly half a microsecond per pair, so this
+/// caps the stall at about 25 ms however deep the backlog is. Past the cap the gauges are a
+/// floor rather than a total, which is the right trade for a number read off a dashboard:
+/// `block_export_lagging_pairs` is exact and free, and says how far past the cap we are.
+#[cfg(with_metrics)]
+const MAX_CENSUS_PAIRS: usize = 50_000;
+
+/// How many chains one sweep may forget, bounding how long it holds the progress mutex that every
+/// chain worker takes on every block.
+const MAX_FORGET_PER_SWEEP: usize = 4096;
+
+impl<S, P> BlockExportQueue<S, P>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+    P: ValidatorNodeProvider,
+    P::Node: Clone + Send + 'static,
+{
+    /// Exports blocks until every handle is dropped, ticking every `idle_catch_up_interval`
+    /// whether or not sends are in flight — backoff expiry and gap repair must not wait for a
+    /// process-wide lull that a busy validator never has.
+    #[instrument(level = "debug", skip_all)]
+    async fn run(mut self, mut receiver: mpsc::Receiver<ExportedBlock>) {
+        /// What woke the loop, decided inside the select so its borrows end before handling.
+        enum Wake {
+            Done(JobDone),
+            Block(Option<ExportedBlock>),
+            Tick,
+        }
+        let mut jobs = FuturesUnordered::new();
+        // One deadline carried across iterations: a timer rebuilt per iteration restarts on
+        // every completion or block, so under sustained load it would never fire — and with it
+        // would die every tick-only duty (drop repair, backoff expiry, the committee scan, the
+        // convergence sweep).
+        let interval = self.config.idle_catch_up_interval;
+        let tick_delta = TimeDelta::from_micros(interval.as_micros() as u64);
+        let mut next_tick = self
+            .storage
+            .clock()
+            .current_time()
+            .saturating_add(tick_delta);
+        loop {
+            let now = self.storage.clock().current_time();
+            // The storage clock is the wall clock in production, so it can step backwards (NTP,
+            // a restored snapshot). The deadline is a timestamp but the wait is real time, so a
+            // backward step of N seconds would otherwise suspend every tick-only duty — backoff
+            // expiry, drop repair, the committee scan — for N seconds. Never wait longer than
+            // one interval.
+            if next_tick.duration_since(now) > interval {
+                next_tick = now.saturating_add(tick_delta);
+            }
+            if now >= next_tick {
+                self.tick(&mut jobs).await;
+                next_tick = self
+                    .storage
+                    .clock()
+                    .current_time()
+                    .saturating_add(tick_delta);
+                continue;
+            }
+            let until_tick = next_tick.duration_since(now);
+            let wake = if jobs.is_empty() {
+                match timeout(until_tick, receiver.recv()).await {
+                    Ok(received) => Wake::Block(received),
+                    Err(_) => Wake::Tick,
+                }
+            } else {
+                // `futures::select_biased` rather than `tokio::select`, which does not compile
+                // for the web target. Completions first, then fresh blocks, then the tick.
+                futures::select_biased! {
+                    done = jobs.next() => Wake::Done(done.expect("jobs is not empty")),
+                    received = receiver.recv().fuse() => Wake::Block(received),
+                    _ = self.storage.clock().sleep_for(until_tick).fuse() => Wake::Tick,
+                }
+            };
+            match wake {
+                Wake::Done(done) => self.on_done(done, &mut jobs),
+                Wake::Block(Some(block)) => self.on_block(block, &mut jobs),
+                Wake::Block(None) => break,
+                Wake::Tick => {
+                    self.tick(&mut jobs).await;
+                    next_tick = self
+                        .storage
+                        .clock()
+                        .current_time()
+                        .saturating_add(tick_delta);
+                }
+            }
+        }
+        // The workers are gone. Let in-flight sends finish, without starting new ones — every
+        // completion would otherwise drain more catch-up work and hold shutdown open.
+        self.draining = true;
+        while let Some(done) = jobs.next().await {
+            self.on_done(done, &mut jobs);
+        }
+        debug!("All block export handles dropped; stopping the export queue");
+    }
+
+    /// Folds a fresh block in: advances the chain's tip and fans out to every destination that
+    /// can take it now; the rest catch up from storage when their turn comes.
+    fn on_block(&mut self, block: ExportedBlock, jobs: &mut FuturesUnordered<JobFuture>) {
+        self.queued_bytes
+            .fetch_sub(block.blob_bytes, std::sync::atomic::Ordering::Relaxed);
+        #[cfg(with_metrics)]
+        {
+            metrics::QUEUE_SIZE.dec();
+            metrics::QUEUE_BYTES.sub(block.blob_bytes as i64);
+            metrics::EXPORT_LATENCY
+                .finish_measurement(block.queued_at.elapsed().as_secs_f64() * 1000.0);
+        }
+        let header = &block.certificate.block().header;
+        let (chain_id, height) = (header.chain_id, header.height);
+        // Only recorded here: loading the committee reads storage, and an await in this handler
+        // stalls every in-flight send — the tick's scan does the loading.
+        if self
+            .announced_epoch
+            .is_none_or(|announced| block.epoch > announced)
+        {
+            self.announced_epoch = Some(block.epoch);
+        }
+        // Per committee change only. Never on "destinations are empty": when a committee's
+        // addresses cannot be resolved that stays true, and the rebuild walks every tracked
+        // chain and re-warns per member — on the block-execution path. The tick retries it.
+        if self.committee_dirty {
+            self.sync_destinations();
+        }
+
+        let now = self.storage.clock().current_time();
+        let tip = height.try_add_one().unwrap_or(BlockHeight::MAX);
+        let record = self
+            .chains
+            .entry(chain_id)
+            .or_insert_with(|| ChainRecord::new(now, &self.destinations, &block.exported_heights));
+        record.tip = record.tip.max(tip);
+        record.last_activity = now;
+        record.seed_missing_cursors(&self.destinations, &block.exported_heights);
+        let indices = self.destinations.keys().copied().collect::<Vec<_>>();
+        for index in indices {
+            let budget = self.budget_remaining();
+            let record = self.chains.get_mut(&chain_id).expect("inserted above");
+            let record_tip = record.tip;
+            let chain_dest = record.dest_entry(index);
+            let dest = self
+                .destinations
+                .get_mut(&index)
+                .expect("iterating destinations");
+            let contiguous = chain_dest.next_height == Some(height);
+            let can_send_now = chain_dest.in_flight.is_none()
+                && chain_dest.retry_at.is_none_or(|at| at <= now)
+                && dest.retry_at.is_none_or(|at| at <= now)
+                && dest.in_flight < dest.window;
+            if contiguous && can_send_now {
+                // The fast path: the block is already in memory and the destination is ready,
+                // so no storage read at all.
+                Self::spawn_job(
+                    jobs,
+                    &self.storage,
+                    &self.config,
+                    chain_id,
+                    index,
+                    dest,
+                    chain_dest,
+                    record_tip,
+                    Some((block.certificate.clone(), block.blobs.clone())),
+                );
+            } else if chain_dest.next_height.is_none_or(|next| next < record_tip) {
+                dest.lagging.insert(chain_id);
+                if can_send_now {
+                    Self::drain_ready(
+                        &mut self.chains,
+                        &self.storage,
+                        &self.config,
+                        index,
+                        dest,
+                        jobs,
+                        now,
+                        budget,
+                    );
+                }
+            }
+        }
+    }
+
+    /// Folds one finished send back into the destination's and the chain's state.
+    fn on_done(
+        &mut self,
+        (chain_id, index, generation, outcome): JobDone,
+        jobs: &mut FuturesUnordered<JobFuture>,
+    ) {
+        let now = self.storage.clock().current_time();
+        let Some(dest) = self.destinations.get_mut(&index) else {
+            return; // The validator left the committee while its send was in flight.
+        };
+        let validator = dest.validator;
+        if dest.generation != generation {
+            // The send ran against a previous incarnation of this destination; its slot was
+            // never counted here and its result must not touch the fresh state.
+            if let Some(chain_dest) = self
+                .chains
+                .get_mut(&chain_id)
+                .and_then(|record| record.dest_mut(index))
+            {
+                // Only the flag this very job set — the pair may since carry a newer job's.
+                if chain_dest.in_flight == Some(generation) {
+                    chain_dest.in_flight = None;
+                }
+            }
+            return;
+        }
+        dest.in_flight = dest.in_flight.saturating_sub(1);
+
+        // Destination health comes from the outcome alone, never gated on the chain record —
+        // a transport failure must shrink the window and set the backoff even for a chain the
+        // queue has since forgotten.
+        match &outcome {
+            SendOutcome::Reached(_) => {
+                dest.failures = 0;
+                dest.retry_at = None;
+                dest.window = (dest.window + 1).min(self.config.max_in_flight_per_destination);
+                self.total_window = (self.total_window + 1).min(self.config.max_in_flight_total);
+                #[cfg(with_metrics)]
+                metrics::SENDS_SUCCEEDED
+                    .with_label_values(&[&dest.address])
+                    .inc();
+            }
+            SendOutcome::ChainScoped(_) => {}
+            SendOutcome::LocalScoped(error) => {
+                // Our storage, not the peer: leave the destination's window alone and halve the
+                // queue's own budget, so the pressure is relieved across every destination
+                // rather than one pair at a time while the rest keep reading.
+                warn!(
+                    %chain_id, %error,
+                    "Export could not read from local storage; halving the queue's total \
+                     in-flight budget",
+                );
+                self.total_window = (self.total_window / 2).max(1);
+                #[cfg(with_metrics)]
+                metrics::TOTAL_WINDOW.set(self.total_window as i64);
+            }
+            SendOutcome::DestinationScoped(error) => {
+                warn!(
+                    validator = %dest.address, %chain_id, %error,
+                    "Failed to export to a validator; backing it off and re-resolving",
+                );
+                dest.window = (dest.window / 2).max(1);
+                back_off(&mut dest.failures, &mut dest.retry_at, now, &self.config);
+                // Re-resolve so a relayed transport draws the next proxy from the rotation; the
+                // backoff above still applies if the validator itself is the problem. Resolved
+                // through the list API because the test provider resolves by *key*, which only
+                // the list variant carries.
+                match self
+                    .node_provider
+                    .make_nodes_from_list(iter::once((validator, dest.address.clone())))
+                {
+                    Ok(mut nodes) => {
+                        if let Some((_, node)) = nodes.next() {
+                            dest.node = node;
+                        }
+                    }
+                    Err(error) => {
+                        warn!(%validator, %error, "Cannot re-resolve a failing destination");
+                    }
+                }
+            }
+        }
+        #[cfg(with_metrics)]
+        metrics::DESTINATION_WINDOW
+            .with_label_values(&[&dest.address])
+            .set(dest.window as i64);
+
+        if let Some(record) = self.chains.get_mut(&chain_id) {
+            record.last_activity = now;
+            let record_tip = record.tip;
+            if let Some(chain_dest) = record.dest_mut(index) {
+                if chain_dest.in_flight == Some(generation) {
+                    chain_dest.in_flight = None;
+                }
+                match &outcome {
+                    SendOutcome::Reached(next_height) => {
+                        if let Some(acked) =
+                            chain_dest.record_reached(*next_height, record_tip, now, &self.config)
+                        {
+                            let mut progress = self
+                                .progress
+                                .lock()
+                                .expect("progress mutex is never poisoned");
+                            let heights = progress.heights.entry(chain_id).or_default();
+                            match heights.binary_search_by_key(&index, |(at, _)| *at) {
+                                Ok(at) => heights[at].1 = acked,
+                                Err(at) => heights.insert(at, (index, acked)),
+                            }
+                        }
+                    }
+                    SendOutcome::LocalScoped(_) => {
+                        // The global budget already shrank; back the pair off too so the same
+                        // unreadable range is not retried immediately.
+                        back_off(
+                            &mut chain_dest.failures,
+                            &mut chain_dest.retry_at,
+                            now,
+                            &self.config,
+                        );
+                    }
+                    SendOutcome::ChainScoped(error) => {
+                        debug!(
+                            %chain_id, %validator, %error,
+                            "Destination cannot accept this chain yet; backing the pair off",
+                        );
+                        #[cfg(with_metrics)]
+                        metrics::CHAIN_SCOPED_BACKOFFS
+                            .with_label_values(&[&dest.address])
+                            .inc();
+                        chain_dest.next_height = None;
+                        back_off(
+                            &mut chain_dest.failures,
+                            &mut chain_dest.retry_at,
+                            now,
+                            &self.config,
+                        );
+                    }
+                    SendOutcome::DestinationScoped(_) => {
+                        chain_dest.next_height = None;
+                    }
+                }
+            }
+        }
+
+        if self.draining {
+            return;
+        }
+        // A pair that advanced but is still behind continues on the next free slot rather than
+        // waiting for a tick — multi-round catch-up must not depend on a process-wide lull.
+        let budget = self.budget_remaining();
+        let dest = self.destinations.get_mut(&index).expect("checked above");
+        if let Some(record) = self.chains.get_mut(&chain_id) {
+            let tip = record.tip;
+            if let Some(chain_dest) = record.dest_mut(index) {
+                // Membership tracks "behind", so convergence removes it and nothing else has
+                // to remember to.
+                if chain_dest.next_height.is_none_or(|next| next < tip) {
+                    dest.lagging.insert(chain_id);
+                } else {
+                    dest.lagging.remove(&chain_id);
+                }
+            }
+        }
+        Self::drain_ready(
+            &mut self.chains,
+            &self.storage,
+            &self.config,
+            index,
+            dest,
+            jobs,
+            now,
+            budget,
+        );
+    }
+
+    /// An idle moment: pick up committee changes from storage and requeue expired backoffs.
+    async fn tick(&mut self, jobs: &mut FuturesUnordered<JobFuture>) {
+        let now = self.storage.clock().current_time();
+        // Occasionally scan storage for committees no block has carried — how a validator
+        // admitted while every chain is idle still becomes a destination. On its own cadence
+        // because the probe reads storage, and ticks now fire even under load.
+        // Eagerly, but at most once per announced epoch: a committee that cannot be loaded
+        // leaves `latest_epoch` behind, and re-triggering on the same announcement would turn
+        // the throttled scan into a storage read every tick for as long as it stays unloadable.
+        // The cadence below still retries it.
+        let announced_newer = self.announced_epoch.is_some_and(|epoch| {
+            self.latest_epoch.is_none_or(|latest| epoch > latest)
+                && self.scan_attempted_for != Some(epoch)
+        });
+        if self.ticks_until_scan == 0 || announced_newer {
+            self.ticks_until_scan = TICKS_PER_COMMITTEE_SCAN;
+            self.scan_attempted_for = self.announced_epoch;
+            self.scan_committees().await;
+        } else {
+            self.ticks_until_scan -= 1;
+        }
+        if self.committee_dirty || (self.destinations.is_empty() && self.committee.is_some()) {
+            self.sync_destinations();
+        }
+
+        // Drain announced tips in: this is what repairs a block the full queue dropped, and what
+        // creates the record when even a chain's first block was dropped. Taken rather than
+        // cloned — the workers contend on this mutex every block, and once folded the records
+        // carry the truth.
+        let tips = std::mem::take(&mut *self.tips.lock().expect("tips mutex is never poisoned"));
+        for (chain_id, tip) in tips {
+            let record = self
+                .chains
+                .entry(chain_id)
+                .or_insert_with(|| ChainRecord::new(now, &self.destinations, &BTreeMap::new()));
+            let advanced = record.tip < tip;
+            record.tip = record.tip.max(tip);
+            if advanced {
+                // The scan that used to notice this is gone, so a tip moving forward records
+                // the chains it just put behind, here and now.
+                for (index, dest) in &mut self.destinations {
+                    let chain_dest = record.dest_entry(*index);
+                    if chain_dest.next_height.is_none_or(|next| next < record.tip) {
+                        dest.lagging.insert(chain_id);
+                    }
+                }
+            }
+        }
+        // When the destination set changed, every destination gets a cursor on every tracked
+        // chain, so a validator that joined after a chain's last block is still caught up on it.
+        // Gated on the change: this walks every record.
+        if self.destinations_changed {
+            self.destinations_changed = false;
+            // The one place a full pass is unavoidable: a destination that just joined has no
+            // idea which chains it is behind on. It runs per committee change, not per tick.
+            for (chain_id, record) in &mut self.chains {
+                for (index, dest) in &mut self.destinations {
+                    let chain_dest = record.dest_entry(*index);
+                    if chain_dest.next_height.is_none_or(|next| next < record.tip) {
+                        dest.lagging.insert(*chain_id);
+                    }
+                }
+            }
+        }
+
+        // Forget chains that converged and stayed quiet past the retention window, so memory
+        // tracks recent and lagging chains rather than every chain ever seen. The grace window
+        // is what lets the chain's worker fold the final heights in before they vanish.
+        // Convergence is judged against the *current* destination set — an empty one (a
+        // single-validator committee) is trivially converged, not immortal.
+        let retention = self.config.converged_chain_retention;
+        let destinations = &self.destinations;
+        let mut forgotten = Vec::new();
+        // On its own cadence: this walks every tracked chain, while the retention window it
+        // enforces is measured in minutes. Running it per tick spent a quarter of a core at
+        // 100k chains to reclaim memory a few seconds sooner.
+        if self.ticks_until_sweep == 0 {
+            self.ticks_until_sweep = TICKS_PER_CONVERGENCE_SWEEP;
+            self.chains.retain(|chain_id, record| {
+                // Bounded per sweep: the removals below are what the chain workers block on, so
+                // the mutex hold has to be a constant, not a function of how much converged at
+                // once. The remainder goes on the next sweep.
+                if forgotten.len() >= MAX_FORGET_PER_SWEEP {
+                    return true;
+                }
+                let converged = destinations.keys().all(|index| {
+                    record.dest(*index).is_some_and(|chain_dest| {
+                        // `>=`: a destination is routinely *ahead* of our tip — the client
+                        // broadcasts to everyone — and ahead must count as done, not as never
+                        // converging.
+                        chain_dest.in_flight.is_none()
+                            && chain_dest
+                                .next_height
+                                .is_some_and(|next| next >= record.tip)
+                    })
+                });
+                if converged && now.duration_since(record.last_activity) > retention {
+                    forgotten.push(*chain_id);
+                    false
+                } else {
+                    true
+                }
+            });
+            // `retain` never shrinks the table, so without this a one-off burst of chains would
+            // hold its peak allocation for the life of the process.
+            if self.chains.capacity() > self.chains.len().saturating_mul(4) {
+                self.chains.shrink_to_fit();
+            }
+        } else {
+            self.ticks_until_sweep -= 1;
+        }
+        if !forgotten.is_empty() {
+            let peak_table = self
+                .progress
+                .lock()
+                .expect("progress mutex is never poisoned")
+                .forget_chains(&forgotten);
+            // The free of a burst's peak-sized table happens here, after the guard above is
+            // gone — measured at milliseconds per gigabyte-scale table, which is fine for the
+            // queue task and was not fine under the mutex.
+            drop(peak_table);
+        }
+
+        #[cfg(with_metrics)]
+        {
+            metrics::TRACKED_CHAINS.set(self.chains.len() as i64);
+            metrics::DESTINATIONS.set(self.destinations.len() as i64);
+            let lagging_pairs = self
+                .destinations
+                .values()
+                .map(|dest| dest.lagging.len())
+                .sum::<usize>();
+            metrics::LAGGING_PAIRS.set(lagging_pairs as i64);
+            metrics::TOTAL_WINDOW.set(self.total_window as i64);
+            if self.ticks_until_census == 0 {
+                self.ticks_until_census = TICKS_PER_BACKLOG_CENSUS;
+                self.publish_backlog();
+            } else {
+                self.ticks_until_census -= 1;
+            }
+        }
+
+        // No requeue scan: each destination's `lagging` set already *is* the list of chains it
+        // owes work on, kept current as pairs fall behind and converge. Draining it is
+        // proportional to the work available, not to how much state the process is holding.
+        let mut budget = self.total_window.saturating_sub(
+            self.destinations
+                .values()
+                .map(|dest| dest.in_flight)
+                .sum::<usize>(),
+        );
+        // Resume where the last round stopped. The budget is queue-wide, so serving destinations
+        // in index order every time lets the first `total_window / window` of them absorb all of
+        // it — at a committee larger than that ratio (8 with the defaults) the rest would get no
+        // catch-up at all. Same starvation the per-chain cursor exists to prevent, one level up.
+        let indices = self.destinations.keys().copied().collect::<Vec<_>>();
+        let order = rotated_order(&indices, self.drain_cursor);
+        self.drain_cursor = next_drain_cursor(&indices, order.first().copied());
+        for index in order {
+            let Some(dest) = self.destinations.get_mut(&index) else {
+                continue;
+            };
+            budget -= Self::drain_ready(
+                &mut self.chains,
+                &self.storage,
+                &self.config,
+                index,
+                dest,
+                jobs,
+                now,
+                budget,
+            );
+        }
+    }
+
+    /// Scans storage for committees newer than the one in use, by listing the admin chain's
+    /// epoch events from the frontier — one bulk read, immune to holes in the history, and
+    /// silent when nothing is new.
+    async fn scan_committees(&mut self) {
+        if self.admin_chain_id.is_none() {
+            self.admin_chain_id = match self.storage.read_network_description().await {
+                Ok(Some(description)) => Some(description.admin_chain_id),
+                Ok(None) => return,
+                Err(error) => {
+                    debug!(%error, "Cannot read the network description to scan for committees");
+                    return;
+                }
+            };
+        }
+        let Some(admin_chain_id) = self.admin_chain_id else {
+            return;
+        };
+        let start = self
+            .latest_epoch
+            .map_or(0, |epoch| epoch.0.saturating_add(1));
+        // Epoch 0 comes from the genesis blob, not an event, so it is never in the list.
+        let genesis = (start == 0).then_some(Epoch(0));
+        let mut candidates = match self
+            .storage
+            .read_events_from_index(&admin_chain_id, &StreamId::system(EPOCH_STREAM_NAME), start)
+            .await
+        {
+            Ok(events) => events
+                .into_iter()
+                .map(|event| Epoch(event.index))
+                .chain(genesis)
+                .collect::<Vec<_>>(),
+            Err(error) => {
+                debug!(%error, "Cannot list epoch events to scan for committees");
+                return;
+            }
+        };
+        // Newest first, and stop at the first that loads: a committee lists the full validator
+        // set, so the newest usable one subsumes the rest. Trying only the newest would stall
+        // the whole scan whenever its blob happens to be missing while an older — but still
+        // newer than ours — one is right there.
+        candidates.sort_unstable_by(|a, b| b.cmp(a));
+        for epoch in candidates {
+            match self.storage.committee_for_epoch(epoch).await {
+                Ok(Some(committee)) => {
+                    self.latest_epoch = Some(epoch);
+                    self.committee = Some(committee);
+                    self.committee_dirty = true;
+                    return;
+                }
+                Ok(None) => debug!(%epoch, "An epoch event exists but its committee cannot load"),
+                Err(error) => debug!(%error, %epoch, "Cannot load a committee from storage"),
+            }
+        }
+    }
+
+    /// Brings the destination set in line with the latest committee: adds joiners, drops
+    /// leavers, and re-resolves a changed address.
+    fn sync_destinations(&mut self) {
+        // Cloned so the index registry below can be updated while the committee is read.
+        let Some(committee) = self.committee.clone() else {
+            return;
+        };
+        self.committee_dirty = false;
+        // A destination whose address merely changed keeps the backlog it had accumulated: it is
+        // the same peer, and rediscovering that list costs a pass over every tracked chain.
+        let mut carried = BTreeMap::new();
+        let mut rebuilt_any = false;
+        #[cfg(with_metrics)]
+        let mut rebuilt_addresses = Vec::new();
+        self.destinations.retain(|index, dest| {
+            let keep = committee
+                .validators()
+                .get(&dest.validator)
+                .is_some_and(|state| state.network_address == dest.address);
+            if !keep {
+                rebuilt_any = true;
+                if committee.validators().contains_key(&dest.validator) {
+                    carried.insert(
+                        *index,
+                        (
+                            std::mem::take(&mut dest.lagging),
+                            dest.lagging_cursor.take(),
+                        ),
+                    );
+                }
+                #[cfg(with_metrics)]
+                rebuilt_addresses.push(dest.address.clone());
+            }
+            keep
+        });
+        if rebuilt_any {
+            self.destinations_changed = true;
+        }
+        // Drop the metric series of every address that just went away, so a departed validator
+        // does not leave a window gauge frozen at its last value and a lag histogram that never
+        // moves again — both read as a live destination that simply stopped changing.
+        #[cfg(with_metrics)]
+        for address in &rebuilt_addresses {
+            // A series that was never created is simply absent; nothing to report either way.
+            metrics::DESTINATION_WINDOW
+                .remove_label_values(&[address])
+                .ok();
+            metrics::SEND_LATENCY.remove_label_values(&[address]).ok();
+            metrics::SENDS_SUCCEEDED
+                .remove_label_values(&[address])
+                .ok();
+            metrics::DESTINATION_LAG
+                .remove_label_values(&[address])
+                .ok();
+            metrics::CHAIN_SCOPED_BACKOFFS
+                .remove_label_values(&[address])
+                .ok();
+            metrics::BLOCKS_OWED.remove_label_values(&[address]).ok();
+            metrics::MAX_CHAIN_GAP.remove_label_values(&[address]).ok();
+        }
+        for (validator, address) in committee.validator_addresses() {
+            if Some(validator) == self.own_public_key {
+                continue;
+            }
+            let index = self.dest_index(validator);
+            if self.destinations.contains_key(&index) {
+                continue;
+            }
+            // One at a time: a batch fails whole on the first bad address, and one unresolvable
+            // validator must not keep every other one out of the destination set. Through the
+            // list API rather than `make_node`, because the test provider resolves by *key*,
+            // which only the list variant carries.
+            match self
+                .node_provider
+                .make_nodes_from_list(iter::once((validator, address)))
+            {
+                Ok(mut nodes) => {
+                    if let Some((_, node)) = nodes.next() {
+                        // Monotonic across the queue's lifetime: derived from surviving
+                        // destinations it could repeat after the set empties, and a repeat lets
+                        // a stale in-flight send corrupt a fresh incarnation's accounting.
+                        self.next_generation += 1;
+                        self.destinations_changed = true;
+                        let (lagging, lagging_cursor) = carried.remove(&index).unwrap_or_default();
+                        self.destinations.insert(
+                            index,
+                            DestState {
+                                node,
+                                validator,
+                                address: address.to_owned(),
+                                generation: self.next_generation,
+                                in_flight: 0,
+                                window: self.config.max_in_flight_per_destination,
+                                retry_at: None,
+                                failures: 0,
+                                lagging,
+                                lagging_cursor,
+                            },
+                        );
+                    }
+                }
+                Err(error) => {
+                    warn!(
+                        %validator, %address, %error,
+                        "Cannot resolve a committee member to export blocks to; \
+                         continuing with the others",
+                    );
+                }
+            }
+        }
+        // A validator that left takes its cursors with it.
+        let destinations = &self.destinations;
+        for record in self.chains.values_mut() {
+            record
+                .dests
+                .retain(|(index, _)| destinations.contains_key(index));
+        }
+    }
+
+    /// Publishes how far behind each destination is, walking the `lagging` sets rather than
+    /// every tracked chain.
+    ///
+    /// Those sets already name exactly the chains a destination owes blocks on, so this costs
+    /// the size of the real backlog: nothing when everyone is caught up, and proportional to the
+    /// outage when they are not. Folding it into the convergence sweep instead would have cost
+    /// that sweep its short-circuit — measured at +142 ms per sweep at 100k chains and a
+    /// 20-member committee, against 9 ms for this.
+    ///
+    /// The maximum rather than a quantile: a per-pair histogram observation measured 150 ms per
+    /// sweep at a million pairs, and the maximum is the tail a quantile would hide anyway.
+    #[cfg(with_metrics)]
+    fn publish_backlog(&self) {
+        // Shared across destinations so one enormous backlog cannot spend the whole budget and
+        // leave every later destination reporting zero.
+        let mut remaining = MAX_CENSUS_PAIRS;
+        let mut unvisited = self.destinations.len();
+        for (index, dest) in &self.destinations {
+            let mut owed = 0u64;
+            let mut worst = 0u64;
+            // Divided by the destinations still to come, not by all of them: dividing by the
+            // total while `remaining` shrinks gives each successive destination a smaller share
+            // than the last, so the ones late in the index order would under-report their
+            // backlog. This way a destination that needs less than its share leaves the surplus
+            // to the rest, and the last one may use whatever is left.
+            let per_destination = remaining / unvisited.max(1);
+            unvisited = unvisited.saturating_sub(1);
+            let mut examined = 0usize;
+            for chain_id in &dest.lagging {
+                if examined >= per_destination {
+                    break;
+                }
+                examined += 1;
+                let Some(record) = self.chains.get(chain_id) else {
+                    continue;
+                };
+                let Some(chain_dest) = record.dest(*index) else {
+                    continue;
+                };
+                let gap = chain_dest
+                    .next_height
+                    .map_or(record.tip.0, |next| record.tip.0.saturating_sub(next.0));
+                owed = owed.saturating_add(gap);
+                worst = worst.max(gap);
+            }
+            // Published for every destination, not just the ones behind: a gauge left at its last
+            // value would read as a permanent debt after the peer caught up.
+            metrics::BLOCKS_OWED
+                .with_label_values(&[&dest.address])
+                .set(owed as i64);
+            metrics::MAX_CHAIN_GAP
+                .with_label_values(&[&dest.address])
+                .set(worst as i64);
+            remaining = remaining.saturating_sub(examined);
+        }
+    }
+
+    /// Sends the queue-wide budget still allows, summed from the destinations rather than
+    /// tracked in a counter that could drift out of step with them.
+    fn budget_remaining(&self) -> usize {
+        let in_flight = self
+            .destinations
+            .values()
+            .map(|dest| dest.in_flight)
+            .sum::<usize>();
+        self.total_window.saturating_sub(in_flight)
+    }
+
+    /// The index `validator`'s per-chain state is keyed by, registering it on first sight.
+    ///
+    /// Published to the handles under the progress mutex, because the chain workers read that
+    /// map back and only the registry can name the validators in it.
+    fn dest_index(&mut self, validator: ValidatorPublicKey) -> DestIndex {
+        if let Some(index) = self.dest_indices.get(&validator) {
+            return *index;
+        }
+        let mut progress = self
+            .progress
+            .lock()
+            .expect("progress mutex is never poisoned");
+        let index = progress.validators.len() as DestIndex;
+        progress.validators.push(validator);
+        self.dest_indices.insert(validator, index);
+        index
+    }
+}
+
+/// The result of one send job: which pair it was for, under which destination generation, and
+/// how it went.
+type JobDone = (ChainId, DestIndex, u64, SendOutcome);
+
+/// One send in flight, boxed so jobs from different call sites share a queue.
+#[cfg(not(web))]
+type JobFuture = futures::future::BoxFuture<'static, JobDone>;
+#[cfg(web)]
+type JobFuture = futures::future::LocalBoxFuture<'static, JobDone>;
+
+impl<S, P> BlockExportQueue<S, P>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+    P: ValidatorNodeProvider,
+    P::Node: Clone + Send + 'static,
+{
+    /// Starts one send for `(chain_id, validator)`: the held block when contiguous, catch-up
+    /// from storage otherwise.
+    #[expect(clippy::too_many_arguments)]
+    fn spawn_job(
+        jobs: &mut FuturesUnordered<JobFuture>,
+        storage: &S,
+        config: &BlockExportConfig,
+        chain_id: ChainId,
+        index: DestIndex,
+        dest: &mut DestState<P::Node>,
+        chain_dest: &mut ChainDest,
+        target: BlockHeight,
+        live: Option<(CacheArc<ConfirmedBlockCertificate>, Vec<CacheArc<Blob>>)>,
+    ) {
+        let generation = dest.generation;
+        chain_dest.in_flight = Some(generation);
+        dest.in_flight += 1;
+        let mut sender = BlockSender {
+            remote_node: RemoteNode {
+                public_key: dest.validator,
+                node: dest.node.clone(),
+            },
+            storage: storage.clone(),
+            certificate_upload_batch_size: config.certificate_upload_batch_size,
+        };
+        let cursor = chain_dest.next_height;
+        let max_catch_up = config.max_catch_up_blocks;
+        #[cfg(with_metrics)]
+        let address = dest.address.clone();
+        let job = async move {
+            #[cfg(with_metrics)]
+            let send_latency = metrics::SEND_LATENCY.with_label_values(&[&address]);
+            #[cfg(with_metrics)]
+            let _latency = send_latency.measure_latency();
+            #[cfg(with_metrics)]
+            metrics::DESTINATION_LAG
+                .with_label_values(&[&address])
+                .observe(match cursor {
+                    Some(next) => target.0.saturating_sub(next.0) as f64,
+                    None => 1.0,
+                });
+            let result = match live {
+                Some((certificate, blobs)) => {
+                    sender
+                        .send_block(&certificate, &blobs, cursor, max_catch_up)
+                        .await
+                }
+                None => {
+                    sender
+                        .send_missing_blocks(chain_id, target, cursor, max_catch_up)
+                        .await
+                }
+            };
+            let outcome = match result {
+                Ok(next_height) => SendOutcome::Reached(next_height),
+                Err(error) if is_local_scoped(&error) => SendOutcome::LocalScoped(Box::new(error)),
+                Err(error) if is_chain_scoped(&error) => SendOutcome::ChainScoped(Box::new(error)),
+                Err(error) => SendOutcome::DestinationScoped(Box::new(error)),
+            };
+            (chain_id, index, generation, outcome)
+        };
+        #[cfg(not(web))]
+        jobs.push(job.boxed());
+        #[cfg(web)]
+        jobs.push(job.boxed_local());
+    }
+
+    /// Starts catch-up sends from this destination's ready list until its window is full.
+    #[expect(clippy::too_many_arguments)]
+    fn drain_ready(
+        chains: &mut HashMap<ChainId, ChainRecord>,
+        storage: &S,
+        config: &BlockExportConfig,
+        index: DestIndex,
+        dest: &mut DestState<P::Node>,
+        jobs: &mut FuturesUnordered<JobFuture>,
+        now: Timestamp,
+        budget: usize,
+    ) -> usize {
+        if dest.retry_at.is_some_and(|at| at > now) || dest.in_flight >= dest.window || budget == 0
+        {
+            return 0;
+        }
+        // Only as far as the window allows, so the cost is the sends we are about to make and
+        // not the size of the backlog. Entries stay in `lagging` until they converge: one that
+        // is mid-send or serving its own backoff is skipped here and picked up by a later tick,
+        // with nothing to remember to re-add it.
+        // From the cursor onwards, then wrapping to the start: every chain gets its turn even
+        // when the backlog is far larger than the window. Bounded by a multiple of the window so
+        // a backlog of ineligible entries cannot turn this back into a full scan.
+        let ordered = dest.drain_candidates(dest.window.saturating_mul(LAGGING_SCAN_FACTOR));
+        let mut spawn = Vec::new();
+        let mut stale = Vec::new();
+        let mut last_visited = None;
+        for chain_id in ordered {
+            if dest.in_flight + spawn.len() >= dest.window || spawn.len() >= budget {
+                break;
+            }
+            last_visited = Some(chain_id);
+            let Some(record) = chains.get(&chain_id) else {
+                // The chain was forgotten under us; drop the entry rather than walk past it on
+                // every drain from here on.
+                stale.push(chain_id);
+                continue;
+            };
+            let Some(chain_dest) = record.dest(index) else {
+                continue;
+            };
+            let behind = chain_dest.next_height.is_none_or(|next| next < record.tip);
+            if behind
+                && chain_dest.in_flight.is_none()
+                && chain_dest.retry_at.is_none_or(|at| at <= now)
+            {
+                spawn.push(chain_id);
+            }
+        }
+        dest.advance_cursor(last_visited);
+        for chain_id in stale {
+            dest.lagging.remove(&chain_id);
+        }
+        let spawned = spawn.len();
+        for chain_id in spawn {
+            let Some(record) = chains.get_mut(&chain_id) else {
+                continue;
+            };
+            let tip = record.tip;
+            let Some(chain_dest) = record.dest_mut(index) else {
+                continue;
+            };
+            Self::spawn_job(
+                jobs, storage, config, chain_id, index, dest, chain_dest, tip, None,
+            );
+        }
+        spawned
+    }
+}
+
+/// Whether this failure is about one chain rather than about the destination. `EventsNotFound`
+/// is the destination lacking a committee — the admin chain's export fixes that, and must not be
+/// throttled by it; the others are gaps on our own side.
+fn is_chain_scoped(error: &chain_client::Error) -> bool {
+    matches!(
+        error,
+        chain_client::Error::RemoteNodeError(
+            NodeError::EventsNotFound(_)
+                | NodeError::BlobsNotFound(_)
+                | NodeError::InactiveChain(_)
+        )
+    )
+}
+
+/// Whether this failure is our own storage rather than anything about the destination.
+///
+/// Halving the destination's window for it would punish the wrong side, but backing off only the
+/// one pair leaves every other pair reading at full rate — so the control loop cannot see the
+/// bottleneck it is creating. These shrink the queue's *global* budget instead.
+fn is_local_scoped(error: &chain_client::Error) -> bool {
+    matches!(
+        error,
+        chain_client::Error::ReadCertificatesError(_) | chain_client::Error::ViewError(_)
+    )
+}
+
+/// Escalating backoff shared by both scopes: doubles from `retry_delay` per consecutive failure,
+/// capped at `max_retry_delay`.
+fn back_off(
+    failures: &mut u32,
+    retry_at: &mut Option<Timestamp>,
+    now: Timestamp,
+    config: &BlockExportConfig,
+) {
+    *retry_at = Some(now.saturating_add(backoff_delay(*failures, config)));
+    *failures = failures.saturating_add(1);
+}
+
+/// The delay after `attempt` consecutive failures: doubles per attempt, capped.
+fn backoff_delay(attempt: u32, config: &BlockExportConfig) -> TimeDelta {
+    let delay = config
+        .retry_delay
+        .saturating_mul(1u32.checked_shl(attempt).unwrap_or(u32::MAX))
+        .min(config.max_retry_delay);
+    TimeDelta::from_micros(delay.as_micros() as u64)
+}
+
+/// Sends this validator's blocks to one other validator, reading everything it needs from
+/// storage.
+///
+/// This is deliberately not [`crate::updater::RemoteNodeUpdater`]: that is the client's tool and
+/// holds a local node, and anything on the export path that reaches a chain worker resets its
+/// TTL. Blobs and certificates for committed blocks are always durable before export sees them
+/// (`write_blobs_and_certificate` precedes execution), so storage is sufficient.
+pub(crate) struct BlockSender<S, N> {
+    pub(crate) remote_node: RemoteNode<N>,
+    pub(crate) storage: S,
+    pub(crate) certificate_upload_batch_size: u64,
+}
+
+impl<S, N> BlockSender<S, N>
+where
+    S: Storage + Clone + 'static,
+    N: ValidatorNode + Clone + 'static,
+{
+    /// Pushes a block the caller already holds, first closing up to `max_catch_up` of any gap
+    /// below it, and returns the height the validator reports afterwards.
+    ///
+    /// The held block is sent only once the gap is gone: one landing above a gap is silently
+    /// preprocessed and never advances the tip.
+    pub(crate) async fn send_block(
+        &mut self,
+        certificate: &CacheArc<ConfirmedBlockCertificate>,
+        blobs: &[CacheArc<Blob>],
+        destination_next_height: Option<BlockHeight>,
+        max_catch_up: u64,
+    ) -> Result<BlockHeight, chain_client::Error> {
+        let block = certificate.block();
+        let (chain_id, height) = (block.header.chain_id, block.header.height);
+
+        let next_height = if destination_next_height == Some(height) {
+            height
+        } else {
+            self.send_missing_blocks(chain_id, height, destination_next_height, max_catch_up)
+                .await?
+        };
+        // Not exactly at this block: either the gap was larger than one chunk, or the validator
+        // is already past it — a re-executed chain re-offers its whole history — and in both
+        // cases sending would be waste, so report the truth instead.
+        if next_height != height {
+            return Ok(next_height);
+        }
+        let info = self.send_confirmed_certificate(certificate, blobs).await?;
+        Ok(info.next_block_height)
+    }
+
+    /// Sends up to `max_blocks` of the blocks of `chain_id` the validator is missing below
+    /// `target_next_height`, returning the height it reports afterwards.
+    ///
+    /// Bounded so a validator that just joined converges over rounds instead of blocking the
+    /// caller once. Heights whose certificates are not in storage are skipped — a chain we merely
+    /// receive from is stored only at its message-bearing blocks, and the destination
+    /// preprocesses above such gaps.
+    pub(crate) async fn send_missing_blocks(
+        &mut self,
+        chain_id: ChainId,
+        target_next_height: BlockHeight,
+        destination_next_height: Option<BlockHeight>,
+        max_blocks: u64,
+    ) -> Result<BlockHeight, chain_client::Error> {
+        let mut next_height = match destination_next_height {
+            Some(height) => height,
+            None => {
+                let query = ChainInfoQuery::new(chain_id);
+                self.remote_node
+                    .handle_chain_info_query(query)
+                    .await?
+                    .next_block_height
+            }
+        };
+        let last = target_next_height
+            .0
+            .min(next_height.0.saturating_add(max_blocks));
+        let heights = (next_height.0..last).map(BlockHeight).collect::<Vec<_>>();
+        for chunk in heights.chunks(self.certificate_upload_batch_size as usize) {
+            let certificates = self
+                .storage
+                .read_certificates_by_heights(chain_id, chunk)
+                .await?;
+            for certificate in certificates.into_iter().flatten() {
+                // The validator's own responses move the cursor, so skip anything it has since
+                // reported holding rather than re-sending it.
+                if certificate.block().header.height < next_height {
+                    continue;
+                }
+                let info = self.send_confirmed_certificate(&certificate, &[]).await?;
+                next_height = info.next_block_height;
+            }
+        }
+        Ok(next_height)
+    }
+
+    /// Sends one confirmed certificate, uploading blobs the validator reports missing.
+    ///
+    /// A missing *committee* (`EventsNotFound` for the epoch stream) is not recovered here: the
+    /// admin chain is a chain like any other, so its own export brings the destination up to
+    /// date, and this block succeeds on a later round. Replaying the admin chain from inside
+    /// another chain's push is how one export round used to stall on an unbounded foreign
+    /// history.
+    ///
+    /// The pair retries indefinitely — the backoff caps at `max_retry_delay` — so it recovers
+    /// whenever the destination learns the epoch, from the admin chain's own export or from the
+    /// client, which pushes it on this same error. After a restart the admin chain re-enters
+    /// this queue's work-list only once it produces a block, so a quiet admin chain can leave a
+    /// pair deferred for a while; `CHAIN_SCOPED_BACKOFFS` is what makes that visible.
+    async fn send_confirmed_certificate(
+        &mut self,
+        certificate: &CacheArc<ConfirmedBlockCertificate>,
+        held: &[CacheArc<Blob>],
+    ) -> Result<Box<crate::data_types::ChainInfo>, chain_client::Error> {
+        let delivery = CrossChainMessageDelivery::NonBlocking;
+        let mut result = self
+            .remote_node
+            .handle_optimized_confirmed_certificate(certificate, delivery)
+            .await;
+        // The same once-per-cause loop as the client's `RemoteNodeUpdater`: a second
+        // `BlobsNotFound` naming new blobs is still recoverable, only repeating a cause is not.
+        let mut sent_blobs = false;
+        loop {
+            match result {
+                Err(NodeError::BlobsNotFound(blob_ids)) if !sent_blobs => {
+                    self.remote_node
+                        .check_blobs_not_found(&**certificate, &blob_ids)?;
+                    let blobs = self.resolve_blobs(&blob_ids, held).await?;
+                    self.remote_node
+                        .node
+                        .upload_blobs(blobs.into_iter().map(CacheArc::into_std).collect())
+                        .await?;
+                    sent_blobs = true;
+                }
+                result => return Ok(result?),
+            }
+            result = self
+                .remote_node
+                .handle_confirmed_certificate(certificate.clone(), delivery)
+                .await;
+        }
+    }
+
+    /// Collects the given blobs, taking each from `held` if present and the rest from storage.
+    async fn resolve_blobs(
+        &self,
+        blob_ids: &[BlobId],
+        held: &[CacheArc<Blob>],
+    ) -> Result<Vec<CacheArc<Blob>>, chain_client::Error> {
+        let mut blobs = Vec::with_capacity(blob_ids.len());
+        let mut to_read = Vec::new();
+        for blob_id in blob_ids {
+            match held.iter().find(|blob| blob.id() == *blob_id) {
+                Some(blob) => blobs.push(blob.clone()),
+                None => to_read.push(*blob_id),
+            }
+        }
+        if to_read.is_empty() {
+            return Ok(blobs);
+        }
+        let read = self
+            .storage
+            .read_blobs(&to_read)
+            .await?
+            .into_iter()
+            .collect::<Option<Vec<_>>>();
+        blobs.extend(read.ok_or(NodeError::BlobsNotFound(to_read))?);
+        Ok(blobs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use linera_base::crypto::CryptoHash;
+
+    use super::*;
+
+    /// Every rejection in `check()` guards a distinct failure mode, so each invalid field must be
+    /// caught on its own — including `max_retry_delay`, whose zero used to slip through and turn
+    /// backoff into a busy retry.
+    #[test]
+    fn config_check_rejects_each_zero_knob() {
+        assert!(BlockExportConfig::default().check().is_ok());
+        let invalid = [
+            BlockExportConfig {
+                certificate_upload_batch_size: 0,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                queue_size: 0,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                queue_bytes: 0,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                max_in_flight_per_destination: 0,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                max_catch_up_blocks: 0,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                idle_catch_up_interval: Duration::ZERO,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                retry_delay: Duration::ZERO,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                max_retry_delay: Duration::ZERO,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                retry_delay: Duration::from_secs(120),
+                max_retry_delay: Duration::from_secs(60),
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                converged_chain_retention: Duration::ZERO,
+                ..BlockExportConfig::default()
+            },
+        ];
+        for config in invalid {
+            assert!(config.check().is_err(), "accepted: {config:?}");
+        }
+    }
+
+    /// A record starts from what the chain persisted, so a restart does not re-query every
+    /// destination of every chain.
+    ///
+    /// This is the one place the persisted `exported_heights` enters the queue. It regressed
+    /// twice — once when the seeding ran only at record creation and the tick could create
+    /// records without it, once when adding the cursor-always-present invariant made the seeding
+    /// a silent no-op — and neither showed up in any behavioural test, because a missing seed
+    /// only costs a query.
+    #[test]
+    fn records_start_from_the_persisted_heights() {
+        let validator = ValidatorPublicKey::test_key(1);
+        let other = ValidatorPublicKey::test_key(2);
+        let destinations = test_destinations([validator, other]);
+        let exported = [(validator, BlockHeight(41))].into_iter().collect();
+
+        let record = ChainRecord::new(Timestamp::now(), &destinations, &exported);
+
+        assert_eq!(
+            record.dest(0).unwrap().next_height,
+            Some(BlockHeight(42)),
+            "a persisted height must seed the cursor for the block after it",
+        );
+        assert_eq!(
+            record.dest(1).unwrap().next_height,
+            None,
+            "a destination with nothing persisted must be queried, not assumed",
+        );
+    }
+
+    /// A cursor already present as `None` — the state a tick-created record starts in — is still
+    /// seeded from the persisted heights.
+    ///
+    /// The seeding has regressed three times, each time because it was tied to record *creation*
+    /// while a second path also creates records. This pins the property that actually matters:
+    /// after the fill, a missing cursor is seeded no matter who made the record.
+    #[test]
+    fn a_cursor_left_unset_is_still_seeded() {
+        let validator = ValidatorPublicKey::test_key(1);
+        let destinations = test_destinations([validator]);
+        let exported: BTreeMap<_, _> = [(validator, BlockHeight(7))].into_iter().collect();
+
+        // As the tick builds it: no heights to hand over, so the cursor starts unset.
+        let mut record = ChainRecord::new(Timestamp::now(), &destinations, &BTreeMap::new());
+        assert_eq!(record.dest(0).unwrap().next_height, None);
+
+        // The fill `on_block` performs once a block for that chain arrives.
+        record.seed_missing_cursors(&destinations, &exported);
+
+        assert_eq!(
+            record.dest(0).unwrap().next_height,
+            Some(BlockHeight(8)),
+            "a record the tick created must still pick up the persisted cursor",
+        );
+    }
+
+    /// The drain rotates through the backlog instead of always serving its lowest chain ids.
+    ///
+    /// The maintained set replaced a FIFO, and a set is *ordered* — walking it from the start
+    /// every tick hands the whole window to the same few chains and starves everything after
+    /// them, which at a large backlog means those chains are never exported at all.
+    #[test]
+    fn draining_rotates_through_the_backlog() {
+        let mut dest = test_dest_state();
+        dest.lagging = test_chain_ids(6).into_iter().collect();
+
+        // Two rounds of a two-chain window; the second must move past the first.
+        let first = dest.drain_candidates(2);
+        dest.advance_cursor(first.last().copied());
+        let second = dest.drain_candidates(2);
+
+        assert_eq!(first.len(), 2);
+        assert_eq!(second.len(), 2);
+        assert!(
+            first.iter().all(|id| !second.contains(id)),
+            "the second round repeated the first: {first:?} then {second:?}",
+        );
+    }
+
+    /// A round that considered nothing must not throw the rotation away.
+    ///
+    /// `drain_ready` returns before looking at a single candidate when the destination is
+    /// already at its window, which for a destination with a backlog is almost every tick. If
+    /// that round reset the cursor, the next one would restart at the lowest chain id and the
+    /// tail of the backlog would never be reached — the starvation the cursor exists to prevent,
+    /// reintroduced by the cursor's own bookkeeping.
+    #[test]
+    fn a_round_that_visits_nothing_keeps_its_place() {
+        let mut dest = test_dest_state();
+        let ids = test_chain_ids(6);
+        dest.lagging = ids.iter().copied().collect();
+
+        let first = dest.drain_candidates(2);
+        dest.advance_cursor(first.last().copied());
+        let parked = dest.lagging_cursor;
+        assert!(parked.is_some(), "the first round must park the cursor");
+
+        // The saturated round: no candidate is visited, so nothing was considered.
+        dest.advance_cursor(None);
+
+        assert_eq!(
+            dest.lagging_cursor, parked,
+            "a round that visited nothing moved the cursor",
+        );
+        let resumed = dest.drain_candidates(2);
+        assert!(
+            resumed.iter().all(|id| !first.contains(id)),
+            "the drain restarted at the front of the backlog: {first:?} then {resumed:?}",
+        );
+    }
+
+    /// A peer that alternates advancing and regressing its reported height pays a doubling
+    /// penalty, while one that genuinely restored pays a single delay.
+    ///
+    /// The first attempt at this backed a regression off using the shared `failures` counter,
+    /// which an advance resets — so alternating answers pinned the delay at the base value
+    /// forever and the "throttled" peer kept a pair re-reading its whole catch-up window at
+    /// roughly two sends a second.
+    #[test]
+    fn an_oscillating_peer_escalates_but_a_restored_one_does_not() {
+        let config = BlockExportConfig {
+            retry_delay: Duration::from_millis(100),
+            max_retry_delay: Duration::from_secs(60),
+            ..BlockExportConfig::default()
+        };
+        let now = Timestamp::now();
+        let tip = BlockHeight(100);
+
+        // A genuine restore: one regression, then it advances from there for good.
+        let mut restored = ChainDest {
+            next_height: Some(BlockHeight(50)),
+            ..ChainDest::default()
+        };
+        assert!(restored
+            .record_reached(BlockHeight(10), tip, now, &config)
+            .is_some());
+        let restore_penalty = restored.retry_at.expect("a regression backs the pair off");
+        assert_eq!(
+            restore_penalty,
+            now.saturating_add(TimeDelta::from_millis(100))
+        );
+        restored.record_reached(BlockHeight(20), tip, now, &config);
+        assert_eq!(
+            restored.retry_at, None,
+            "an advance after the restore must clear the penalty",
+        );
+
+        // An oscillator: every regression costs double the last, however many advances it
+        // interleaves.
+        let mut liar = ChainDest {
+            next_height: Some(BlockHeight(50)),
+            ..ChainDest::default()
+        };
+        let mut penalties = Vec::new();
+        for round in 0..4 {
+            liar.record_reached(BlockHeight(10), tip, now, &config);
+            penalties.push(
+                liar.retry_at
+                    .expect("a regression backs the pair off")
+                    .delta_since(now),
+            );
+            liar.record_reached(BlockHeight(50 + round), tip, now, &config);
+        }
+        assert_eq!(
+            penalties,
+            vec![
+                TimeDelta::from_millis(100),
+                TimeDelta::from_millis(200),
+                TimeDelta::from_millis(400),
+                TimeDelta::from_millis(800),
+            ],
+            "an advance between regressions reset the penalty",
+        );
+    }
+
+    /// A destination claiming a height above our own tip is acknowledged only up to that tip.
+    ///
+    /// The acknowledged height is merged into the chain's persisted `exported_heights` by
+    /// maximum, so believing an over-report would write a "converged" marker that outlives the
+    /// process and silently ends export to that pair. Being *ahead* is normal — the client
+    /// broadcasts to everyone — so the report cannot simply be rejected either.
+    #[test]
+    fn a_height_above_our_tip_is_acknowledged_only_up_to_it() {
+        let config = BlockExportConfig::default();
+        let tip = BlockHeight(100);
+
+        // An over-report is clamped — in the acknowledgement AND in the stored cursor. Leaving
+        // the cursor raw satisfies every "converged" predicate and no "behind" one, and only a
+        // completed send can rewrite it, so the pair would never be scheduled again.
+        let mut liar = ChainDest::default();
+        let acked = liar.record_reached(BlockHeight(u64::MAX), tip, Timestamp::now(), &config);
+        assert_eq!(
+            acked,
+            Some(BlockHeight(99)),
+            "acknowledged a height we never exported",
+        );
+        assert_eq!(
+            liar.next_height,
+            Some(tip),
+            "stored a cursor above our tip: the pair is now unschedulable and reads as converged",
+        );
+
+        // And an honest report below the tip is taken at its word, not rounded up to it —
+        // otherwise "always acknowledge tip - 1" would satisfy the clamp just as well.
+        let mut honest = ChainDest::default();
+        let acked = honest.record_reached(BlockHeight(40), tip, Timestamp::now(), &config);
+        assert_eq!(
+            acked,
+            Some(BlockHeight(39)),
+            "acknowledged more than the destination reported",
+        );
+        assert_eq!(honest.next_height, Some(BlockHeight(40)));
+    }
+
+    /// The regression counter has to be free: this is per (chain, destination), and a down peer
+    /// holds one per tracked chain.
+    #[test]
+    fn the_regression_counter_costs_no_memory() {
+        assert_eq!(size_of::<ChainDest>(), 56);
+    }
+
+    /// Our own storage failing is not the destination's fault, and not one pair's problem
+    /// either: it shrinks the queue-wide budget, leaving the peer's window alone.
+    ///
+    /// Classifying it per-pair (as `ChainScoped` did) backs off one pair at a time while every
+    /// other pair keeps reading at full rate, so the control loop cannot see the bottleneck it
+    /// is creating.
+    #[test]
+    fn local_storage_errors_are_neither_chain_nor_destination_scoped() {
+        let view_error = chain_client::Error::ViewError(linera_views::ViewError::NotFound(
+            "storage is unhappy".to_owned(),
+        ));
+        assert!(is_local_scoped(&view_error));
+        assert!(
+            !is_chain_scoped(&view_error),
+            "a storage failure would back off one pair and leave the budget untouched",
+        );
+
+        // A destination genuinely lacking the chain's events stays chain-scoped.
+        let events_missing =
+            chain_client::Error::RemoteNodeError(NodeError::EventsNotFound(vec![]));
+        assert!(is_chain_scoped(&events_missing));
+        assert!(!is_local_scoped(&events_missing));
+    }
+
+    /// The queue-wide budget is offered to a different destination each round.
+    ///
+    /// It is shared across destinations, so serving them in index order every time lets the
+    /// first `max_in_flight_total / max_in_flight_per_destination` of them absorb all of it —
+    /// with the defaults that is eight, and every destination past the eighth in a larger
+    /// committee would get no catch-up at all.
+    #[test]
+    fn the_budget_is_offered_to_a_different_destination_each_round() {
+        let indices = (0..12 as DestIndex).collect::<Vec<_>>();
+        let mut cursor = None;
+        let mut first_served = Vec::new();
+
+        for _ in 0..12 {
+            let order = rotated_order(&indices, cursor);
+            first_served.push(order[0]);
+            cursor = next_drain_cursor(&indices, order.first().copied());
+        }
+
+        assert_eq!(
+            first_served,
+            vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+            "the same destinations kept first claim on the budget",
+        );
+    }
+
+    /// A drained burst hands back its peak-sized table for freeing off the mutex; a live one
+    /// keeps its table.
+    ///
+    /// Pinned because the sweep's mutex-hold budget has been broken twice: once by never
+    /// shrinking at all, once by an in-place shrink whose free of the peak table ran under the
+    /// lock.
+    #[test]
+    fn forgetting_a_drained_burst_returns_its_table() {
+        let mut progress = ProgressMap::default();
+        let chains = test_chain_ids(20_000);
+        for chain_id in &chains {
+            progress.heights.insert(*chain_id, Vec::new());
+        }
+        let peak_capacity = progress.heights.capacity();
+
+        // Still holding more than one sweep's budget: no rebuild, however oversized the table.
+        // This is the case that separates the two halves of the guard — the table below is
+        // several times too big, so a capacity test on its own would rebuild it here, under the
+        // mutex, at a size the sweep's budget was written to exclude.
+        let keep = MAX_FORGET_PER_SWEEP + 1000;
+        let (bulk, _) = chains.split_at(chains.len() - keep);
+        assert!(
+            progress.forget_chains(bulk).is_none(),
+            "rebuilt a map still holding {} entries, past the {MAX_FORGET_PER_SWEEP} budget",
+            progress.heights.len(),
+        );
+        assert!(
+            progress.heights.capacity() > progress.heights.len().saturating_mul(4),
+            "the table has to be oversized here or the case proves nothing",
+        );
+
+        // Down to within the budget: the peak table is handed back, not freed in place.
+        let survivors = 10;
+        let within_budget = chains.len() - survivors;
+        let old_table = progress.forget_chains(&chains[chains.len() - keep..within_budget]);
+        assert!(
+            old_table.is_some_and(|table| table.capacity() > peak_capacity / 2),
+            "the peak-sized table was not handed back for freeing off the mutex",
+        );
+        assert!(progress.heights.capacity() < peak_capacity / 4);
+        assert_eq!(progress.heights.len(), survivors);
+    }
+
+    /// Chain ids in the order `lagging` holds them, so a test can name "the front" of a backlog.
+    fn test_chain_ids(count: usize) -> Vec<ChainId> {
+        let mut ids = (0..count)
+            .map(|i| ChainId(CryptoHash::test_hash(format!("chain{i}"))))
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        ids
+    }
+
+    /// Destinations indexed the way `sync_destinations` assigns them: in registration order.
+    fn test_destinations(
+        validators: impl IntoIterator<Item = ValidatorPublicKey>,
+    ) -> BTreeMap<DestIndex, DestState<()>> {
+        validators
+            .into_iter()
+            .enumerate()
+            .map(|(index, validator)| {
+                let dest = DestState {
+                    validator,
+                    ..test_dest_state()
+                };
+                (index as DestIndex, dest)
+            })
+            .collect()
+    }
+
+    fn test_dest_state() -> DestState<()> {
+        DestState {
+            node: (),
+            validator: ValidatorPublicKey::test_key(0),
+            address: "grpc:localhost:1".to_string(),
+            generation: 1,
+            in_flight: 0,
+            window: 1,
+            retry_at: None,
+            failures: 0,
+            lagging: BTreeSet::new(),
+            lagging_cursor: None,
+        }
+    }
+
+    /// The backoff must escalate across consecutive failures — computing it from a reset counter
+    /// is how it once retried a hopeless destination at the base delay forever.
+    #[test]
+    fn back_off_escalates_and_caps() {
+        let config = BlockExportConfig {
+            retry_delay: Duration::from_millis(100),
+            max_retry_delay: Duration::from_millis(450),
+            ..BlockExportConfig::default()
+        };
+        let mut failures = 0;
+        let mut retry_at = None;
+        let now = Timestamp::now();
+        let mut delays = Vec::new();
+        for _ in 0..4 {
+            back_off(&mut failures, &mut retry_at, now, &config);
+            delays.push(retry_at.expect("set by back_off").delta_since(now));
+        }
+        assert_eq!(
+            delays,
+            [
+                TimeDelta::from_millis(100),
+                TimeDelta::from_millis(200),
+                TimeDelta::from_millis(400),
+                TimeDelta::from_millis(450),
+            ],
+        );
+    }
+}

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -5,9 +5,14 @@
 
 mod config;
 mod delivery_notifier;
+pub(crate) mod export;
 pub(crate) mod handle;
 pub(crate) mod state;
 
 pub(super) use self::delivery_notifier::DeliveryNotifier;
 pub(crate) use self::state::{BlockOutcome, CrossChainUpdateResult, EventSubscriptionsResult};
-pub use self::{config::ChainWorkerConfig, state::ProcessConfirmedBlockMode};
+pub use self::{
+    config::ChainWorkerConfig,
+    export::{spawn_block_export_queue, BlockExportConfig, BlockExportHandle},
+    state::ProcessConfirmedBlockMode,
+};

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -52,7 +52,9 @@ use tokio::sync::oneshot;
 use tracing::{debug, info, instrument, trace, warn};
 
 use crate::{
-    chain_worker::{handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier},
+    chain_worker::{
+        export::BlockExportHandle, handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier,
+    },
     client::{ChainModes, ListeningMode},
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     worker::{BatchRequest, NetworkActions, Notification, Reason, WorkerError},
@@ -128,6 +130,11 @@ where
     /// Set to `true` if a database `save` failure has left storage potentially
     /// inconsistent.
     poisoned: bool,
+    /// The process-wide export queue, if the server enabled block export.
+    block_export: Option<BlockExportHandle>,
+    /// When export progress was last folded into `exported_heights`, to bound the register
+    /// rewrites on an active chain.
+    last_exported_heights_fold: Option<linera_base::time::Instant>,
 }
 
 /// The result of processing a cross-chain update.
@@ -190,6 +197,7 @@ where
         chain_id: ChainId,
         service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
         service_runtime_task: Option<web_thread_pool::Task<()>>,
+        block_export: Option<BlockExportHandle>,
     ) -> Result<Self, WorkerError> {
         let chain = storage.load_chain(chain_id).await?;
 
@@ -206,6 +214,8 @@ where
             delivery_notifier,
             knows_chain_is_active: false,
             poisoned: false,
+            block_export,
+            last_exported_heights_fold: None,
         })
     }
 
@@ -1246,6 +1256,17 @@ where
         tip: ChainTipState,
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
+        // Cached only when export is on: the queue holds the shared pointer, and inserting on
+        // every executed block would otherwise churn the dedup cache for nothing.
+        let (cached, plain) = if self.block_export.is_some() {
+            (Some(self.storage.cache_certificate(certificate)), None)
+        } else {
+            (None, Some(certificate))
+        };
+        let certificate = cached
+            .as_deref()
+            .or(plain.as_ref())
+            .expect("exactly one of the two is set");
         let block_hash = certificate.hash();
         let block = certificate.block();
         let chain_id = block.header.chain_id;
@@ -1311,9 +1332,9 @@ where
                         .clone_with_base_key(ctx.base_key().bytes.clone())
                 })
                 .await;
-            certificate.into_value()
+            Cow::Borrowed(certificate.value())
         } else {
-            let (proposed_block, outcome) = certificate.into_value().into_block().into_proposal();
+            let (proposed_block, outcome) = block.clone().into_proposal();
             let (proposed_block, verified, _resource_tracker, _) = chain
                 .execute_block(
                     proposed_block,
@@ -1334,7 +1355,7 @@ where
                 ))
                 .into());
             }
-            ConfirmedBlock::new(Block::new(proposed_block, verified))
+            Cow::Owned(ConfirmedBlock::new(Block::new(proposed_block, verified)))
         };
 
         let updated_streams = chain
@@ -1344,6 +1365,8 @@ where
                 tracked.as_deref().map(|h| h.inner()),
             )
             .await?;
+        self.export_block(cached.as_ref(), published_blobs, blobs)
+            .await;
         let mut actions = self.create_network_actions(None).await?;
         trace!("Processed confirmed block {height}");
         actions.notifications.push(Notification {
@@ -1365,8 +1388,10 @@ where
         }
         self.save().await?;
 
-        self.block_values
-            .insert_hashed(Cow::Owned(confirmed_block.into_inner()));
+        self.block_values.insert_hashed(match confirmed_block {
+            Cow::Borrowed(block) => Cow::Borrowed(block.inner()),
+            Cow::Owned(block) => Cow::Owned(block.into_inner()),
+        });
 
         self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
             .await;
@@ -1376,6 +1401,76 @@ where
             actions,
             BlockOutcome::Processed,
         ))
+    }
+
+    /// Queues the block just executed for export and folds the queue's progress into the chain
+    /// state, for the save that follows to persist. Returns as soon as it is queued, and does
+    /// nothing if export is disabled. Never fails the block: export is replication, not
+    /// consensus, so a problem here is logged and the block stands.
+    async fn export_block(
+        &mut self,
+        certificate: Option<&CacheArc<ConfirmedBlockCertificate>>,
+        published_blobs: Vec<Blob>,
+        read_blobs: BTreeMap<BlobId, Blob>,
+    ) {
+        // The certificate is cached exactly when export is enabled, so both are `Some` or
+        // neither is.
+        let (Some(export), Some(certificate)) = (self.block_export.clone(), certificate) else {
+            return;
+        };
+        // The committee *after* applying the block: a validator that this very block admits has to
+        // be exported to from now on.
+        let (epoch, committee) = match self.chain.current_committee().await {
+            Ok((epoch, committee)) => (epoch, committee),
+            Err(error) => {
+                warn!(%error, "Not exporting a block of a chain with no current committee");
+                return;
+            }
+        };
+
+        // Through the cache rather than `Arc::new`: these blobs are already in storage's cache
+        // in the common case, and the cache is what keeps one allocation per blob content.
+        let blobs = published_blobs
+            .into_iter()
+            .chain(read_blobs.into_values())
+            .map(|blob| self.storage.cache_blob(blob))
+            .collect();
+        export.export(
+            certificate.clone(),
+            blobs,
+            epoch,
+            (**self.chain.exported_heights.get()).clone(),
+        );
+
+        // Fold in what the queue has recorded so far — which never includes the block we just
+        // queued. Merged by maximum: the queue drops a chain's progress once it converges, and an
+        // empty read must not regress what an earlier save persisted.
+        let acknowledged = export.progress(self.chain.chain_id(), &committee);
+        let mut merged = std::collections::BTreeMap::new();
+        for validator in committee.validators().keys() {
+            let previous = self.chain.exported_heights.get().get(validator).copied();
+            let reported = acknowledged.get(validator).copied();
+            if let Some(height) = previous.max(reported) {
+                merged.insert(*validator, height);
+            }
+        }
+        if **self.chain.exported_heights.get() != merged {
+            // Rewrites of an already-populated register are throttled: it is re-serialized
+            // whole, changes on every block of an active chain, and is a lower bound by design.
+            // The first real content is never held back. The tail of a burst may therefore
+            // never be folded at all — there is no later save to carry it — which is accepted:
+            // the cost is one query per destination when the cursor is rebuilt, and the
+            // alternative is a full register write per block.
+            let now = linera_base::time::Instant::now();
+            let throttled = !self.chain.exported_heights.get().is_empty()
+                && self.last_exported_heights_fold.is_some_and(|last| {
+                    now.duration_since(last) < self.config.exported_heights_fold_interval
+                });
+            if !throttled {
+                self.last_exported_heights_fold = Some(now);
+                self.chain.exported_heights.set(merged.into());
+            }
+        }
     }
 
     /// Schedules a notification for when cross-chain messages are delivered up to the given

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1425,7 +1425,7 @@ impl<Env: Environment> Client<Env> {
     fn remote_node_updater(
         &self,
         remote_node: RemoteNode<Env::ValidatorNode>,
-    ) -> RemoteNodeUpdater<Env> {
+    ) -> RemoteNodeUpdater<Env::Storage, Env::ValidatorNode> {
         RemoteNodeUpdater {
             remote_node,
             local_node: self.local_node.clone(),

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -72,6 +72,7 @@ pub fn init_metrics() {
     linera_execution::init_metrics();
     linera_storage::init_metrics();
     linera_views::init_metrics();
+    chain_worker::export::metrics::init_metrics();
     chain_worker::state::metrics::init_metrics();
     client::metrics::init_metrics();
     client::requests_scheduler::init_metrics();

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -14,7 +14,10 @@
 #![allow(async_fn_in_trait)]
 
 mod chain_worker;
-pub use chain_worker::{ChainWorkerConfig, ProcessConfirmedBlockMode};
+pub use chain_worker::{
+    spawn_block_export_queue, BlockExportConfig, BlockExportHandle, ChainWorkerConfig,
+    ProcessConfirmedBlockMode,
+};
 /// The high-level client for interacting with chains and validators.
 pub mod client;
 pub use client::Client;

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2697,7 +2697,6 @@ where
     use crate::{
         local_node::LocalNodeClient,
         remote_node::RemoteNode,
-        test_utils::NodeProvider,
         updater::{CommunicateAction, RemoteNodeUpdater},
         worker::WorkerState,
         ChainWorkerConfig,
@@ -2745,16 +2744,15 @@ where
         None,
     );
     let node = builder.node(1);
-    let mut updater =
-        RemoteNodeUpdater::<crate::environment::Impl<B::Storage, NodeProvider<B::Storage>>> {
-            remote_node: RemoteNode {
-                public_key: node.name(),
-                node,
-            },
-            local_node: LocalNodeClient::new(state),
-            admin_chain_id: builder.admin_chain_id(),
-            certificate_upload_batch_size: 100,
-        };
+    let mut updater = RemoteNodeUpdater {
+        remote_node: RemoteNode {
+            public_key: node.name(),
+            node,
+        },
+        local_node: LocalNodeClient::new(state),
+        admin_chain_id: builder.admin_chain_id(),
+        certificate_upload_batch_size: 100,
+    };
     let submit = |proposal| {
         let (clock_skew_sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
         CommunicateAction::SubmitBlock {
@@ -5044,5 +5042,559 @@ where
     );
     assert!(client.pending_proposal().await.is_none());
 
+    Ok(())
+}
+
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[test_log::test(tokio::test)]
+async fn test_blocks_are_exported_to_the_committee<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new_with_block_export(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    // Each save folds in whatever the export task has acknowledged *so far*, so the recorded
+    // heights necessarily trail the tip: the block being saved has only just been queued. Keep
+    // producing blocks until the exports of the earlier ones have been folded in.
+    let mut exported = BTreeMap::new();
+    for _ in 0..10 {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+        exported = builder.exported_heights(0, chain_id).await;
+        if exported.len() == 3 && exported.values().all(|height| *height >= BlockHeight(1)) {
+            break;
+        }
+        builder
+            .clock()
+            .add(linera_base::data_types::TimeDelta::from_millis(50));
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(50)).await;
+    }
+
+    // One entry per *other* committee member: a validator never exports to itself.
+    assert_eq!(
+        exported.len(),
+        3,
+        "expected the first validator to have exported to the three others, got {exported:?}"
+    );
+    assert!(
+        exported.values().all(|height| *height >= BlockHeight(1)),
+        "expected every destination to have acknowledged at least height 1, got {exported:?}"
+    );
+
+    // The destinations really do hold the chain, and the exporter's cursors agree with them.
+    let tip = sender.chain_info().await?.next_block_height;
+    for index in 0..4 {
+        assert_eq!(builder.next_block_height(index, chain_id).await, tip);
+    }
+    Ok(())
+}
+
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_blocks_are_not_exported_by_default<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+
+    for _ in 0..3 {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+
+    assert!(
+        builder
+            .exported_heights(0, sender.chain_id())
+            .await
+            .is_empty(),
+        "block export must stay off unless a chain exporter factory is installed",
+    );
+    Ok(())
+}
+
+/// A validator that missed blocks is caught up by export alone, while the chain is idle.
+///
+/// After the validator comes back, *nothing else happens* — no blocks, no client traffic — so the
+/// only thing that can close the gap is the export task noticing a lagging destination.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_export_catches_a_lagging_validator_up_while_idle<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new_with_block_export(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    // Validator 3 misses everything below. The other three still form a quorum, so the chain
+    // advances without it.
+    builder.set_fault_type([3], FaultType::Offline);
+    for _ in 0..5 {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+    let tip = sender.chain_info().await?.next_block_height;
+    assert!(tip >= BlockHeight(5));
+
+    // Bring it back and then do nothing at all: no new blocks, no client activity. Anything that
+    // happens from here is export catching up on its own. (Its height can only be read once it is
+    // reachable again — an offline validator answers no queries.)
+    builder.set_fault_type([3], FaultType::Honest);
+    assert!(
+        builder.next_block_height(3, chain_id).await < tip,
+        "the validator that was offline should start out behind",
+    );
+    for _ in 0..60 {
+        if builder.next_block_height(3, chain_id).await == tip {
+            return Ok(());
+        }
+        builder
+            .clock()
+            .add(linera_base::data_types::TimeDelta::from_millis(100));
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
+    }
+    panic!(
+        "export did not catch the lagging validator up to {tip} while idle; it is at {}",
+        builder.next_block_height(3, chain_id).await,
+    );
+}
+
+/// A destination that is unreachable must not stall export to the rest of the committee.
+///
+/// One dead peer must degrade to a gap in `exported_heights`, not to a stalled chain.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_export_survives_an_unreachable_destination<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new_with_block_export(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    // Take one validator away. Its own exporter stops too, which is why the assertions below are
+    // all made from validator 0's point of view.
+    builder.set_fault_type([3], FaultType::Offline);
+
+    for _ in 0..6 {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+
+    // Three peers, one down, so exactly two are ever recorded. Which one is down is deliberately
+    // not asserted: `set_fault_type` indexes creation order, the committee map is keyed by public
+    // key, and the count is the property that matters.
+    // A block per iteration, because `exported_heights` is only folded while a block is being
+    // processed: progress acknowledged after the last block has nothing to write it. The clock
+    // advance is what lets the export tick run at all — it reads the storage clock, so under the
+    // test clock it only moves when the test moves it.
+    let mut exported = BTreeMap::new();
+    for _ in 0..40 {
+        exported = builder.exported_heights(0, chain_id).await;
+        if exported.len() >= 2 {
+            break;
+        }
+        builder
+            .clock()
+            .add(linera_base::data_types::TimeDelta::from_millis(100));
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+    assert_eq!(
+        exported.len(),
+        2,
+        "expected the two reachable peers to be exported to, and only those; got {exported:?}",
+    );
+    assert!(
+        exported.values().all(|height| *height >= BlockHeight(1)),
+        "reachable peers should have acknowledged real progress; got {exported:?}",
+    );
+    Ok(())
+}
+
+/// One catch-up round sends at most `max_catch_up_blocks`, and the next round picks up where it
+/// left off.
+///
+/// Asserted directly rather than through the export loop's timing, because a convergence-only
+/// test passes just as well with the bound ignored — ignoring it converges in one round.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_catch_up_sends_at_most_the_bound_per_round<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    use crate::remote_node::RemoteNode;
+
+    /// Small enough that the backlog below needs several rounds, and not a divisor of it, so a
+    /// final short round is exercised too.
+    const MAX_CATCH_UP_BLOCKS: u64 = 3;
+    const BACKLOG: usize = 11;
+
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    // Validator 3 misses the whole backlog. The other three still form a quorum.
+    builder.set_fault_type([3], FaultType::Offline);
+    for _ in 0..BACKLOG {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+    let target = sender.chain_info().await?.next_block_height;
+    assert_eq!(target, BlockHeight(BACKLOG as u64));
+    builder.set_fault_type([3], FaultType::Honest);
+    assert_eq!(builder.next_block_height(3, chain_id).await, BlockHeight(0));
+
+    // Drive the sender the way an export round does: at validator 3, reading the blocks out of
+    // validator 0's storage (it stayed online throughout).
+    let node = builder.node(3);
+    let mut sender_task = crate::chain_worker::export::BlockSender {
+        remote_node: RemoteNode {
+            public_key: node.name(),
+            node,
+        },
+        storage: builder.validator_storage(0),
+        certificate_upload_batch_size: 100,
+    };
+
+    // Round by round: each one advances by exactly the bound until the last, which sends only the
+    // remainder and stops at the target rather than overshooting.
+    let mut reached = None;
+    let mut rounds = 0;
+    while reached != Some(target) {
+        let before = reached;
+        reached = Some(
+            sender_task
+                .send_missing_blocks(chain_id, target, reached, MAX_CATCH_UP_BLOCKS)
+                .await?,
+        );
+        rounds += 1;
+        let expected = target.min(BlockHeight(
+            before.unwrap_or(BlockHeight(0)).0 + MAX_CATCH_UP_BLOCKS,
+        ));
+        assert_eq!(
+            reached,
+            Some(expected),
+            "round {rounds} starting at {before:?} should have reached {expected}",
+        );
+        assert_eq!(
+            builder.next_block_height(3, chain_id).await,
+            expected,
+            "the validator itself should be at {expected} after round {rounds}",
+        );
+        assert!(rounds <= BACKLOG, "catch-up is not converging");
+    }
+    // 11 blocks in chunks of 3: three full rounds and a remainder of two.
+    assert_eq!(rounds, 4);
+    Ok(())
+}
+
+/// A validator behind by more blocks than one round may send is still caught up, over several
+/// rounds, by the idle export loop alone.
+///
+/// The bound must not also stop the backfill short. The backlog is several times the bound and
+/// nothing else is running, so only the export loop repeating rounds can close the gap.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_export_catches_up_a_backlog_larger_than_the_bound<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    const MAX_CATCH_UP_BLOCKS: u64 = 2;
+    const BACKLOG: usize = 9;
+
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new_with_block_export_config(
+        storage_builder,
+        4,
+        0,
+        signer,
+        crate::BlockExportConfig {
+            max_catch_up_blocks: MAX_CATCH_UP_BLOCKS,
+            // The smallest queue the config accepts, so the bound is exercised; the sequential
+            // burst never outruns the in-process task, so no block is actually dropped here.
+            queue_size: 2,
+            ..TestBuilder::<B>::test_block_export_config()
+        },
+    )
+    .await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    builder.set_fault_type([3], FaultType::Offline);
+    for _ in 0..BACKLOG {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+    let tip = sender.chain_info().await?.next_block_height;
+    assert_eq!(tip, BlockHeight(BACKLOG as u64));
+
+    // Back online, then idle. Everything from here is the export loop's doing.
+    builder.set_fault_type([3], FaultType::Honest);
+    assert!(builder.next_block_height(3, chain_id).await < tip);
+
+    for _ in 0..100 {
+        if builder.next_block_height(3, chain_id).await == tip {
+            return Ok(());
+        }
+        builder
+            .clock()
+            .add(linera_base::data_types::TimeDelta::from_millis(100));
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
+    }
+    panic!(
+        "export did not drain a backlog of {BACKLOG} in rounds of {MAX_CATCH_UP_BLOCKS}; it \
+         stopped at {} of {tip}",
+        builder.next_block_height(3, chain_id).await,
+    );
+}
+
+/// A block the destination already has is not sent again.
+///
+/// `reset_and_reexecute_chain` replays a chain's whole history, and without the guard every block
+/// goes back out. Taking the destination offline is what makes it observable: skipping succeeds
+/// precisely because nothing is sent.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_send_block_skips_a_block_the_destination_already_has<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    use crate::remote_node::RemoteNode;
+
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    for _ in 0..4 {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+    let tip = sender.chain_info().await?.next_block_height;
+    assert_eq!(tip, BlockHeight(4));
+    // Every validator followed along, so validator 3 is fully caught up.
+    assert_eq!(builder.next_block_height(3, chain_id).await, tip);
+
+    let storage = builder.validator_storage(0);
+    let hash = storage
+        .read_certificate_hashes_by_heights(chain_id, &[BlockHeight(0)])
+        .await?
+        .into_iter()
+        .next()
+        .flatten()
+        .expect("the chain has a block at height 0");
+    let certificate = storage
+        .read_certificate(hash)
+        .await?
+        .expect("the certificate at height 0 is in storage");
+
+    // From here the destination answers nothing at all, so reaching for it is an error.
+    builder.set_fault_type([3], FaultType::Offline);
+    let node = builder.node(3);
+    let mut sender_task = crate::chain_worker::export::BlockSender {
+        remote_node: RemoteNode {
+            public_key: node.name(),
+            node,
+        },
+        storage,
+        certificate_upload_batch_size: 100,
+    };
+
+    // Re-offer an old block, exactly as a re-execution would.
+    let reached = sender_task
+        .send_block(&certificate, &[], Some(tip), 100)
+        .await?;
+    assert_eq!(
+        reached, tip,
+        "the destination's height must be reported back"
+    );
+    Ok(())
+}
+
+/// A chain worker expires at its TTL even while block export is enabled.
+///
+/// The export machinery must never touch its own chain worker: a periodic touch resets the
+/// keep-alive clock, and a worker that is touched forever is resident forever — on a validator
+/// with many chains, that is unbounded memory growth and the TTL flag is a no-op.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_chain_workers_expire_while_export_is_enabled<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    const TTL: linera_base::time::Duration = linera_base::time::Duration::from_millis(500);
+
+    let signer = InMemorySigner::new(None);
+    let mut builder =
+        TestBuilder::new_with_block_export_and_ttl(storage_builder, 4, 0, signer, TTL).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+
+    sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_millis(1),
+            Account::chain(recipient.chain_id()),
+        )
+        .await
+        .unwrap_ok_committed();
+    assert!(builder.resident_chain_workers(0).await > 0);
+
+    // From here nothing touches any chain. Every worker must be gone within a few TTLs;
+    // the generous deadline keeps slow CI from flaking, not the assertion from biting.
+    for _ in 0..100 {
+        if builder.resident_chain_workers(0).await == 0 {
+            return Ok(());
+        }
+        builder
+            .clock()
+            .add(linera_base::data_types::TimeDelta::from_millis(100));
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
+    }
+    panic!(
+        "{} chain workers still resident 10s after the last activity, with a TTL of 500ms — \
+         something in the export path is touching them",
+        builder.resident_chain_workers(0).await,
+    );
+}
+
+/// A validator that has fallen behind its cursor reports its own height, which is what lets the
+/// queue notice a regression.
+///
+/// A validator restored from a backup is *behind* where we last saw it. The queue's cursor is
+/// only corrected because a send above that cursor comes back carrying the validator's real
+/// height rather than the one we assumed — this asserts that reporting, which
+/// `on_done` then follows downwards.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_send_block_reports_the_destinations_own_height<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    use crate::remote_node::RemoteNode;
+
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    // Validator 3 misses everything, so its real height stays far below the others'.
+    builder.set_fault_type([3], FaultType::Offline);
+    for _ in 0..4 {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+    let tip = sender.chain_info().await?.next_block_height;
+    builder.set_fault_type([3], FaultType::Honest);
+    assert_eq!(builder.next_block_height(3, chain_id).await, BlockHeight(0));
+
+    let storage = builder.validator_storage(0);
+    let node = builder.node(3);
+    let mut sender_task = crate::chain_worker::export::BlockSender {
+        remote_node: RemoteNode {
+            public_key: node.name(),
+            node,
+        },
+        storage,
+        certificate_upload_batch_size: 100,
+    };
+
+    // Ask with no cursor at all — the state a failed send leaves behind. One bounded round must
+    // come back with what the validator actually holds, so the queue can act on the truth.
+    let reached = sender_task
+        .send_missing_blocks(chain_id, tip, None, 2)
+        .await?;
+    assert_eq!(
+        reached,
+        BlockHeight(2),
+        "a bounded round must report the validator's own height afterwards",
+    );
     Ok(())
 }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -917,12 +917,107 @@ impl<B> TestBuilder<B>
 where
     B: StorageBuilder,
 {
+    /// The simulated clock every storage here shares, so a test can drive the export queue's
+    /// tick in virtual time instead of sleeping through it.
+    pub fn clock(&self) -> &TestClock {
+        self.storage_builder.clock()
+    }
+
     /// Creates a test setup with `count` validators, `with_faulty_validators` of which are faulty.
     pub async fn new(
+        storage_builder: B,
+        count: usize,
+        with_faulty_validators: usize,
+        signer: TestSigner,
+    ) -> Result<Self, anyhow::Error> {
+        Self::build(
+            storage_builder,
+            count,
+            with_faulty_validators,
+            signer,
+            None,
+            None,
+        )
+        .await
+    }
+
+    /// Creates a test setup like [`TestBuilder::new`], in which every validator also pushes the
+    /// blocks it executes to the rest of the committee.
+    pub async fn new_with_block_export(
+        storage_builder: B,
+        count: usize,
+        with_faulty_validators: usize,
+        signer: TestSigner,
+    ) -> Result<Self, anyhow::Error> {
+        Self::build(
+            storage_builder,
+            count,
+            with_faulty_validators,
+            signer,
+            Some(Self::test_block_export_config()),
+            None,
+        )
+        .await
+    }
+
+    /// Creates a test setup like [`TestBuilder::new_with_block_export`] with an explicit chain
+    /// worker TTL, for asserting that workers expire even while export is enabled.
+    pub async fn new_with_block_export_and_ttl(
+        storage_builder: B,
+        count: usize,
+        with_faulty_validators: usize,
+        signer: TestSigner,
+        chain_worker_ttl: Duration,
+    ) -> Result<Self, anyhow::Error> {
+        Self::build(
+            storage_builder,
+            count,
+            with_faulty_validators,
+            signer,
+            Some(Self::test_block_export_config()),
+            Some(chain_worker_ttl),
+        )
+        .await
+    }
+
+    /// Creates a test setup like [`TestBuilder::new_with_block_export`], with the export tuned by
+    /// the caller. Used to shrink `max_catch_up_blocks` far below its default so that a backlog a
+    /// test can actually produce still takes several rounds to drain.
+    pub async fn new_with_block_export_config(
+        storage_builder: B,
+        count: usize,
+        with_faulty_validators: usize,
+        signer: TestSigner,
+        config: crate::BlockExportConfig,
+    ) -> Result<Self, anyhow::Error> {
+        Self::build(
+            storage_builder,
+            count,
+            with_faulty_validators,
+            signer,
+            Some(config),
+            None,
+        )
+        .await
+    }
+
+    /// The export settings the block-export tests run with: production backoff is measured in
+    /// seconds, which would make every test that exercises a failing destination wait it out.
+    pub fn test_block_export_config() -> crate::BlockExportConfig {
+        crate::BlockExportConfig {
+            retry_delay: Duration::from_millis(20),
+            max_retry_delay: Duration::from_millis(200),
+            ..crate::BlockExportConfig::default()
+        }
+    }
+
+    async fn build(
         mut storage_builder: B,
         count: usize,
         with_faulty_validators: usize,
         mut signer: TestSigner,
+        block_export: Option<crate::BlockExportConfig>,
+        chain_worker_ttl: Option<Duration>,
     ) -> Result<Self, anyhow::Error> {
         let mut validators = Vec::new();
         for _ in 0..count {
@@ -935,7 +1030,9 @@ where
             .map(|(validating, account)| (validating.public_key, *account))
             .collect::<Vec<_>>();
         let initial_committee = Committee::make_simple(for_committee);
-        let mut validator_clients = Vec::new();
+        // Created up front and filled in below, so that each validator's export tasks can resolve
+        // the others through it even though those clients do not exist yet.
+        let node_provider = NodeProvider(Arc::new(std::sync::Mutex::new(Vec::new())));
         let mut validator_storages = HashMap::new();
         let mut validator_key_pairs = HashMap::new();
         let mut faulty_validators = HashSet::new();
@@ -945,16 +1042,31 @@ where
             let secret_key_copy = validator_keypair.secret_key.copy();
             let config = ChainWorkerConfig {
                 nickname: format!("Node {i}"),
+                // Export folds progress into the chain state when the worker next saves, so
+                // give workers a lifetime instead of dropping them after every request, and fold
+                // unthrottled so assertions see progress as it happens.
+                ttl: chain_worker_ttl
+                    .or_else(|| block_export.is_some().then(|| Duration::from_secs(60))),
+                exported_heights_fold_interval: Duration::ZERO,
                 ..ChainWorkerConfig::default()
             }
             .with_key_pair(Some(validator_keypair.secret_key));
-            let state = WorkerState::new(storage.clone(), config, None);
+            let mut state = WorkerState::new(storage.clone(), config, None);
+            if let Some(export_config) = block_export.clone() {
+                let handle = crate::spawn_block_export_queue(
+                    storage.clone(),
+                    Arc::new(node_provider.clone()),
+                    export_config,
+                    Some(validator_public_key),
+                );
+                state = state.with_block_export(handle);
+            }
             let mut validator = LocalValidatorClient::new(validator_public_key, state);
             if i < with_faulty_validators {
                 faulty_validators.insert(validator_public_key);
                 validator.set_fault_type(FaultType::NoChains);
             }
-            validator_clients.push(validator);
+            node_provider.0.lock().unwrap().push(validator);
             validator_storages.insert(validator_public_key, storage);
             validator_key_pairs.insert(validator_public_key, secret_key_copy);
         }
@@ -968,7 +1080,7 @@ where
             admin_description: None,
             network_description: None,
             genesis_storage_builder: GenesisStorageBuilder::default(),
-            node_provider: NodeProvider::from_iter(validator_clients),
+            node_provider,
             validator_storages,
             validator_key_pairs,
             chain_client_storages: Vec::new(),
@@ -1136,6 +1248,13 @@ where
         self.node_provider.clone()
     }
 
+    /// Returns the storage of the validator at `index`, which holds every block that validator
+    /// has processed.
+    pub fn validator_storage(&mut self, index: usize) -> B::Storage {
+        let public_key = self.node(index).public_key;
+        self.validator_storages.get(&public_key).unwrap().clone()
+    }
+
     /// Returns a clone of the validator client at the given index.
     pub fn node(&mut self, index: usize) -> LocalValidatorClient<B::Storage> {
         self.node_provider.0.lock().unwrap()[index].clone()
@@ -1281,6 +1400,36 @@ where
             }
         }
         assert!(count >= target_count);
+    }
+
+    /// Returns how far the validator at `index` believes it has exported the given chain to each
+    /// of the other validators.
+    pub async fn exported_heights(
+        &self,
+        index: usize,
+        chain_id: ChainId,
+    ) -> BTreeMap<ValidatorPublicKey, BlockHeight> {
+        let validator = self.node_provider.all_nodes()[index].clone();
+        let guard = validator.client.lock().await;
+        let chain = guard.state.chain_state_view(chain_id).await.unwrap();
+        chain.exported_heights.get().clone().into()
+    }
+
+    /// Returns how many chain workers the validator at `index` currently has resident.
+    pub async fn resident_chain_workers(&self, index: usize) -> usize {
+        let validator = self.node_provider.all_nodes()[index].clone();
+        let guard = validator.client.lock().await;
+        guard.state.resident_chain_worker_count()
+    }
+
+    /// Returns the next block height the validator at `index` has for the given chain.
+    pub async fn next_block_height(&self, index: usize, chain_id: ChainId) -> BlockHeight {
+        let validator = self.node_provider.all_nodes()[index].clone();
+        let response = validator
+            .handle_chain_info_query(ChainInfoQuery::new(chain_id))
+            .await
+            .unwrap();
+        response.info.next_block_height
     }
 
     /// Panics if any validator has a nonempty outbox for the given chain.

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -31,7 +31,6 @@ use tracing::{instrument, Level};
 use crate::{
     client::chain_client,
     data_types::{ChainInfo, ChainInfoQuery},
-    environment::Environment,
     local_node::LocalNodeClient,
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
     remote_node::RemoteNode,
@@ -134,17 +133,17 @@ impl CommunicateAction {
 /// node must not mutate the client's own state. When a validator turns out to be *ahead* of the
 /// local node, the updater signals that with [`chain_client::Error::LocalNodeLagging`] and lets
 /// the caller decide whether to pull the missing state.
-pub struct RemoteNodeUpdater<Env>
+pub struct RemoteNodeUpdater<S, N>
 where
-    Env: Environment,
+    S: Storage,
 {
-    pub remote_node: RemoteNode<Env::ValidatorNode>,
-    pub local_node: LocalNodeClient<Env::Storage>,
+    pub remote_node: RemoteNode<N>,
+    pub local_node: LocalNodeClient<S>,
     pub admin_chain_id: ChainId,
     pub certificate_upload_batch_size: usize,
 }
 
-impl<Env: Environment> Clone for RemoteNodeUpdater<Env> {
+impl<S: Storage + Clone, N: Clone> Clone for RemoteNodeUpdater<S, N> {
     fn clone(&self) -> Self {
         RemoteNodeUpdater {
             remote_node: self.remote_node.clone(),
@@ -315,9 +314,10 @@ where
     })
 }
 
-impl<Env> RemoteNodeUpdater<Env>
+impl<S, N> RemoteNodeUpdater<S, N>
 where
-    Env: Environment + 'static,
+    S: Storage + Clone + 'static,
+    N: ValidatorNode + Clone + 'static,
 {
     /// Logs a warning if the error is not an expected part of the protocol flow.
     fn warn_if_unexpected(&self, err: &NodeError) {
@@ -334,6 +334,7 @@ where
         level = "trace", skip_all, err(level = Level::DEBUG),
         fields(chain_id = %certificate.block().header.chain_id)
     )]
+    /// Sends a single confirmed certificate, uploading its missing dependencies and retrying.
     async fn send_confirmed_certificate(
         &mut self,
         certificate: &CacheArc<ConfirmedBlockCertificate>,
@@ -370,7 +371,7 @@ where
                     let blobs = maybe_blobs.ok_or(NodeError::BlobsNotFound(blob_ids))?;
                     self.remote_node
                         .node
-                        .upload_blobs(blobs.into_iter().map(|b| b.into_std()).collect())
+                        .upload_blobs(blobs.into_iter().map(CacheArc::into_std).collect())
                         .await?;
                     sent_blobs = true;
                 }
@@ -766,9 +767,11 @@ where
 
     async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
         let local_admin_info = self.local_node.chain_info(self.admin_chain_id).await?;
+        let admin_chain_id = self.admin_chain_id;
+        let target = local_admin_info.next_block_height;
         Box::pin(self.send_chain_information(
-            self.admin_chain_id,
-            local_admin_info.next_block_height,
+            admin_chain_id,
+            target,
             CrossChainMessageDelivery::NonBlocking,
             None,
         ))

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -65,8 +65,8 @@ impl<S: Storage> std::ops::Deref for ChainStateViewReadGuard<S> {
 pub(crate) use crate::chain_worker::EventSubscriptionsResult;
 use crate::{
     chain_worker::{
-        handle, state::ChainWorkerState, BlockOutcome, ChainWorkerConfig, CrossChainUpdateResult,
-        DeliveryNotifier, ProcessConfirmedBlockMode,
+        handle, state::ChainWorkerState, BlockExportHandle, BlockOutcome, ChainWorkerConfig,
+        CrossChainUpdateResult, DeliveryNotifier, ProcessConfirmedBlockMode,
     },
     client::{ChainModes, ListeningMode},
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
@@ -703,6 +703,9 @@ pub struct WorkerState<StorageClient: Storage> {
     /// corrupted chain. The RPC server layer installs this; without it, we fall
     /// back to dispatching locally through `handle_cross_chain_request`.
     outbound_cross_chain_sender: Option<OutboundCrossChainSender>,
+    /// The process-wide export queue, installed by the server binary — the only layer that
+    /// knows how to reach another validator. `None` means blocks are not exported.
+    block_export: Option<BlockExportHandle>,
 }
 
 /// Dispatcher for outbound cross-chain requests that handles the source-shard-to-
@@ -724,6 +727,7 @@ where
             chain_workers: self.chain_workers.clone(),
             chain_batches: self.chain_batches.clone(),
             outbound_cross_chain_sender: self.outbound_cross_chain_sender.clone(),
+            block_export: self.block_export.clone(),
         }
     }
 }
@@ -925,7 +929,16 @@ where
             #[cfg_attr(web, expect(clippy::arc_with_non_send_sync))]
             chain_batches: Arc::new(papaya::HashMap::new()),
             outbound_cross_chain_sender: None,
+            block_export: None,
         }
+    }
+
+    /// Installs the process-wide block export queue. Must be called before any chain worker is
+    /// created: workers capture the handle as they load, so one created earlier would never
+    /// export.
+    pub fn with_block_export(mut self, handle: BlockExportHandle) -> Self {
+        self.block_export = Some(handle);
+        self
     }
 
     /// Installs a shard-routing dispatcher used for outbound cross-chain requests
@@ -1134,6 +1147,19 @@ where
         .forget();
     }
 
+    /// Returns how many chain workers are currently resident in memory. Used to assert that
+    /// workers expire at their TTL — a task that keeps touching one holds it forever.
+    #[cfg(with_testing)]
+    pub fn resident_chain_worker_count(&self) -> usize {
+        self.chain_workers
+            .pin()
+            .iter()
+            .filter(
+                |(_, future)| matches!(future.peek(), Some(Ok(weak)) if weak.strong_count() > 0),
+            )
+            .count()
+    }
+
     /// Evicts a poisoned chain worker from the cache, but only if the entry still
     /// points to the same instance. This avoids removing a fresh replacement that
     /// another task may have already loaded.
@@ -1310,6 +1336,7 @@ where
             chain_id,
             service_runtime_endpoint,
             service_runtime_task,
+            self.block_export.clone(),
         )
         .await?;
 

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -10,6 +10,54 @@ service NotifierService {
   rpc NotifyBatch(NotificationBatch) returns (google.protobuf.Empty);
 }
 
+// A service run by the proxy which forwards a shard's requests to another validator.
+//
+// Shards hold the validator's secret key, so the proxy is the only component that opens outbound
+// connections. A shard names the validator its request is meant for and the proxy performs it.
+// Limited to the operations block export needs, so reaching this service does not confer the
+// ability to make the proxy issue arbitrary requests.
+service ValidatorRelay {
+  // Forward a lite certificate to another validator.
+  rpc RelayLiteCertificate(RelayLiteCertificateRequest) returns (ChainInfoResult);
+
+  // Forward a confirmed certificate to another validator.
+  rpc RelayConfirmedCertificate(RelayConfirmedCertificateRequest) returns (ChainInfoResult);
+
+  // Ask another validator for the state of a chain.
+  rpc RelayChainInfoQuery(RelayChainInfoQueryRequest) returns (ChainInfoResult);
+
+  // Upload a blob to another validator.
+  rpc RelayUploadBlob(RelayUploadBlobRequest) returns (BlobId);
+}
+
+// A lite certificate, and the validator it is for.
+message RelayLiteCertificateRequest {
+  // The public network address of the destination validator.
+  string destination = 1;
+  LiteCertificate inner = 2;
+}
+
+// A confirmed certificate, and the validator it is for.
+message RelayConfirmedCertificateRequest {
+  // The public network address of the destination validator.
+  string destination = 1;
+  HandleConfirmedCertificateRequest inner = 2;
+}
+
+// A chain info query, and the validator it is for.
+message RelayChainInfoQueryRequest {
+  // The public network address of the destination validator.
+  string destination = 1;
+  ChainInfoQuery inner = 2;
+}
+
+// A blob, and the validator it is for.
+message RelayUploadBlobRequest {
+  // The public network address of the destination validator.
+  string destination = 1;
+  BlobContent inner = 2;
+}
+
 // Interface provided by each physical shard (aka "worker") of a validator or a local node.
 // * All commands return either the current chain info or an error.
 // * Repeating commands produces no changes and returns no error.

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -6,6 +6,7 @@ mod conversions;
 mod node_provider;
 /// A pool of reusable gRPC transport channels.
 pub mod pool;
+mod relay;
 #[cfg(with_server)]
 mod server;
 /// Transport-level configuration and channel construction for gRPC.
@@ -14,6 +15,7 @@ pub mod transport;
 pub use client::*;
 pub use conversions::*;
 pub use node_provider::*;
+pub use relay::{RelayClient, RelayNodeProvider};
 #[cfg(with_server)]
 pub use server::*;
 

--- a/linera-rpc/src/grpc/relay.rs
+++ b/linera-rpc/src/grpc/relay.rs
@@ -1,0 +1,360 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reaching other validators through this validator's own proxy.
+//!
+//! Shards hold the validator's secret key, so the proxy is the only component that should open
+//! outbound connections. A shard needing another validator — today, a chain worker exporting a
+//! block — sends its request to the proxy's existing internal port naming the intended validator,
+//! and the proxy performs it and returns the answer.
+//!
+//! [`RelayClient`] therefore implements [`ValidatorNode`] only for the operations block export
+//! uses; the rest are refused rather than silently doing something else. Retries are absent by
+//! design, since the export task already backs off per destination.
+
+use std::{
+    str::FromStr as _,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+use linera_base::{
+    crypto::CryptoHash,
+    data_types::{BlobContent, BlockHeight, NetworkDescription},
+    identifiers::{BlobId, ChainId, EventId},
+};
+use linera_chain::{data_types, types};
+use linera_core::node::{
+    BlobStream, CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
+    ValidatorNodeProvider,
+};
+use linera_version::VersionInfo;
+use tonic::Request;
+use tracing::{debug, instrument, Level};
+
+use super::{
+    api::{self, validator_relay_client::ValidatorRelayClient},
+    pool::GrpcConnectionPool,
+    transport, GrpcError, GRPC_MAX_MESSAGE_SIZE,
+};
+use crate::{
+    config::ValidatorPublicNetworkConfig, node_provider::NodeOptions,
+    HandleConfirmedCertificateRequest, HandleLiteCertRequest,
+};
+
+/// Refuses an operation that the relay deliberately does not carry.
+fn unsupported(operation: &str) -> NodeError {
+    NodeError::GrpcError {
+        error: format!(
+            "{operation} is not available through the validator relay, which only carries the \
+             requests needed to export blocks"
+        ),
+    }
+}
+
+/// A validator reached through this validator's proxy.
+#[derive(Clone)]
+pub struct RelayClient {
+    /// The destination validator's address as the committee spells it, e.g. `grpc:host:port`.
+    /// Kept in the committee's own form so the proxy resolves it the way any other consumer
+    /// would.
+    destination: String,
+    /// The same validator as a URL, used only to name it in logs and metrics.
+    address: String,
+    client: ValidatorRelayClient<transport::Channel>,
+}
+
+impl RelayClient {
+    /// Turns the proxy's answer into the chain info the caller expects.
+    fn try_into_chain_info(
+        result: api::ChainInfoResult,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let inner = result.inner.ok_or_else(|| NodeError::GrpcError {
+            error: "missing body from response".to_string(),
+        })?;
+        match inner {
+            api::chain_info_result::Inner::ChainInfoResponse(response) => {
+                Ok(response.try_into().map_err(|error| NodeError::GrpcError {
+                    error: format!("failed to unmarshal response: {error}"),
+                })?)
+            }
+            // bincode, matching what the validator used. Load-bearing: the recovery paths
+            // dispatch on the *variant* — `EventsNotFound` pushes the admin chain,
+            // `BlobsNotFound` uploads blobs — so a mangled error silently disables them.
+            api::chain_info_result::Inner::Error(error) => Err(bincode::deserialize(&error)
+                .map_err(|error| NodeError::GrpcError {
+                    error: format!("failed to unmarshal error message: {error}"),
+                })?),
+        }
+    }
+}
+
+impl ValidatorNode for RelayClient {
+    type NotificationStream = NotificationStream;
+
+    fn address(&self) -> String {
+        self.address.clone()
+    }
+
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.address))]
+    async fn handle_lite_certificate(
+        &self,
+        certificate: types::LiteCertificate<'_>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let inner = HandleLiteCertRequest {
+            certificate,
+            wait_for_outgoing_messages: delivery.wait_for_outgoing_messages(),
+        };
+        let request = api::RelayLiteCertificateRequest {
+            destination: self.destination.clone(),
+            inner: Some(inner.try_into()?),
+        };
+        debug!(handler = "relay_lite_certificate", "sending gRPC request");
+        let result = self
+            .client
+            .clone()
+            .relay_lite_certificate(Request::new(request))
+            .await?
+            .into_inner();
+        Self::try_into_chain_info(result)
+    }
+
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.address))]
+    async fn handle_confirmed_certificate(
+        &self,
+        certificate: linera_storage::Arc<types::ConfirmedBlockCertificate>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let inner = HandleConfirmedCertificateRequest {
+            certificate: linera_storage::Arc::unwrap_or_clone(certificate),
+            wait_for_outgoing_messages: delivery.wait_for_outgoing_messages(),
+        };
+        let request = api::RelayConfirmedCertificateRequest {
+            destination: self.destination.clone(),
+            inner: Some(inner.try_into()?),
+        };
+        debug!(
+            handler = "relay_confirmed_certificate",
+            "sending gRPC request"
+        );
+        let result = self
+            .client
+            .clone()
+            .relay_confirmed_certificate(Request::new(request))
+            .await?
+            .into_inner();
+        Self::try_into_chain_info(result)
+    }
+
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.address))]
+    async fn handle_chain_info_query(
+        &self,
+        query: linera_core::data_types::ChainInfoQuery,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let request = api::RelayChainInfoQueryRequest {
+            destination: self.destination.clone(),
+            inner: Some(query.try_into()?),
+        };
+        debug!(handler = "relay_chain_info_query", "sending gRPC request");
+        let result = self
+            .client
+            .clone()
+            .relay_chain_info_query(Request::new(request))
+            .await?
+            .into_inner();
+        Self::try_into_chain_info(result)
+    }
+
+    #[instrument(target = "relay_client", skip(self), err(level = Level::DEBUG), fields(destination = self.address))]
+    async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError> {
+        let request = api::RelayUploadBlobRequest {
+            destination: self.destination.clone(),
+            inner: Some(content.try_into()?),
+        };
+        debug!(handler = "relay_upload_blob", "sending gRPC request");
+        let blob_id = self
+            .client
+            .clone()
+            .relay_upload_blob(Request::new(request))
+            .await?
+            .into_inner();
+        Ok(blob_id.try_into()?)
+    }
+
+    async fn handle_block_proposal(
+        &self,
+        _proposal: data_types::BlockProposal,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        Err(unsupported("handle_block_proposal"))
+    }
+
+    async fn handle_validated_certificate(
+        &self,
+        _certificate: types::ValidatedBlockCertificate,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        Err(unsupported("handle_validated_certificate"))
+    }
+
+    async fn handle_timeout_certificate(
+        &self,
+        _certificate: types::GenericCertificate<types::Timeout>,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        Err(unsupported("handle_timeout_certificate"))
+    }
+
+    async fn get_version_info(&self) -> Result<VersionInfo, NodeError> {
+        Err(unsupported("get_version_info"))
+    }
+
+    async fn get_network_description(&self) -> Result<NetworkDescription, NodeError> {
+        Err(unsupported("get_network_description"))
+    }
+
+    async fn subscribe(
+        &self,
+        _chains: Vec<ChainId>,
+    ) -> Result<Self::NotificationStream, NodeError> {
+        Err(unsupported("subscribe"))
+    }
+
+    async fn download_blob(&self, _blob_id: BlobId) -> Result<BlobContent, NodeError> {
+        Err(unsupported("download_blob"))
+    }
+
+    async fn download_blobs(&self, _blob_ids: Vec<BlobId>) -> Result<BlobStream, NodeError> {
+        Err(unsupported("download_blobs"))
+    }
+
+    async fn download_pending_blob(
+        &self,
+        _chain_id: ChainId,
+        _blob_id: BlobId,
+    ) -> Result<BlobContent, NodeError> {
+        Err(unsupported("download_pending_blob"))
+    }
+
+    async fn handle_pending_blob(
+        &self,
+        _chain_id: ChainId,
+        _blob: BlobContent,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        Err(unsupported("handle_pending_blob"))
+    }
+
+    async fn download_certificate(
+        &self,
+        _hash: CryptoHash,
+    ) -> Result<types::ConfirmedBlockCertificate, NodeError> {
+        Err(unsupported("download_certificate"))
+    }
+
+    async fn download_certificates(
+        &self,
+        _hashes: Vec<CryptoHash>,
+    ) -> Result<Vec<types::ConfirmedBlockCertificate>, NodeError> {
+        Err(unsupported("download_certificates"))
+    }
+
+    async fn blob_last_used_by(&self, _blob_id: BlobId) -> Result<CryptoHash, NodeError> {
+        Err(unsupported("blob_last_used_by"))
+    }
+
+    async fn event_block_heights(
+        &self,
+        _event_ids: Vec<EventId>,
+    ) -> Result<Vec<Option<BlockHeight>>, NodeError> {
+        Err(unsupported("event_block_heights"))
+    }
+
+    async fn get_shard_info(
+        &self,
+        _chain_id: ChainId,
+    ) -> Result<linera_core::data_types::ShardInfo, NodeError> {
+        Err(unsupported("get_shard_info"))
+    }
+
+    async fn missing_blob_ids(&self, _blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
+        Err(unsupported("missing_blob_ids"))
+    }
+
+    async fn blob_last_used_by_certificate(
+        &self,
+        _blob_id: BlobId,
+    ) -> Result<types::ConfirmedBlockCertificate, NodeError> {
+        Err(unsupported("blob_last_used_by_certificate"))
+    }
+
+    async fn download_certificates_by_heights(
+        &self,
+        _chain_id: ChainId,
+        _heights: Vec<BlockHeight>,
+    ) -> Result<Vec<types::ConfirmedBlockCertificate>, NodeError> {
+        Err(unsupported("download_certificates_by_heights"))
+    }
+}
+
+/// A node provider that reaches every validator through this validator's own proxies.
+#[derive(Clone)]
+pub struct RelayNodeProvider {
+    /// The internal addresses of this validator's proxies — the same ones the shards already
+    /// send notifications to.
+    relay_addresses: Vec<String>,
+    /// Round-robin cursor over `relay_addresses`. Each request goes through exactly one proxy,
+    /// but successive nodes draw different ones so egress is spread. Shared across clones, so
+    /// every chain worker in the process uses one rotation.
+    next: Arc<AtomicUsize>,
+    pool: GrpcConnectionPool,
+}
+
+impl RelayNodeProvider {
+    /// Creates a provider that relays through the given proxies, in rotation. Panics if
+    /// `relay_addresses` is empty: a shard must not open the connection itself.
+    pub fn new(relay_addresses: Vec<String>, options: NodeOptions) -> Self {
+        assert!(
+            !relay_addresses.is_empty(),
+            "relaying to other validators needs at least one proxy",
+        );
+        Self {
+            relay_addresses,
+            next: Arc::new(AtomicUsize::new(0)),
+            pool: GrpcConnectionPool::new(transport::Options::from(&options)),
+        }
+    }
+
+    /// Returns the next proxy in the rotation.
+    fn next_relay(&self) -> &str {
+        let index = self.next.fetch_add(1, Ordering::Relaxed) % self.relay_addresses.len();
+        &self.relay_addresses[index]
+    }
+}
+
+impl ValidatorNodeProvider for RelayNodeProvider {
+    type Node = RelayClient;
+
+    fn make_node(&self, address: &str) -> Result<Self::Node, NodeError> {
+        // Parsed even though the proxy is the one that dials it, so that a malformed committee
+        // entry is rejected here rather than on every request.
+        let network = ValidatorPublicNetworkConfig::from_str(address).map_err(|_| {
+            NodeError::CannotResolveValidatorAddress {
+                address: address.to_string(),
+            }
+        })?;
+        let relay = self.next_relay();
+        let channel = self
+            .pool
+            .channel(relay.to_owned())
+            .map_err(|error: GrpcError| NodeError::GrpcError {
+                error: format!("error creating channel to the relay {relay}: {error}"),
+            })?;
+        Ok(RelayClient {
+            destination: address.to_owned(),
+            address: network.http_address(),
+            client: ValidatorRelayClient::new(channel)
+                .max_encoding_message_size(GRPC_MAX_MESSAGE_SIZE)
+                .max_decoding_message_size(GRPC_MAX_MESSAGE_SIZE),
+        })
+    }
+}

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -446,6 +446,11 @@ type ChainStateExtendedView {
 	that tracks all chains and never filters.
 	"""
 	outboxIndexTrackedHash: CryptoHash
+	"""
+	The highest block of this chain pushed to each other committee validator. A validator with
+	no entry is queried before its first push; ones that leave the committee are pruned.
+	"""
+	exportedHeights: JSONObject!
 }
 
 """

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -55,6 +55,7 @@ metrics = [
     "prometheus",
     "linera-base/metrics",
     "linera-client/metrics",
+    "linera-exporter/metrics",
     "linera-faucet-server/metrics",
     "linera-metrics",
 ]

--- a/linera-service/src/cli/net_up_utils.rs
+++ b/linera-service/src/cli/net_up_utils.rs
@@ -152,6 +152,8 @@ pub async fn handle_net_up_service(
     );
     let initial_amount = Amount::from_tokens(initial_amount);
     let config = LocalNetConfig {
+        block_export_transport: crate::config::BlockExportTransport::Relay,
+        export_blocks_to_committee: false,
         network,
         database,
         testing_prng_seed,

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -16,6 +16,7 @@ use anyhow::{anyhow, bail, ensure, Context, Result};
 #[cfg(with_testing)]
 use async_lock::RwLock;
 use async_trait::async_trait;
+use clap::ValueEnum as _;
 use linera_base::{
     command::{resolve_binary, CommandExt},
     data_types::Amount,
@@ -42,6 +43,7 @@ use crate::{
     cli_wrappers::{
         ClientWrapper, LineraNet, LineraNetConfig, Network, NetworkConfig, OnClientDrop,
     },
+    config::BlockExportTransport,
     storage::{InnerStorageConfig, StorageConfig},
     util::ChildExt,
 };
@@ -227,6 +229,12 @@ pub struct LocalNetConfig {
     /// Optional directory where the `linera`, `linera-proxy`, and `linera-server` binaries
     /// are located. If `None`, binaries are resolved from the current binary's directory.
     pub binary_dir: Option<PathBuf>,
+    /// Whether the validators push each block they execute to the rest of the committee,
+    /// through their own proxies.
+    pub export_blocks_to_committee: bool,
+    /// How exporting validators reach the others: through their own proxy, or straight from the
+    /// shards.
+    pub block_export_transport: BlockExportTransport,
 }
 
 /// The setup for the block exporters.
@@ -272,6 +280,8 @@ pub struct LocalNet {
     path_provider: PathProvider,
     block_exporters: ExportersSetup,
     binary_dir: Option<PathBuf>,
+    export_blocks_to_committee: bool,
+    block_export_transport: BlockExportTransport,
 }
 
 /// The name of the environment variable that allows specifying additional arguments to be passed
@@ -320,6 +330,20 @@ impl Validator {
 
     fn add_proxy(&mut self, proxy: Child) {
         self.proxies.push(proxy)
+    }
+
+    /// Kills one of this validator's proxies, leaving the rest running.
+    #[cfg(with_testing)]
+    async fn kill_proxy(&mut self, proxy_id: usize) -> Result<()> {
+        ensure!(
+            proxy_id < self.proxies.len(),
+            "no proxy {proxy_id} to kill; this validator runs {}",
+            self.proxies.len()
+        );
+        // Removed rather than killed in place, as `terminate_server` does: `terminate()` later
+        // kills whatever remains in the vec, and must not have to reason about dead entries.
+        let mut proxy = self.proxies.remove(proxy_id);
+        proxy.kill().await.context("killing validator proxy")
     }
 
     fn add_server(&mut self, server: Child) {
@@ -383,6 +407,8 @@ impl LocalNetConfig {
             block_exporters: ExportersSetup::Local(vec![]),
             http_request_allow_list: Some(vec!["localhost".to_string()]),
             binary_dir: None,
+            export_blocks_to_committee: false,
+            block_export_transport: BlockExportTransport::Relay,
         }
     }
 }
@@ -405,6 +431,8 @@ impl LineraNetConfig for LocalNetConfig {
             self.path_provider,
             self.block_exporters,
             self.binary_dir,
+            self.export_blocks_to_committee,
+            self.block_export_transport,
         );
         let client = net.make_client().await;
         ensure!(
@@ -482,6 +510,8 @@ impl LocalNet {
         path_provider: PathProvider,
         block_exporters: ExportersSetup,
         binary_dir: Option<PathBuf>,
+        export_blocks_to_committee: bool,
+        block_export_transport: BlockExportTransport,
     ) -> Self {
         Self {
             network,
@@ -499,6 +529,8 @@ impl LocalNet {
             path_provider,
             block_exporters,
             binary_dir,
+            export_blocks_to_committee,
+            block_export_transport,
         }
     }
 
@@ -524,15 +556,18 @@ impl LocalNet {
         test_offset_port() + validator * self.num_shards + shard + 1
     }
 
-    fn proxy_internal_port(&self, validator: usize, proxy_id: usize) -> usize {
+    /// Returns the internal port of the given proxy, which its own shards use to reach it.
+    pub fn proxy_internal_port(&self, validator: usize, proxy_id: usize) -> usize {
         test_offset_port() + 1000 + validator * self.num_proxies + proxy_id + 1
     }
 
-    fn shard_metrics_port(&self, validator: usize, shard: usize) -> usize {
+    /// Returns the metrics port of the given shard of the given validator.
+    pub fn shard_metrics_port(&self, validator: usize, shard: usize) -> usize {
         test_offset_port() + 2000 + validator * self.num_shards + shard + 1
     }
 
-    fn proxy_metrics_port(&self, validator: usize, proxy_id: usize) -> usize {
+    /// Returns the metrics port of the given proxy of the given validator.
+    pub fn proxy_metrics_port(&self, validator: usize, proxy_id: usize) -> usize {
         test_offset_port() + 3000 + validator * self.num_proxies + proxy_id + 1
     }
 
@@ -967,6 +1002,16 @@ impl LocalNet {
             .args(["--server", &format!("server_{validator}.json")])
             .args(["--shard", &shard.to_string()])
             .args(self.cross_chain_config.to_args());
+        if self.export_blocks_to_committee {
+            command.arg("--export-blocks-to-committee");
+            command.args([
+                "--block-export-transport",
+                self.block_export_transport
+                    .to_possible_value()
+                    .expect("every transport is a selectable value")
+                    .get_name(),
+            ]);
+        }
         let child = command.spawn_into()?;
 
         let port = self.shard_port(validator, shard);
@@ -1065,6 +1110,16 @@ impl LocalNet {
 
 #[cfg(with_testing)]
 impl LocalNet {
+    /// Kills one proxy of the given validator, leaving its other proxies and shards running, to
+    /// check that traffic relayed through it moves to another rather than being stranded.
+    pub async fn kill_proxy(&mut self, validator: usize, proxy_id: usize) -> Result<()> {
+        self.running_validators
+            .get_mut(&validator)
+            .context("no such validator")?
+            .kill_proxy(proxy_id)
+            .await
+    }
+
     /// Returns the validating key and an account key of the validator.
     pub fn validator_keys(&self, validator: usize) -> Option<&(String, String)> {
         self.validator_keys.get(&validator)

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -5,3 +5,19 @@ pub use linera_exporter::config::{
     BlockExporterConfig, Destination, DestinationConfig, DestinationId, DestinationKind,
     LimitsConfig,
 };
+
+/// How a shard reaches the other validators when exporting the blocks it executes.
+///
+/// A trade-off between this validator's own proxy load and keeping shards off the internet, left
+/// to the operator because relaying's cost is not predictable from the code. Neither setting
+/// changes what the *receiving* proxy absorbs, though relaying does concentrate the connections.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum BlockExportTransport {
+    /// Send through this validator's own proxy, which forwards to the destination. Shards need no
+    /// outbound access, which matters because a shard holds the validator secret key.
+    Relay,
+    /// Send straight from the shard to the destination validator's public endpoint. Takes the
+    /// sending proxy out of the path entirely, at the cost of giving shards — which hold the
+    /// validator secret key — outbound access to the other validators.
+    Direct,
+}

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -5,9 +5,11 @@
 #![allow(unknown_lints)]
 
 use std::{
+    collections::HashSet,
     fmt::Debug,
     marker::PhantomData,
     net::SocketAddr,
+    str::FromStr as _,
     sync::Arc,
     task::{Context, Poll},
     time::Duration,
@@ -16,10 +18,14 @@ use std::{
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::{future::BoxFuture, FutureExt as _};
-use linera_base::identifiers::ChainId;
+use linera_base::{
+    data_types::Epoch,
+    identifiers::{ChainId, StreamId},
+};
 use linera_core::{
     data_types::CertificatesByHeightRequest, notifier::ChannelNotifier, JoinSetExt as _,
 };
+use linera_execution::system::EPOCH_STREAM_NAME;
 #[cfg(with_metrics)]
 use linera_metrics::monitoring_server;
 #[cfg(all(with_metrics, feature = "opentelemetry"))]
@@ -27,12 +33,17 @@ use linera_rpc::propagation::get_traffic_type_from_request;
 #[cfg(feature = "opentelemetry")]
 use linera_rpc::propagation::OtelContextLayer;
 use linera_rpc::{
-    config::{ProxyConfig, ShardConfig, TlsConfig, ValidatorInternalNetworkConfig},
+    config::{
+        ProxyConfig, ShardConfig, TlsConfig, ValidatorInternalNetworkConfig,
+        ValidatorPublicNetworkConfig,
+    },
     grpc::{
         api::{
             self,
             notifier_service_server::{NotifierService, NotifierServiceServer},
+            validator_node_client::ValidatorNodeClient,
             validator_node_server::{ValidatorNode, ValidatorNodeServer},
+            validator_relay_server::{ValidatorRelay, ValidatorRelayServer},
             validator_worker_client::ValidatorWorkerClient,
             BlobContent, BlobId, BlobIds, BlockProposal, Certificate, CertificatesBatchRequest,
             CertificatesBatchResponse, ChainInfoResult, CryptoHash, HandlePendingBlobRequest,
@@ -74,6 +85,15 @@ pub(crate) mod metrics {
                 "Proxy request latency",
                 &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
                 linear_bucket_interval(1.0, 50.0, 5000.0),
+            );
+
+        /// Requests this proxy has carried to another validator on behalf of one of its shards.
+        /// Shards have no internet route, so this is what shows the traffic goes through the relay.
+        pub static RELAYED_REQUEST_COUNT: IntCounterVec =
+            register_int_counter_vec(
+                "proxy_relayed_request_count",
+                "Requests forwarded to another validator on behalf of a shard",
+                &[METHOD_NAME_LABEL],
             );
 
         pub static PROXY_REQUEST_COUNT: IntCounterVec =
@@ -202,10 +222,27 @@ pub struct GrpcProxy<S>(Arc<GrpcProxyInner<S>>);
 struct GrpcProxyInner<S> {
     internal_config: ValidatorInternalNetworkConfig,
     worker_connection_pool: GrpcConnectionPool,
+    /// Connections to the other validators, used to carry requests on behalf of this validator's
+    /// shards, which have no route to the internet of their own. Pooled, so a peer costs one
+    /// connection for the whole process rather than one per shard.
+    peer_connection_pool: GrpcConnectionPool,
     notifier: ChannelNotifier<Result<Notification, Status>>,
     tls: TlsConfig,
     storage: S,
     id: usize,
+    /// The validator addresses this proxy will relay to, and the next epoch it has yet to learn.
+    /// Without this, anything able to reach the internal port could use the proxy to dial an
+    /// arbitrary host, defeating the point of keeping shards off the internet.
+    relay_destinations: Arc<tokio::sync::RwLock<RelayDestinations>>,
+}
+
+/// Committee members seen so far, and how far the epochs have been scanned.
+#[derive(Default)]
+struct RelayDestinations {
+    addresses: HashSet<String>,
+    next_epoch: u32,
+    /// Resolved from the network description once and cached.
+    admin_chain_id: Option<ChainId>,
 }
 
 impl<S> GrpcProxy<S>
@@ -225,10 +262,14 @@ where
             worker_connection_pool: GrpcConnectionPool::default()
                 .with_connect_timeout(connect_timeout)
                 .with_timeout(timeout),
+            peer_connection_pool: GrpcConnectionPool::default()
+                .with_connect_timeout(connect_timeout)
+                .with_timeout(timeout),
             notifier: ChannelNotifier::default(),
             tls,
             storage,
             id,
+            relay_destinations: Arc::default(),
         }))
     }
 
@@ -248,6 +289,142 @@ where
 
     fn as_notifier_service(&self) -> NotifierServiceServer<Self> {
         NotifierServiceServer::new(self.clone())
+    }
+
+    fn as_validator_relay(&self) -> ValidatorRelayServer<Self> {
+        ValidatorRelayServer::new(self.clone())
+            .max_encoding_message_size(GRPC_MAX_MESSAGE_SIZE)
+            .max_decoding_message_size(GRPC_MAX_MESSAGE_SIZE)
+    }
+
+    /// Whether this proxy will relay to `address`, i.e. whether it belongs to a validator in any
+    /// committee it can see. Epochs are scanned forward from the last scan, so a validator
+    /// admitted after startup is picked up on the first request naming it.
+    ///
+    /// `Err` means the scan itself failed and says nothing about the address, so the caller must
+    /// answer "try again", not "refused".
+    async fn is_relay_destination(&self, address: &str) -> Result<bool, anyhow::Error> {
+        let (known, start, admin_chain_id) = {
+            let destinations = self.0.relay_destinations.read().await;
+            (
+                destinations.addresses.contains(address),
+                destinations.next_epoch,
+                destinations.admin_chain_id,
+            )
+        };
+        if known {
+            return Ok(true);
+        }
+        let admin_chain_id = match admin_chain_id {
+            Some(admin_chain_id) => admin_chain_id,
+            None => match self.0.storage.read_network_description().await? {
+                Some(description) => description.admin_chain_id,
+                None => return Ok(false),
+            },
+        };
+
+        // The events are listed in one bulk read from the frontier, outside any lock — so holes
+        // in the admin history are simply absent from the list rather than wedging a probe, and
+        // termination is the end of the list, not a heuristic. A committee lists the full
+        // validator set, so an epoch that stays unloadable is covered by any later one.
+        let events = self
+            .0
+            .storage
+            .read_events_from_index(
+                &admin_chain_id,
+                &StreamId::system(EPOCH_STREAM_NAME),
+                start.max(1),
+            )
+            .await?;
+        let mut found = Vec::new();
+        let mut scanned_to = start;
+        if start == 0 {
+            // Epoch 0 comes from the genesis blob, not an event. The frontier only moves past it
+            // once it has actually loaded: on a network that has never changed epochs it is the
+            // only committee there is, so burning past it would refuse every validator forever.
+            if let Some(committee) = self.0.storage.committee_for_epoch(Epoch(0)).await? {
+                found.extend(
+                    committee
+                        .validator_addresses()
+                        .map(|(_, address)| address.to_owned()),
+                );
+                scanned_to = 1;
+            }
+        }
+        for event in events {
+            let loaded = match self
+                .0
+                .storage
+                .committee_for_epoch(Epoch(event.index))
+                .await?
+            {
+                Some(committee) => {
+                    found.extend(
+                        committee
+                            .validator_addresses()
+                            .map(|(_, address)| address.to_owned()),
+                    );
+                    true
+                }
+                None => false,
+            };
+            // The frontier moves past an epoch we could not load — any validator still in the
+            // committee reappears in a later one, so its members are not lost — except when it
+            // is the newest we know of: there is no later committee to carry them, so leave the
+            // frontier on it and pick it up when it becomes loadable.
+            scanned_to = if loaded {
+                scanned_to.max(event.index.saturating_add(1))
+            } else {
+                scanned_to.max(event.index)
+            };
+        }
+
+        let mut destinations = self.0.relay_destinations.write().await;
+        destinations.admin_chain_id = Some(admin_chain_id);
+        destinations.addresses.extend(found);
+        destinations.next_epoch = destinations.next_epoch.max(scanned_to);
+        Ok(destinations.addresses.contains(address))
+    }
+
+    /// Returns a client for the validator a relayed request names. Requests are forwarded as they
+    /// arrived, without decoding into Rust types: the proxy carries the shard's request.
+    async fn peer(
+        &self,
+        destination: &str,
+        #[cfg_attr(not(with_metrics), allow(unused_variables))] method: &str,
+    ) -> Result<ValidatorNodeClient<Channel>, Status> {
+        let network = ValidatorPublicNetworkConfig::from_str(destination).map_err(|_| {
+            Status::invalid_argument(format!("invalid destination validator: {destination}"))
+        })?;
+        match self.is_relay_destination(destination).await {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err(Status::permission_denied(format!(
+                    "refusing to relay to {destination}: not a member of any known committee"
+                )));
+            }
+            // A scan failure says nothing about the destination; refusing here would disguise a
+            // storage problem as an authorization decision.
+            Err(error) => {
+                return Err(Status::unavailable(format!(
+                    "cannot verify the relay destination {destination} right now: {error}"
+                )));
+            }
+        }
+        // Counted only once the destination is accepted, so the metric measures relayed traffic
+        // rather than rejected attempts.
+        #[cfg(with_metrics)]
+        metrics::RELAYED_REQUEST_COUNT
+            .with_label_values(&[method])
+            .inc();
+        let channel = self
+            .0
+            .peer_connection_pool
+            .channel(network.http_address())
+            .map_err(|error| Status::unavailable(format!("cannot reach {destination}: {error}")))?;
+        Ok(ValidatorNodeClient::new(channel)
+            .max_encoding_message_size(GRPC_MAX_MESSAGE_SIZE)
+            .max_decoding_message_size(GRPC_MAX_MESSAGE_SIZE))
     }
 
     fn public_address(&self) -> SocketAddr {
@@ -324,6 +501,7 @@ where
         let internal_server = join_set.spawn_task(
             Server::builder()
                 .add_service(self.as_notifier_service())
+                .add_service(self.as_validator_relay())
                 .serve(self.internal_address())
                 .in_current_span(),
         );
@@ -867,6 +1045,75 @@ where
             .await
             .map_err(Self::view_error_to_status)?;
         Ok(Response::new(heights.into()))
+    }
+}
+
+/// Performs, on behalf of this validator's shards, the requests they must send to other
+/// validators, returning each answer verbatim — including the peer's errors, which export depends
+/// on. Served only on the internal listener, limited to the four requests block export makes.
+#[async_trait]
+impl<S> ValidatorRelay for GrpcProxy<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    #[instrument(skip_all, err(Display), fields(method = "relay_lite_certificate"))]
+    async fn relay_lite_certificate(
+        &self,
+        request: Request<api::RelayLiteCertificateRequest>,
+    ) -> Result<Response<ChainInfoResult>, Status> {
+        let request = request.into_inner();
+        let inner = request
+            .inner
+            .ok_or_else(|| Status::invalid_argument("missing lite certificate"))?;
+        self.peer(&request.destination, "relay_lite_certificate")
+            .await?
+            .handle_lite_certificate(Request::new(inner))
+            .await
+    }
+
+    #[instrument(skip_all, err(Display), fields(method = "relay_confirmed_certificate"))]
+    async fn relay_confirmed_certificate(
+        &self,
+        request: Request<api::RelayConfirmedCertificateRequest>,
+    ) -> Result<Response<ChainInfoResult>, Status> {
+        let request = request.into_inner();
+        let inner = request
+            .inner
+            .ok_or_else(|| Status::invalid_argument("missing confirmed certificate"))?;
+        self.peer(&request.destination, "relay_confirmed_certificate")
+            .await?
+            .handle_confirmed_certificate(Request::new(inner))
+            .await
+    }
+
+    #[instrument(skip_all, err(Display), fields(method = "relay_chain_info_query"))]
+    async fn relay_chain_info_query(
+        &self,
+        request: Request<api::RelayChainInfoQueryRequest>,
+    ) -> Result<Response<ChainInfoResult>, Status> {
+        let request = request.into_inner();
+        let inner = request
+            .inner
+            .ok_or_else(|| Status::invalid_argument("missing chain info query"))?;
+        self.peer(&request.destination, "relay_chain_info_query")
+            .await?
+            .handle_chain_info_query(Request::new(inner))
+            .await
+    }
+
+    #[instrument(skip_all, err(Display), fields(method = "relay_upload_blob"))]
+    async fn relay_upload_blob(
+        &self,
+        request: Request<api::RelayUploadBlobRequest>,
+    ) -> Result<Response<api::BlobId>, Status> {
+        let request = request.into_inner();
+        let inner = request
+            .inner
+            .ok_or_else(|| Status::invalid_argument("missing blob"))?;
+        self.peer(&request.destination, "relay_upload_blob")
+            .await?
+            .upload_blob(Request::new(inner))
+            .await
     }
 }
 

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -33,7 +33,8 @@ use linera_base::{
 };
 use linera_client::config::{CommitteeConfig, ValidatorConfig, ValidatorServerConfig};
 use linera_core::{
-    worker::WorkerState, ChainWorkerConfig, JoinSetExt as _, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
+    spawn_block_export_queue, worker::WorkerState, BlockExportConfig, BlockExportHandle,
+    ChainWorkerConfig, JoinSetExt as _, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 use linera_execution::{WasmRuntime, WithWasmDefault};
 #[cfg(with_metrics)]
@@ -45,10 +46,11 @@ use linera_rpc::{
         ShardConfig, ShardId, TlsConfig, ValidatorInternalNetworkConfig,
         ValidatorPublicNetworkConfig,
     },
-    grpc, simple,
+    grpc, simple, NodeOptions,
 };
 use linera_sdk::linera_base_types::{AccountSecretKey, ValidatorKeypair};
 use linera_service::{
+    config::BlockExportTransport,
     storage::{CommonStorageOptions, Runnable, StorageConfig},
     util,
 };
@@ -73,6 +75,12 @@ struct ServerContext {
     allow_revert_confirm: bool,
     reset_on_corrupted_chain_state_mins: Option<u64>,
     recovery_whitelist: Option<HashSet<ChainId>>,
+    /// How to push executed blocks to the other committee validators, or `None` to not push them.
+    block_export_config: Option<BlockExportConfig>,
+    /// The transport options for the connections block export makes.
+    block_export_node_options: NodeOptions,
+    /// How block export reaches the other validators.
+    block_export_transport: BlockExportTransport,
     #[cfg(with_metrics)]
     enable_memory_profiling: bool,
 }
@@ -83,6 +91,7 @@ impl ServerContext {
         local_ip_addr: &str,
         shard_id: ShardId,
         storage: S,
+        block_export: Option<BlockExportHandle>,
     ) -> (WorkerState<S>, ShardId, ShardConfig)
     where
         S: Storage + Clone + Send + Sync + 'static,
@@ -111,8 +120,58 @@ impl ServerContext {
             recovery_whitelist: self.recovery_whitelist.clone(),
             ..ChainWorkerConfig::default()
         };
-        let state = WorkerState::new(storage, config, None);
+        let mut state = WorkerState::new(storage, config, None);
+        if let Some(handle) = block_export {
+            state = state.with_block_export(handle);
+        }
         (state, shard_id, shard.clone())
+    }
+
+    /// Spawns the process-wide block export queue, if export is enabled. One per process: every
+    /// shard in it hands blocks to the same queue, so a peer costs one connection pool and one
+    /// rate-limit window rather than one per shard.
+    fn spawn_block_export<S>(&self, storage: S) -> Option<BlockExportHandle>
+    where
+        S: Storage + Clone + Send + Sync + 'static,
+    {
+        let export_config = self.block_export_config.clone()?;
+        let own_public_key = self.server_config.validator_secret.public();
+        let node_options = self.block_export_node_options;
+        // Both arms get the destination's committee address and differ only in who dials it. In
+        // neither do the retry fields of `node_options` take effect — the relay pool drops them,
+        // the direct provider gets zeros — because retrying is the export queue's job.
+        let handle = match self.block_export_transport {
+            BlockExportTransport::Relay => {
+                let internal_network = &self.server_config.internal_network;
+                // All of this validator's proxies, rotated over by the provider: each export
+                // leaves through exactly one of them, but successive destinations draw different
+                // ones so the egress is spread rather than landing entirely on the first.
+                let relay_addresses = internal_network
+                    .proxies
+                    .iter()
+                    .map(|proxy| proxy.internal_address(&internal_network.protocol))
+                    .collect::<Vec<_>>();
+                assert!(
+                    !relay_addresses.is_empty(),
+                    "relaying exported blocks needs at least one proxy to relay through, but this \
+                     validator's internal network configures none; use \
+                     `--block-export-transport direct` to send without a proxy",
+                );
+                spawn_block_export_queue(
+                    storage,
+                    Arc::new(grpc::RelayNodeProvider::new(relay_addresses, node_options)),
+                    export_config,
+                    Some(own_public_key),
+                )
+            }
+            BlockExportTransport::Direct => spawn_block_export_queue(
+                storage,
+                Arc::new(linera_rpc::NodeProvider::new(node_options)),
+                export_config,
+                Some(own_public_key),
+            ),
+        };
+        Some(handle)
     }
 
     #[cfg_attr(not(with_metrics), allow(unused_variables))]
@@ -257,17 +316,27 @@ impl Runnable for ServerContext {
         #[cfg(not(with_metrics))]
         let enable_memory_profiling = false;
 
+        // One export queue per process, shared by every shard this process runs.
+        let block_export = self.spawn_block_export(storage.clone());
+
         // Run the server
         let states = match self.shard {
             Some(shard) => {
                 info!("Running shard number {}", shard);
-                vec![self.make_shard_state(&listen_address, shard, storage)]
+                vec![self.make_shard_state(&listen_address, shard, storage, block_export)]
             }
             None => {
                 info!("Running all shards");
                 let num_shards = self.server_config.internal_network.shards.len();
                 (0..num_shards)
-                    .map(|shard| self.make_shard_state(&listen_address, shard, storage.clone()))
+                    .map(|shard| {
+                        self.make_shard_state(
+                            &listen_address,
+                            shard,
+                            storage.clone(),
+                            block_export.clone(),
+                        )
+                    })
                     .collect()
             }
         };
@@ -501,6 +570,107 @@ enum ServerCommand {
         #[arg(long, value_delimiter = ',')]
         recovery_whitelist: Option<Vec<ChainId>>,
 
+        /// Push each block this validator executes to the other committee validators, so every
+        /// validator holds every chain rather than only the quorum that signed each block.
+        #[arg(
+            long,
+            default_value_t = false,
+            env = "LINERA_EXPORT_BLOCKS_TO_COMMITTEE"
+        )]
+        export_blocks_to_committee: bool,
+
+        /// How exported blocks reach the other validators: relayed through this validator's own
+        /// proxy, or sent straight from the shards. Relaying keeps shards off the internet;
+        /// sending directly removes the proxy from the path if relaying proves too expensive.
+        #[arg(
+            long,
+            value_enum,
+            default_value_t = BlockExportTransport::Relay,
+            env = "LINERA_BLOCK_EXPORT_TRANSPORT"
+        )]
+        block_export_transport: BlockExportTransport,
+
+        /// How many certificates are read from storage and pushed per batch when a block export
+        /// has to catch a lagging validator up. Only used with `--export-blocks-to-committee`.
+        #[arg(long, default_value_t = BlockExportConfig::default().certificate_upload_batch_size)]
+        block_export_batch_size: u64,
+
+        /// How many missing blocks block export pushes to one validator per round. Bounds how
+        /// long a freshly-joined validator's backfill can delay a live block.
+        #[arg(long, default_value_t = BlockExportConfig::default().max_catch_up_blocks)]
+        block_export_max_catch_up_blocks: u64,
+
+        /// How many blocks the export queue holds; a full queue drops blocks for catch-up to
+        /// re-send from storage.
+        #[arg(long, default_value_t = BlockExportConfig::default().queue_size)]
+        block_export_queue_size: usize,
+
+        /// The most blob payload bytes queued blocks may pin; past it blocks are dropped for
+        /// catch-up to re-send from storage.
+        #[arg(long, default_value_t = BlockExportConfig::default().queue_bytes)]
+        block_export_queue_bytes: usize,
+
+        /// The most concurrent sends to one destination validator. Export backs off from this
+        /// ceiling on its own when a destination slows down or fails.
+        #[arg(long, default_value_t = BlockExportConfig::default().max_in_flight_per_destination)]
+        block_export_max_in_flight: usize,
+
+        /// The most concurrent sends across all destinations. Each one can read up to
+        /// `--block-export-max-catch-up-blocks` certificates, so this is what bounds the load
+        /// catch-up puts on storage; export halves it whenever a read fails.
+        #[arg(long, default_value_t = BlockExportConfig::default().max_in_flight_total)]
+        block_export_max_in_flight_total: usize,
+
+        /// How long export remembers a fully caught-up chain before dropping its bookkeeping.
+        #[arg(
+            long = "block-export-converged-retention-ms",
+            default_value = "300000",
+            value_parser = util::parse_millis
+        )]
+        block_export_converged_retention: Duration,
+
+        /// How long block export waits for a new block before spending a round backfilling
+        /// validators that are behind. With the catch-up bound, this sets the backfill rate.
+        #[arg(
+            long = "block-export-idle-interval-ms",
+            default_value = "200",
+            value_parser = util::parse_millis
+        )]
+        block_export_idle_interval: Duration,
+
+        /// How long block export skips a validator after a failed push, doubling up to
+        /// `--block-export-max-retry-delay-ms` while it keeps failing.
+        #[arg(
+            long = "block-export-retry-delay-ms",
+            default_value = "1000",
+            value_parser = util::parse_millis
+        )]
+        block_export_retry_delay: Duration,
+
+        /// The longest block export skips a failing validator for.
+        #[arg(
+            long = "block-export-max-retry-delay-ms",
+            default_value = "60000",
+            value_parser = util::parse_millis
+        )]
+        block_export_max_retry_delay: Duration,
+
+        /// How long block export waits to open a connection to one of this validator's proxies.
+        #[arg(
+            long = "block-export-send-timeout-ms",
+            default_value = "4000",
+            value_parser = util::parse_millis
+        )]
+        block_export_send_timeout: Duration,
+
+        /// How long block export waits for a proxy to answer a relayed request.
+        #[arg(
+            long = "block-export-recv-timeout-ms",
+            default_value = "4000",
+            value_parser = util::parse_millis
+        )]
+        block_export_recv_timeout: Duration,
+
         /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
         #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
         otlp_exporter_endpoint: Option<String>,
@@ -637,6 +807,20 @@ async fn run(options: ServerOptions) {
             allow_revert_confirm,
             reset_on_corrupted_chain_state_mins,
             recovery_whitelist,
+            export_blocks_to_committee,
+            block_export_transport,
+            block_export_batch_size,
+            block_export_max_catch_up_blocks,
+            block_export_queue_size,
+            block_export_queue_bytes,
+            block_export_max_in_flight,
+            block_export_max_in_flight_total,
+            block_export_converged_retention,
+            block_export_idle_interval,
+            block_export_retry_delay,
+            block_export_max_retry_delay,
+            block_export_send_timeout,
+            block_export_recv_timeout,
             otlp_exporter_endpoint: _,
         } => {
             linera_version::VERSION_INFO.log();
@@ -659,6 +843,28 @@ async fn run(options: ServerOptions) {
                 allow_revert_confirm,
                 reset_on_corrupted_chain_state_mins,
                 recovery_whitelist: recovery_whitelist.map(HashSet::from_iter),
+                block_export_config: export_blocks_to_committee.then(|| {
+                    let config = BlockExportConfig {
+                        certificate_upload_batch_size: block_export_batch_size,
+                        queue_size: block_export_queue_size,
+                        queue_bytes: block_export_queue_bytes,
+                        max_in_flight_per_destination: block_export_max_in_flight,
+                        max_in_flight_total: block_export_max_in_flight_total,
+                        max_catch_up_blocks: block_export_max_catch_up_blocks,
+                        idle_catch_up_interval: block_export_idle_interval,
+                        retry_delay: block_export_retry_delay,
+                        max_retry_delay: block_export_max_retry_delay,
+                        converged_chain_retention: block_export_converged_retention,
+                    };
+                    config.check().expect("invalid block export configuration");
+                    config
+                }),
+                block_export_transport,
+                block_export_node_options: NodeOptions {
+                    send_timeout: block_export_send_timeout,
+                    recv_timeout: block_export_recv_timeout,
+                    ..NodeOptions::default()
+                },
                 #[cfg(with_metrics)]
                 enable_memory_profiling,
             };

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -1,0 +1,483 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end coverage of in-worker block export over a real network.
+//!
+//! The `linera-core` unit tests drive the export task against in-process validators, so they say
+//! nothing about the transport. This covers what they cannot: real shards, proxies and gRPC.
+//!
+//! ```text
+//! cargo test -p linera-service --test block_export_tests --features storage-service,metrics \
+//!     -- --ignored
+//! ```
+//!
+//! `metrics` is required because the assertions read the proxies' metrics endpoint, and `cargo
+//! test` rebuilds the spawned binaries with whatever features the command names. Each test takes
+//! `INTEGRATION_TEST_GUARD`: every network derives its ports from the same `test_offset_port()`.
+
+#![cfg(any(feature = "scylladb", feature = "storage-service"))]
+
+mod guard;
+
+use anyhow::{Context as _, Result};
+use guard::INTEGRATION_TEST_GUARD;
+use linera_base::time::Duration;
+use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
+use linera_rpc::grpc::api::{self, validator_relay_client::ValidatorRelayClient};
+use linera_service::{
+    cli_wrappers::{
+        local_net::{Database, LocalNet, LocalNetConfig},
+        LineraNet, LineraNetConfig, Network,
+    },
+    config::BlockExportTransport,
+    test_name,
+};
+use test_case::test_case;
+
+/// Requests the proxy of `validator` reports carrying to other validators for its shards. Worth
+/// asserting on because the client talks to every validator anyway, so the blocks arriving prove
+/// nothing about the path they took.
+async fn relayed_requests(net: &LocalNet, validator: usize) -> Result<u64> {
+    let port = net.proxy_metrics_port(validator, 0);
+    let metrics = reqwest::get(format!("http://127.0.0.1:{port}/metrics"))
+        .await?
+        .text()
+        .await?;
+    // The scrape itself must have worked: an empty or non-Prometheus body would otherwise make
+    // every count read as zero — exactly what the direct-transport test asserts, for the wrong
+    // reason. A silent *rename* of the counter is indistinguishable from "never incremented"
+    // here, which is why `test_block_export_through_the_proxy` asserts the same counter is
+    // nonzero: the pair fails loudly if the name rots.
+    anyhow::ensure!(
+        metrics.lines().any(|line| line.starts_with("# TYPE")),
+        "the metrics scrape of validator {validator} returned no Prometheus payload",
+    );
+    let mut total = 0;
+    for line in metrics.lines() {
+        // e.g. `linera_proxy_relayed_request_count{method_name="relay_confirmed_certificate"} 7`
+        if line.starts_with('#') || !line.contains("proxy_relayed_request_count") {
+            continue;
+        }
+        let value = line
+            .rsplit(' ')
+            .next()
+            .expect("rsplit yields at least one piece");
+        total += value
+            .parse::<u64>()
+            .with_context(|| format!("unparseable metric line: {line}"))?;
+    }
+    Ok(total)
+}
+
+/// Export sends each destination *acknowledged*, per destination address, from the first shard
+/// of `validator`. Successes, not attempts: the latency histogram counts failed sends too, so a
+/// transport that cannot deliver anything still moves it — this counter only moves when the
+/// destination answered.
+async fn export_successes(
+    net: &LocalNet,
+    validator: usize,
+) -> Result<std::collections::BTreeMap<String, u64>> {
+    let port = net.shard_metrics_port(validator, 0);
+    let metrics = reqwest::get(format!("http://127.0.0.1:{port}/metrics"))
+        .await?
+        .text()
+        .await?;
+    anyhow::ensure!(
+        metrics.lines().any(|line| line.starts_with("# TYPE")),
+        "the metrics scrape of validator {validator}'s shard returned no Prometheus payload",
+    );
+    let mut per_destination = std::collections::BTreeMap::new();
+    for line in metrics.lines() {
+        // e.g. `linera_block_export_sends_succeeded{validator="grpc:127.0.0.1:9001"} 4`
+        if line.starts_with('#') || !line.contains("block_export_sends_succeeded") {
+            continue;
+        }
+        let (labels, value) = line
+            .rsplit_once(' ')
+            .with_context(|| format!("unparseable metric line: {line}"))?;
+        per_destination.insert(
+            labels.to_owned(),
+            value
+                .parse::<u64>()
+                .with_context(|| format!("unparseable metric line: {line}"))?,
+        );
+    }
+    Ok(per_destination)
+}
+
+#[ignore]
+#[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(Database::ScyllaDb, Network::Grpc ; "scylladb_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_block_export_through_the_proxy(database: Database, network: Network) -> Result<()> {
+    let _guard: tokio::sync::MutexGuard<'_, ()> = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let config = LocalNetConfig {
+        num_initial_validators: 4,
+        num_shards: 1,
+        export_blocks_to_committee: true,
+        ..LocalNetConfig::new_test(database, network)
+    };
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.default_chain().expect("client has no default chain");
+
+    // Every one of these is executed by each validator's chain worker, which hands it to that
+    // chain's export task.
+    for _ in 0..3 {
+        client
+            .transfer_with_silent_logs(1.into(), chain, chain)
+            .await?;
+    }
+
+    // Export is asynchronous, and the heights a worker records trail the tip by design, so give
+    // the tasks a moment to drain before looking.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Each validator pushed to the three others, so each proxy must have carried traffic. A shard
+    // that had opened its own connection to a peer — the thing this design exists to prevent —
+    // would leave these at zero while the blocks still propagated.
+    for validator in 0..4 {
+        let relayed = relayed_requests(&net, validator).await?;
+        assert!(
+            relayed > 0,
+            "validator {validator} exported nothing through its proxy",
+        );
+    }
+
+    // And the blocks really did land everywhere.
+    for validator in 0..4 {
+        let info = net
+            .validator_client(validator)?
+            .handle_chain_info_query(ChainInfoQuery::new(chain))
+            .await?;
+        assert_eq!(info.info.next_block_height, 3.into());
+    }
+
+    net.terminate().await?;
+    Ok(())
+}
+
+/// A validator admitted to the committee after a chain already has history is brought up to date
+/// by export alone.
+///
+/// The newcomer has never heard of the chain, so it answers a height query with 0 and every block
+/// is replayed. Catch-up is bounded per round, so this asserts convergence, not one-shot.
+#[ignore]
+#[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_export_catches_up_a_newly_added_validator(
+    database: Database,
+    network: Network,
+) -> Result<()> {
+    let _guard: tokio::sync::MutexGuard<'_, ()> = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let config = LocalNetConfig {
+        num_initial_validators: 4,
+        num_shards: 1,
+        export_blocks_to_committee: true,
+        ..LocalNetConfig::new_test(database, network)
+    };
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.default_chain().expect("client has no default chain");
+
+    // History the newcomer will have to be told about in full — on the client's chain, and on a
+    // second chain that stays completely idle from here on. The idle one is the harder case:
+    // nothing after the admission ever touches it, so only the export queue's own bookkeeping
+    // can tell the newcomer it exists.
+    for _ in 0..3 {
+        client
+            .transfer_with_silent_logs(1.into(), chain, chain)
+            .await?;
+    }
+    let (idle_chain, _) = client
+        .open_chain(chain, None, linera_base::data_types::Amount::from_tokens(2))
+        .await?;
+    for _ in 0..2 {
+        client
+            .transfer_with_silent_logs(1.into(), idle_chain, chain)
+            .await?;
+    }
+
+    // Bring up a fifth validator and admit it. It starts knowing nothing of this chain.
+    net.generate_validator_config(4).await?;
+    net.start_validator(4).await?;
+    client
+        .set_validator(
+            net.validator_keys(4).unwrap(),
+            net.proxy_public_port(4, 0),
+            100,
+        )
+        .await?;
+
+    // Nothing below drives the chain forward, so any progress the newcomer makes on it is export
+    // replaying the history to it.
+    let target = net
+        .validator_client(0)?
+        .handle_chain_info_query(ChainInfoQuery::new(chain))
+        .await?
+        .info
+        .next_block_height;
+    let idle_target = net
+        .validator_client(0)?
+        .handle_chain_info_query(ChainInfoQuery::new(idle_chain))
+        .await?
+        .info
+        .next_block_height;
+    assert!(
+        idle_target >= 2.into(),
+        "the idle chain needs history for its replay to be observable",
+    );
+
+    for _ in 0..60 {
+        // A query the newcomer cannot answer yet — it may not even hold a chain's description —
+        // is the transient this poll waits out, not a failure.
+        let height = net
+            .validator_client(4)?
+            .handle_chain_info_query(ChainInfoQuery::new(chain))
+            .await
+            .map_or(linera_base::data_types::BlockHeight::ZERO, |response| {
+                response.info.next_block_height
+            });
+        let idle_height = net
+            .validator_client(4)?
+            .handle_chain_info_query(ChainInfoQuery::new(idle_chain))
+            .await
+            .map_or(linera_base::data_types::BlockHeight::ZERO, |response| {
+                response.info.next_block_height
+            });
+        if height >= target && idle_height >= idle_target {
+            net.terminate().await?;
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    let height = net
+        .validator_client(4)?
+        .handle_chain_info_query(ChainInfoQuery::new(chain))
+        .await
+        .map_or(linera_base::data_types::BlockHeight::ZERO, |response| {
+            response.info.next_block_height
+        });
+    let idle_height = net
+        .validator_client(4)?
+        .handle_chain_info_query(ChainInfoQuery::new(idle_chain))
+        .await
+        .map_or(linera_base::data_types::BlockHeight::ZERO, |response| {
+            response.info.next_block_height
+        });
+    panic!(
+        "the newly added validator did not catch up: active chain {height}/{target}, \
+         idle chain {idle_height}/{idle_target}",
+    );
+}
+
+/// Export keeps flowing when one of this validator's proxies dies.
+///
+/// A destination keeps the proxy it was handed, so without the rebuild-on-failure path a dead
+/// proxy strands every destination assigned to it — silently, since the chain still looks healthy.
+#[ignore]
+#[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_export_survives_a_dead_proxy(database: Database, network: Network) -> Result<()> {
+    let _guard: tokio::sync::MutexGuard<'_, ()> = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let config = LocalNetConfig {
+        num_initial_validators: 4,
+        num_shards: 1,
+        num_proxies: 2,
+        export_blocks_to_committee: true,
+        ..LocalNetConfig::new_test(database, network)
+    };
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.default_chain().expect("client has no default chain");
+
+    client
+        .transfer_with_silent_logs(1.into(), chain, chain)
+        .await?;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    let before = relayed_requests(&net, 0).await?;
+    assert!(
+        before > 0,
+        "export should be relaying before the proxy is killed"
+    );
+    // Every destination must have been reached at least once before the kill, so that "its
+    // counter grew afterwards" is meaningful for all three.
+    let mut reached = std::collections::BTreeMap::new();
+    for _ in 0..30 {
+        reached = export_successes(&net, 0).await?;
+        if reached.len() >= 3 && reached.values().all(|count| *count > 0) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    assert!(
+        reached.len() >= 3 && reached.values().all(|count| *count > 0),
+        "not every destination was reached before the kill: {reached:?}",
+    );
+
+    // Kill one of validator 0's two proxies. Destinations pinned to it must move to the other.
+    net.kill_proxy(0, 1).await?;
+
+    // The baseline is taken *after* the kill: a send that completed between an earlier snapshot
+    // and the proxy actually dying would count towards "grew afterwards" while proving nothing.
+    // Growth beyond this baseline can only come through the surviving proxy.
+    let successes_before = export_successes(&net, 0).await?;
+
+    // The load-bearing assertion: *every* destination's acknowledged-send counter grows after
+    // the kill. The chains converging proves nothing (the client broadcasts every block to every
+    // validator whether export works or not), and total relay traffic on the surviving proxy
+    // proves little more — the destinations round-robined onto proxy 0 keep it growing even
+    // with the destination stranded on the dead proxy never re-pointed. A frozen per-destination
+    // counter is that stranding, directly. Blocks are produced inside the loop so a lagging
+    // recovery still has traffic to prove itself on.
+    for attempt in 0..30 {
+        client
+            .transfer_with_silent_logs(1.into(), chain, chain)
+            .await?;
+        let successes = export_successes(&net, 0).await?;
+        let all_grew = successes_before
+            .iter()
+            .all(|(address, before)| successes.get(address).is_some_and(|now| now > before));
+        if all_grew {
+            net.terminate().await?;
+            return Ok(());
+        }
+        if attempt == 29 {
+            panic!(
+                "a destination stopped being reached after its proxy was killed: \
+                 {successes_before:?} before, {successes:?} after",
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    unreachable!("the loop either returns or panics on its last attempt");
+}
+
+/// The proxy refuses to relay to a host that is not in any committee.
+///
+/// Relaying only buys anything if the proxy will not dial wherever it is told, so this asserts
+/// the refusal directly rather than inferring it from export working.
+#[ignore]
+#[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_relay_refuses_a_non_committee_destination(
+    database: Database,
+    network: Network,
+) -> Result<()> {
+    let _guard: tokio::sync::MutexGuard<'_, ()> = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let config = LocalNetConfig {
+        num_initial_validators: 4,
+        num_shards: 1,
+        export_blocks_to_committee: true,
+        ..LocalNetConfig::new_test(database, network)
+    };
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.default_chain().expect("client has no default chain");
+
+    // Produce a block so the proxy has certainly served some legitimate relay traffic; whatever
+    // rejection follows is therefore about the destination, not about the relay being unavailable.
+    client
+        .transfer_with_silent_logs(1.into(), chain, chain)
+        .await?;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Speak to validator 0's relay port directly, as one of its own shards would, but name a host
+    // that is in no committee.
+    let relay = format!("http://127.0.0.1:{}", net.proxy_internal_port(0, 0));
+    let channel = tonic::transport::Channel::from_shared(relay)?
+        .connect()
+        .await?;
+    let mut relay_client = ValidatorRelayClient::new(channel);
+    let status = relay_client
+        .relay_chain_info_query(api::RelayChainInfoQueryRequest {
+            destination: "grpc:198.51.100.7:443".to_string(),
+            inner: Some(ChainInfoQuery::new(chain).try_into()?),
+        })
+        .await
+        .expect_err("the proxy should refuse a destination that is in no committee");
+    assert_eq!(
+        status.code(),
+        tonic::Code::PermissionDenied,
+        "expected a refusal, got: {status:?}",
+    );
+
+    net.terminate().await?;
+    Ok(())
+}
+
+/// With `--block-export-transport direct`, shards reach the other validators themselves and the
+/// proxy carries nothing.
+///
+/// The exact mirror of `test_block_export_through_the_proxy` — same blocks everywhere, but the
+/// relay counters stay at zero — so the two together pin down which path each setting takes. The
+/// trade-off: shards hold the validator secret key, so direct means giving them outbound access.
+#[ignore]
+#[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_block_export_direct_bypasses_the_proxy(
+    database: Database,
+    network: Network,
+) -> Result<()> {
+    let _guard: tokio::sync::MutexGuard<'_, ()> = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let config = LocalNetConfig {
+        num_initial_validators: 4,
+        num_shards: 1,
+        export_blocks_to_committee: true,
+        block_export_transport: BlockExportTransport::Direct,
+        ..LocalNetConfig::new_test(database, network)
+    };
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.default_chain().expect("client has no default chain");
+
+    for _ in 0..3 {
+        client
+            .transfer_with_silent_logs(1.into(), chain, chain)
+            .await?;
+    }
+
+    // The load-bearing positive assertion: every destination *acknowledged* a direct send. The
+    // blocks reaching every validator proves nothing (the client broadcasts to all of them), the
+    // relay counters staying at zero is also satisfied by a transport that exports nothing, and
+    // counting send *attempts* would also be satisfied by one that fails every time.
+    let mut successes = std::collections::BTreeMap::new();
+    for _ in 0..30 {
+        successes = export_successes(&net, 0).await?;
+        if successes.len() >= 3 && successes.values().all(|count| *count > 0) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    assert!(
+        successes.len() >= 3 && successes.values().all(|count| *count > 0),
+        "the direct transport was not acknowledged by every destination: {successes:?}",
+    );
+
+    // The blocks still reach every validator...
+    for validator in 0..4 {
+        let info = net
+            .validator_client(validator)?
+            .handle_chain_info_query(ChainInfoQuery::new(chain))
+            .await?;
+        assert_eq!(info.info.next_block_height, 3.into());
+    }
+
+    // ...without a single one of them going through a proxy's relay.
+    for validator in 0..4 {
+        let relayed = relayed_requests(&net, validator).await?;
+        assert_eq!(
+            relayed, 0,
+            "validator {validator} relayed {relayed} requests through its proxy despite \
+             --block-export-transport direct",
+        );
+    }
+
+    net.terminate().await?;
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

Front-port of #6639, which merged into `testnet_conway` as 793c5055e7a. The change replaces the
separate block-exporter binary with in-process peer-to-peer export: chain workers hand each block
they execute to one queue task per server process, which pushes it to the other committee
validators through this validator's own proxy. It removes the reason for the unbounded exporter
partition (#4095) rather than fixing that partition.

Off by default behind `--export-blocks-to-committee`, so merging changes no behaviour: the queue
task is never spawned, `export_block` returns immediately, and `ChainStateView::exported_heights`
is never read or written.

## Proposal

The architecture is unchanged from #6639 — see that PR for the design discussion and the review
history. This PR is the port, and the parts worth reviewing are where `main` had moved.

**Merge conflicts, and how they were resolved:**

| File | Divergence | Resolution |
| --- | --- | --- |
| `.github/workflows/rust.yml` | `main` deleted the old exporter integration step | Kept only the new block-export step |
| `linera-core/src/updater.rs` | `main` added a `&ConfirmedBlockCertificate` annotation; #6639's change there was cosmetic | Took `main`'s |
| `linera-service/src/cli_wrappers/local_net.rs` | `main` added `binary_dir` at the six places #6639 adds two fields | Kept both, `main`'s first, so the struct, the signature and the call site stay positionally aligned |
| `linera-service/src/server.rs` | `main` dropped `AssertStorageV1` from an import | `main`'s import list plus `BlockExportTransport` |
| `linera-service/src/proxy/grpc.rs` | `main` migrated metrics to `declare_metrics!` | Ported `RELAYED_REQUEST_COUNT` into that idiom — which is an improvement, since the macro's generated `init_metrics()` forces the series so it exists before the first relayed request rather than after |

**API drift the cherry-pick could not see**, all mechanical but none automatic:

- `Storage::get_or_load_committee` is `committee_for_epoch` on `main`, and reports
  `ExecutionError` where the old call reported `ViewError`. Two call sites in the proxy and one in
  the export queue. `is_relay_destination` widened to `anyhow::Error` accordingly — its caller only
  formats the error into a `Status::unavailable`, so nothing downstream distinguishes the types.
- `RemoteNode::check_blobs_not_found` is now generic over `Certified`, which the storage cache's
  `Arc` does not implement — dereferenced at the call site.
- `execute_contiguous_block` consumes the certificate via `into_value()` on `main`, but #6639's
  cached/plain split makes it a borrow; took the block by clone, as the conway version does.
- `ValidatorNode` lost `previous_event_blocks` and gained `event_block_heights` and
  `get_shard_info`. The relay implements only the four requests export makes, so the new pair joins
  the `unsupported` set.

**One fix that is `main`'s, not this PR's.** `linera-service`'s `metrics` feature does not
propagate to `linera-exporter`, while `linera-service/src/lib.rs:41` calls
`linera_exporter::init_metrics()`, which is `#[cfg(with_metrics)]` in that crate. So
`cargo check -p linera-service --features storage-service,metrics` fails on `main` today. Nothing
builds that combination yet — the CI step that does is the one this PR adds — so the breakage is
latent rather than observed. Fixed here by adding `linera-exporter/metrics` to the feature list;
happy to split it into its own PR if you would rather land it separately.

## Test Plan

Run against this branch, on `main`:

```
cargo check --workspace --all-targets --exclude linera-web
cargo test -p linera-core --lib                                    # 192 passed, 0 failed
cargo test -p linera-service --test block_export_tests \
    --features storage-service,metrics -- --ignored                # 5 passed, 0 failed
cargo +nightly fmt -- --check
bash scripts/check_chain_loads.sh
```

The five network tests are the ones that matter for the port, because they exercise the pieces
that had to be re-aimed at `main`'s APIs: the relay path through the proxy (`ValidatorNode` impl),
the committee lookup behind the SSRF guard (`committee_for_epoch`), and proxy rotation on failure.

`test_export_catches_up_a_newly_added_validator` includes a chain left idle since before the
admission, so only the queue's own bookkeeping can deliver it.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6639 — the original, merged to `testnet_conway` as 793c5055e7a
- #6715 — rollout risks, tests and instrumentation before enabling anywhere
- #4095 — the unbounded exporter partition this line of work removes
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
