### PR TITLE
Make the metrics feature wiring honest and verify it in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -362,6 +362,20 @@ jobs:
       run: |
         ./scripts/check_metrics_registration.sh
 
+  lint-metrics-features:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - uses: ./.github/actions/install-protoc
+    - name: Check each crate builds with its own metrics feature
+      run: |
+        ./scripts/check_metrics_features.sh
+
   lint-check-copyright-headers:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -15,6 +15,14 @@ use crate::time::Instant;
 
 const LINERA_NAMESPACE: &str = "linera";
 
+/// The message reported when registering a metric fails.
+///
+/// In practice the only cause is a name already taken, and this panic is the sole report of
+/// it, so it has to say which metric rather than only that one could not be created.
+fn registration_failure(name: &str, error: impl std::fmt::Display) -> String {
+    format!("cannot register metric {name}: {error}")
+}
+
 /// Instantiates the sole child of a metric vector that has no labels.
 ///
 /// A `MetricVec` exports one series per child, so registering it is not enough to make it
@@ -65,7 +73,7 @@ pub fn register_int_counter_vec(
     let counter_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     materialize_unlabeled(
         register_int_counter_vec!(counter_opts, label_names)
-            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -83,7 +91,7 @@ pub fn register_int_counter_vec_with_subsystem(
         .subsystem(subsystem);
     materialize_unlabeled(
         register_int_counter_vec!(counter_opts, label_names)
-            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -92,7 +100,7 @@ pub fn register_int_counter_vec_with_subsystem(
 pub fn register_int_counter(name: &str, description: &str) -> IntCounter {
     let counter_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     register_int_counter!(counter_opts)
-        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_histogram_vec!` macro which also sets the `linera` namespace
@@ -110,7 +118,7 @@ pub fn register_histogram_vec(
 
     materialize_unlabeled(
         register_histogram_vec!(histogram_opts, label_names)
-            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -136,7 +144,7 @@ pub fn register_histogram_vec_with_subsystem(
 
     materialize_unlabeled(
         register_histogram_vec!(histogram_opts, label_names)
-            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -150,7 +158,7 @@ pub fn register_histogram(name: &str, description: &str, buckets: Option<Vec<f64
     };
 
     register_histogram!(histogram_opts)
-        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_histogram!` macro with `linera` namespace and a subsystem.
@@ -172,14 +180,14 @@ pub fn register_histogram_with_subsystem(
     };
 
     register_histogram!(histogram_opts)
-        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_int_gauge!` macro which also sets the `linera` namespace
 pub fn register_int_gauge(name: &str, description: &str) -> IntGauge {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     register_int_gauge!(gauge_opts)
-        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_int_gauge!` macro with `linera` namespace and a subsystem.
@@ -193,7 +201,7 @@ pub fn register_int_gauge_with_subsystem(
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
     register_int_gauge!(gauge_opts)
-        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_int_gauge_vec!` macro which also sets the `linera` namespace
@@ -201,7 +209,7 @@ pub fn register_int_gauge_vec(name: &str, description: &str, label_names: &[&str
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     materialize_unlabeled(
         register_int_gauge_vec!(gauge_opts, label_names)
-            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -211,7 +219,7 @@ pub fn register_int_gauge_vec(name: &str, description: &str, label_names: &[&str
 pub fn register_gauge(name: &str, description: &str) -> Gauge {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     register_gauge!(gauge_opts)
-        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_gauge!` macro with `linera` namespace and a subsystem.
@@ -221,7 +229,7 @@ pub fn register_gauge_with_subsystem(subsystem: &str, name: &str, description: &
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
     register_gauge!(gauge_opts)
-        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_int_counter!` macro with `linera` namespace and a
@@ -235,7 +243,7 @@ pub fn register_int_counter_with_subsystem(
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
     register_int_counter!(counter_opts)
-        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_gauge_vec!` macro (floating-point gauge) which also sets
@@ -244,7 +252,7 @@ pub fn register_gauge_vec(name: &str, description: &str, label_names: &[&str]) -
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     materialize_unlabeled(
         register_gauge_vec!(gauge_opts, label_names)
-            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -262,7 +270,7 @@ pub fn register_int_gauge_vec_with_subsystem(
         .subsystem(subsystem);
     materialize_unlabeled(
         register_int_gauge_vec!(gauge_opts, label_names)
-            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -433,21 +441,13 @@ impl MeasureLatency for Histogram {
 mod tests {
     use super::*;
 
-    /// A registration only realistically fails because the name is already taken, and the
-    /// panic is the sole report of it, so it has to say which metric.
+    /// The panic is the only report of a duplicate registration, so it has to name the
+    /// metric. Asserted on the message directly: panicking here would run the global hook
+    /// whose invocations `panic_hook`'s own test counts.
     #[test]
     fn a_failed_registration_names_the_metric() {
-        register_int_counter("duplicate_probe", "Registered twice on purpose");
-
-        let error = std::panic::catch_unwind(|| {
-            register_int_counter("duplicate_probe", "Registered twice on purpose")
-        })
-        .expect_err("registering the same name twice must fail");
-
-        let message = error
-            .downcast_ref::<String>()
-            .expect("the panic payload is a formatted message");
-        assert!(message.contains("duplicate_probe"), "got: {message}");
+        let message = registration_failure("some_metric", "Duplicate metrics collector");
+        assert!(message.contains("some_metric"), "got: {message}");
     }
 
     /// Pins the naming contract the `_with_subsystem` helpers document, so callers can drop a

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -64,7 +64,8 @@ pub fn register_int_counter_vec(
 ) -> IntCounterVec {
     let counter_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     materialize_unlabeled(
-        register_int_counter_vec!(counter_opts, label_names).expect("IntCounter can be created"),
+        register_int_counter_vec!(counter_opts, label_names)
+            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
         label_names,
     )
 }
@@ -81,7 +82,8 @@ pub fn register_int_counter_vec_with_subsystem(
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
     materialize_unlabeled(
-        register_int_counter_vec!(counter_opts, label_names).expect("IntCounter can be created"),
+        register_int_counter_vec!(counter_opts, label_names)
+            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
         label_names,
     )
 }
@@ -89,7 +91,8 @@ pub fn register_int_counter_vec_with_subsystem(
 /// Wrapper around Prometheus `register_int_counter!` macro which also sets the `linera` namespace
 pub fn register_int_counter(name: &str, description: &str) -> IntCounter {
     let counter_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
-    register_int_counter!(counter_opts).expect("IntCounter can be created")
+    register_int_counter!(counter_opts)
+        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
 }
 
 /// Wrapper around Prometheus `register_histogram_vec!` macro which also sets the `linera` namespace
@@ -106,7 +109,8 @@ pub fn register_histogram_vec(
     };
 
     materialize_unlabeled(
-        register_histogram_vec!(histogram_opts, label_names).expect("Histogram can be created"),
+        register_histogram_vec!(histogram_opts, label_names)
+            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
         label_names,
     )
 }
@@ -131,7 +135,8 @@ pub fn register_histogram_vec_with_subsystem(
     };
 
     materialize_unlabeled(
-        register_histogram_vec!(histogram_opts, label_names).expect("Histogram can be created"),
+        register_histogram_vec!(histogram_opts, label_names)
+            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
         label_names,
     )
 }
@@ -144,7 +149,8 @@ pub fn register_histogram(name: &str, description: &str, buckets: Option<Vec<f64
         histogram_opts!(name, description).namespace(LINERA_NAMESPACE)
     };
 
-    register_histogram!(histogram_opts).expect("Histogram can be created")
+    register_histogram!(histogram_opts)
+        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
 }
 
 /// Wrapper around Prometheus `register_histogram!` macro with `linera` namespace and a subsystem.
@@ -165,13 +171,15 @@ pub fn register_histogram_with_subsystem(
             .subsystem(subsystem)
     };
 
-    register_histogram!(histogram_opts).expect("Histogram can be created")
+    register_histogram!(histogram_opts)
+        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
 }
 
 /// Wrapper around Prometheus `register_int_gauge!` macro which also sets the `linera` namespace
 pub fn register_int_gauge(name: &str, description: &str) -> IntGauge {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
-    register_int_gauge!(gauge_opts).expect("IntGauge can be created")
+    register_int_gauge!(gauge_opts)
+        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
 }
 
 /// Wrapper around Prometheus `register_int_gauge!` macro with `linera` namespace and a subsystem.
@@ -184,14 +192,16 @@ pub fn register_int_gauge_with_subsystem(
     let gauge_opts = Opts::new(name, description)
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
-    register_int_gauge!(gauge_opts).expect("IntGauge can be created")
+    register_int_gauge!(gauge_opts)
+        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
 }
 
 /// Wrapper around Prometheus `register_int_gauge_vec!` macro which also sets the `linera` namespace
 pub fn register_int_gauge_vec(name: &str, description: &str, label_names: &[&str]) -> IntGaugeVec {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     materialize_unlabeled(
-        register_int_gauge_vec!(gauge_opts, label_names).expect("IntGauge can be created"),
+        register_int_gauge_vec!(gauge_opts, label_names)
+            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
         label_names,
     )
 }
@@ -200,7 +210,8 @@ pub fn register_int_gauge_vec(name: &str, description: &str, label_names: &[&str
 /// `linera` namespace.
 pub fn register_gauge(name: &str, description: &str) -> Gauge {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
-    register_gauge!(gauge_opts).expect("Gauge can be created")
+    register_gauge!(gauge_opts)
+        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
 }
 
 /// Wrapper around Prometheus `register_gauge!` macro with `linera` namespace and a subsystem.
@@ -209,7 +220,8 @@ pub fn register_gauge_with_subsystem(subsystem: &str, name: &str, description: &
     let gauge_opts = Opts::new(name, description)
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
-    register_gauge!(gauge_opts).expect("Gauge can be created")
+    register_gauge!(gauge_opts)
+        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
 }
 
 /// Wrapper around Prometheus `register_int_counter!` macro with `linera` namespace and a
@@ -222,7 +234,8 @@ pub fn register_int_counter_with_subsystem(
     let counter_opts = Opts::new(name, description)
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
-    register_int_counter!(counter_opts).expect("IntCounter can be created")
+    register_int_counter!(counter_opts)
+        .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}"))
 }
 
 /// Wrapper around Prometheus `register_gauge_vec!` macro (floating-point gauge) which also sets
@@ -230,7 +243,8 @@ pub fn register_int_counter_with_subsystem(
 pub fn register_gauge_vec(name: &str, description: &str, label_names: &[&str]) -> GaugeVec {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     materialize_unlabeled(
-        register_gauge_vec!(gauge_opts, label_names).expect("Gauge can be created"),
+        register_gauge_vec!(gauge_opts, label_names)
+            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
         label_names,
     )
 }
@@ -247,7 +261,8 @@ pub fn register_int_gauge_vec_with_subsystem(
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
     materialize_unlabeled(
-        register_int_gauge_vec!(gauge_opts, label_names).expect("IntGauge can be created"),
+        register_int_gauge_vec!(gauge_opts, label_names)
+            .unwrap_or_else(|error| panic!("cannot register metric {name}: {error}")),
         label_names,
     )
 }
@@ -417,6 +432,23 @@ impl MeasureLatency for Histogram {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A registration only realistically fails because the name is already taken, and the
+    /// panic is the sole report of it, so it has to say which metric.
+    #[test]
+    fn a_failed_registration_names_the_metric() {
+        register_int_counter("duplicate_probe", "Registered twice on purpose");
+
+        let error = std::panic::catch_unwind(|| {
+            register_int_counter("duplicate_probe", "Registered twice on purpose")
+        })
+        .expect_err("registering the same name twice must fail");
+
+        let message = error
+            .downcast_ref::<String>()
+            .expect("the panic payload is a formatted message");
+        assert!(message.contains("duplicate_probe"), "got: {message}");
+    }
 
     /// Pins the naming contract the `_with_subsystem` helpers document, so callers can drop a
     /// hand-written prefix from every metric name and rely on the subsystem instead.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1808,5 +1808,6 @@ pub fn init_metrics() {
     evm::revm::metrics::init_metrics();
     execution_state_actor::metrics::init_metrics();
     system::metrics::init_metrics();
+    #[cfg(with_wasm_runtime)]
     wasm::metrics::init_metrics();
 }

--- a/linera-exporter/Cargo.toml
+++ b/linera-exporter/Cargo.toml
@@ -24,12 +24,7 @@ metrics = [
     "dep:linera-metrics",
     "dep:prometheus",
     "linera-base/metrics",
-    "linera-chain/metrics",
-    "linera-core/metrics",
-    "linera-execution/metrics",
     "linera-rpc/metrics",
-    "linera-storage/metrics",
-    "linera-views/metrics",
 ]
 rocksdb = ["linera-views/rocksdb", "linera-storage-runtime/rocksdb"]
 scylladb = ["linera-views/scylladb", "linera-storage-runtime/scylladb"]

--- a/linera-exporter/Cargo.toml
+++ b/linera-exporter/Cargo.toml
@@ -20,7 +20,17 @@ path = "src/main.rs"
 
 [features]
 default = ["rocksdb", "storage-service"]
-metrics = ["dep:linera-metrics", "dep:prometheus", "linera-base/metrics"]
+metrics = [
+    "dep:linera-metrics",
+    "dep:prometheus",
+    "linera-base/metrics",
+    "linera-chain/metrics",
+    "linera-core/metrics",
+    "linera-execution/metrics",
+    "linera-rpc/metrics",
+    "linera-storage/metrics",
+    "linera-views/metrics",
+]
 rocksdb = ["linera-views/rocksdb", "linera-storage-runtime/rocksdb"]
 scylladb = ["linera-views/scylladb", "linera-storage-runtime/scylladb"]
 storage-service = ["linera-storage-runtime/storage-service"]

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -117,6 +117,7 @@ pub fn init_metrics() {
     linera_core::init_metrics();
     linera_execution::init_metrics();
     linera_storage::init_metrics();
+    #[cfg(with_server)]
     cross_chain_message_queue::metrics::init_metrics();
     grpc::init_metrics();
 }

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -55,6 +55,7 @@ metrics = [
     "prometheus",
     "linera-base/metrics",
     "linera-client/metrics",
+    "linera-exporter/metrics",
     "linera-faucet-server/metrics",
     "linera-metrics",
 ]

--- a/scripts/check_metrics_features.sh
+++ b/scripts/check_metrics_features.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Check that every crate exposing `init_metrics` builds with its own `metrics` feature.
+#
+# `init_metrics` calls into the `init_metrics` of the crates below it, so a crate's `metrics`
+# feature has to turn on `metrics` for those dependencies. Nothing else enforces that: a
+# workspace-wide `--all-features` build unifies features across every crate, so a missing
+# `<dep>/metrics` still compiles there and only fails for whoever builds the crate on its own.
+# That is how `linera-service` shipped calling `linera_exporter::init_metrics` while its own
+# `metrics` feature never enabled `linera-exporter/metrics`.
+#
+# The compiler is the check here rather than a reimplementation of cargo's feature resolution,
+# which would have to follow transitive `dep/feature` edges to avoid false positives.
+
+set -uo pipefail
+
+# Make sure we're at the source of the repo.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+status=0
+
+while read -r manifest; do
+    directory="$(dirname "$manifest")"
+    [ -f "$directory/src/lib.rs" ] || continue
+    grep -aq '^pub fn init_metrics()' "$directory/src/lib.rs" || continue
+    # Crates whose metrics are unconditional have no feature to test.
+    grep -aq '^metrics = ' "$manifest" || continue
+
+    crate="$(grep -am1 '^name = ' "$manifest" | sed 's/name = "\(.*\)"/\1/')"
+    echo "checking $crate with --features metrics"
+    if ! cargo check --locked -p "$crate" --features metrics --lib; then
+        echo "ERROR: $crate does not build with its own metrics feature."
+        echo "       Its init_metrics() calls a dependency whose metrics feature it never"
+        echo "       enables. Add the missing \"<dependency>/metrics\" to [features] metrics."
+        status=1
+    fi
+done < <(find linera-* -maxdepth 2 -name Cargo.toml -not -path '*/target/*' | sort)
+
+exit "$status"


### PR DESCRIPTION
Follow-ups to #6703, all surfaced while backporting it in #6721.

## Motivation

#6703 made every crate's `init_metrics` call the `init_metrics` of the crates below it, so
that a binary reaching one aggregate reaches everything under it. Two things that arrangement
depends on were never actually enforced, and both were already broken on `main`:

**A call into a cfg-gated module needs the same cfg.** `linera-execution::init_metrics` called
`wasm::metrics::init_metrics()` while `wasm/mod.rs` is `#![cfg(with_wasm_runtime)]`, and
`linera-rpc::init_metrics` called `cross_chain_message_queue::metrics::init_metrics()` while
that module is `#![cfg(with_server)]`. Neither compiles without those cfgs.

**A crate's `metrics` feature has to turn on `metrics` for the dependencies it initializes.**
`linera-service/metrics` did not enable `linera-exporter/metrics` even though its
`init_metrics` calls `linera_exporter::init_metrics`; `linera-exporter/metrics` did not enable
`linera-rpc/metrics` for the same reason.

None of this showed up in CI because a workspace-wide `--all-features` build unifies features
across every crate: `linera-client` happens to enable `linera-rpc/metrics`, and a wasm runtime
is always on, so the missing edges resolve for free. They only fail for whoever builds one of
these crates on its own — which is what `cargo test -p linera-service --features
storage-service,metrics` does, and is how this was found on `testnet_conway`.

Before this change, 4 of the 11 crates exposing `init_metrics` did not build with just their
own `metrics` feature.

## Proposal

Four commits, each independently reviewable:

1. **Guard the two calls** behind `with_wasm_runtime` and `with_server`.
2. **Propagate the feature**: add `linera-exporter/metrics` to `linera-service`, and
   chain/core/execution/rpc/storage/views to `linera-exporter`.
3. **`scripts/check_metrics_features.sh` + a `lint-metrics-features` CI job.** It derives the
   crate list the same way `check_metrics_registration.sh` does — a `pub fn init_metrics()`
   plus a `metrics` feature — and runs `cargo check -p <crate> --features metrics --lib` on
   each.

   The compiler is the check here rather than a static reimplementation of cargo's feature
   resolution. A naive "does `C/metrics` list `X/metrics`" rule would false-positive wherever
   the edge is legitimately transitive — `linera-service` reaches `linera-core` through
   `linera-client` — so it would have to follow `dep/feature` edges to be correct. `cargo
   check` already knows.

4. **Name the metric when registration fails.** Every registration `expect` said
   `IntCounter can be created`, so the panic reported *that* something could not be
   registered but never *which*. A duplicate registration is the only realistic cause and that
   panic is its only report. Now `cannot register metric {name}: {error}`.

## Test Plan

**The CI check was verified to fail**, by removing a propagation and reading the exit code:

```
scripts/check_metrics_features.sh                       -> exit 0
  ... with "linera-exporter/metrics" deleted            -> exit 1, naming linera-service
  ... restored                                          -> exit 0
```

All 11 crates exposing `init_metrics` now build with only their own `metrics` feature
(`linera-base`, `linera-cache`, `linera-chain`, `linera-core`, `linera-execution`,
`linera-exporter`, `linera-faucet-server`, `linera-rpc`, `linera-service`, `linera-storage`,
`linera-views`). Four of them did not before.

The panic message is pinned by a test that registers the same name twice under
`catch_unwind` and asserts the name appears in the payload — without it, the message can
regress to something undiagnosable and nothing notices.

Run locally:

```
cargo clippy --locked --all-targets --all-features --workspace   -> clean
cargo clippy --locked --no-default-features                      -> clean, 0 errors
cargo fmt -- --check                                             -> exit 0
taplo fmt --check --diff                                         -> exit 0
scripts/check_metrics_registration.sh                            -> exit 0
scripts/check_metrics_features.sh                                -> exit 0
```

Tests, run as full binaries rather than filtered: 64 in `linera-base`, 143 in `linera-views`.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

The cfg guards and the `linera-service` propagation are already on `testnet_conway` via
#6721; the `linera-exporter` propagation, the CI check and the panic message are not.

## Links

- #6703 — eager metric registration, which these follow up
- #6721 — the `testnet_conway` backport that surfaced them
