### PR TITLE
[testnet_conway] Make the metrics feature wiring honest and verify it in CI (#6727)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -422,6 +422,20 @@ jobs:
       run: |
         ./scripts/check_metrics_registration.sh
 
+  lint-metrics-features:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - uses: ./.github/actions/install-protoc
+    - name: Check each crate builds with its own metrics feature
+      run: |
+        ./scripts/check_metrics_features.sh
+
   lint-check-copyright-headers:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -15,6 +15,14 @@ use crate::time::Instant;
 
 const LINERA_NAMESPACE: &str = "linera";
 
+/// The message reported when registering a metric fails.
+///
+/// In practice the only cause is a name already taken, and this panic is the sole report of
+/// it, so it has to say which metric rather than only that one could not be created.
+fn registration_failure(name: &str, error: impl std::fmt::Display) -> String {
+    format!("cannot register metric {name}: {error}")
+}
+
 /// Instantiates the sole child of a metric vector that has no labels.
 ///
 /// A `MetricVec` exports one series per child, so registering it is not enough to make it
@@ -64,7 +72,8 @@ pub fn register_int_counter_vec(
 ) -> IntCounterVec {
     let counter_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     materialize_unlabeled(
-        register_int_counter_vec!(counter_opts, label_names).expect("IntCounter can be created"),
+        register_int_counter_vec!(counter_opts, label_names)
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -81,7 +90,8 @@ pub fn register_int_counter_vec_with_subsystem(
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
     materialize_unlabeled(
-        register_int_counter_vec!(counter_opts, label_names).expect("IntCounter can be created"),
+        register_int_counter_vec!(counter_opts, label_names)
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -89,7 +99,8 @@ pub fn register_int_counter_vec_with_subsystem(
 /// Wrapper around Prometheus `register_int_counter!` macro which also sets the `linera` namespace
 pub fn register_int_counter(name: &str, description: &str) -> IntCounter {
     let counter_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
-    register_int_counter!(counter_opts).expect("IntCounter can be created")
+    register_int_counter!(counter_opts)
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_int_counter!` macro with `linera` namespace and a subsystem.
@@ -102,7 +113,8 @@ pub fn register_int_counter_with_subsystem(
     let counter_opts = Opts::new(name, description)
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
-    register_int_counter!(counter_opts).expect("IntCounter can be created")
+    register_int_counter!(counter_opts)
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_histogram_vec!` macro which also sets the `linera` namespace
@@ -119,7 +131,8 @@ pub fn register_histogram_vec(
     };
 
     materialize_unlabeled(
-        register_histogram_vec!(histogram_opts, label_names).expect("Histogram can be created"),
+        register_histogram_vec!(histogram_opts, label_names)
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -144,7 +157,8 @@ pub fn register_histogram_vec_with_subsystem(
     };
 
     materialize_unlabeled(
-        register_histogram_vec!(histogram_opts, label_names).expect("Histogram can be created"),
+        register_histogram_vec!(histogram_opts, label_names)
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -157,7 +171,8 @@ pub fn register_histogram(name: &str, description: &str, buckets: Option<Vec<f64
         histogram_opts!(name, description).namespace(LINERA_NAMESPACE)
     };
 
-    register_histogram!(histogram_opts).expect("Histogram can be created")
+    register_histogram!(histogram_opts)
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_histogram!` macro with `linera` namespace and a subsystem.
@@ -178,13 +193,15 @@ pub fn register_histogram_with_subsystem(
             .subsystem(subsystem)
     };
 
-    register_histogram!(histogram_opts).expect("Histogram can be created")
+    register_histogram!(histogram_opts)
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_int_gauge!` macro which also sets the `linera` namespace
 pub fn register_int_gauge(name: &str, description: &str) -> IntGauge {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
-    register_int_gauge!(gauge_opts).expect("IntGauge can be created")
+    register_int_gauge!(gauge_opts)
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_int_gauge!` macro with `linera` namespace and a subsystem.
@@ -197,14 +214,16 @@ pub fn register_int_gauge_with_subsystem(
     let gauge_opts = Opts::new(name, description)
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
-    register_int_gauge!(gauge_opts).expect("IntGauge can be created")
+    register_int_gauge!(gauge_opts)
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_int_gauge_vec!` macro which also sets the `linera` namespace
 pub fn register_int_gauge_vec(name: &str, description: &str, label_names: &[&str]) -> IntGaugeVec {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     materialize_unlabeled(
-        register_int_gauge_vec!(gauge_opts, label_names).expect("IntGauge can be created"),
+        register_int_gauge_vec!(gauge_opts, label_names)
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -213,7 +232,8 @@ pub fn register_int_gauge_vec(name: &str, description: &str, label_names: &[&str
 /// `linera` namespace.
 pub fn register_gauge(name: &str, description: &str) -> Gauge {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
-    register_gauge!(gauge_opts).expect("Gauge can be created")
+    register_gauge!(gauge_opts)
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_gauge!` macro with `linera` namespace and a subsystem.
@@ -222,7 +242,8 @@ pub fn register_gauge_with_subsystem(subsystem: &str, name: &str, description: &
     let gauge_opts = Opts::new(name, description)
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
-    register_gauge!(gauge_opts).expect("Gauge can be created")
+    register_gauge!(gauge_opts)
+        .unwrap_or_else(|error| panic!("{}", registration_failure(name, error)))
 }
 
 /// Wrapper around Prometheus `register_gauge_vec!` macro (floating-point gauge) which also sets
@@ -230,7 +251,8 @@ pub fn register_gauge_with_subsystem(subsystem: &str, name: &str, description: &
 pub fn register_gauge_vec(name: &str, description: &str, label_names: &[&str]) -> GaugeVec {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     materialize_unlabeled(
-        register_gauge_vec!(gauge_opts, label_names).expect("Gauge can be created"),
+        register_gauge_vec!(gauge_opts, label_names)
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -247,7 +269,8 @@ pub fn register_int_gauge_vec_with_subsystem(
         .namespace(LINERA_NAMESPACE)
         .subsystem(subsystem);
     materialize_unlabeled(
-        register_int_gauge_vec!(gauge_opts, label_names).expect("IntGauge can be created"),
+        register_int_gauge_vec!(gauge_opts, label_names)
+            .unwrap_or_else(|error| panic!("{}", registration_failure(name, error))),
         label_names,
     )
 }
@@ -407,6 +430,15 @@ impl MeasureLatency for Histogram {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The panic is the only report of a duplicate registration, so it has to name the
+    /// metric. Asserted on the message directly: panicking here would run the global hook
+    /// whose invocations `panic_hook`'s own test counts.
+    #[test]
+    fn a_failed_registration_names_the_metric() {
+        let message = registration_failure("some_metric", "Duplicate metrics collector");
+        assert!(message.contains("some_metric"), "got: {message}");
+    }
 
     /// Pins the naming contract the `_with_subsystem` helpers document, so callers can drop a
     /// hand-written prefix from every metric name and rely on the subsystem instead.

--- a/linera-exporter/Cargo.toml
+++ b/linera-exporter/Cargo.toml
@@ -20,7 +20,12 @@ path = "src/main.rs"
 
 [features]
 default = ["rocksdb", "storage-service"]
-metrics = ["dep:linera-metrics", "dep:prometheus", "linera-base/metrics"]
+metrics = [
+    "dep:linera-metrics",
+    "dep:prometheus",
+    "linera-base/metrics",
+    "linera-rpc/metrics",
+]
 rocksdb = ["linera-views/rocksdb", "linera-storage-runtime/rocksdb"]
 scylladb = ["linera-views/scylladb", "linera-storage-runtime/scylladb"]
 storage-service = ["linera-storage-runtime/storage-service"]

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -113,6 +113,7 @@ pub fn init_metrics() {
     linera_core::init_metrics();
     linera_execution::init_metrics();
     linera_storage::init_metrics();
+    #[cfg(with_server)]
     cross_chain_message_queue::metrics::init_metrics();
     grpc::init_metrics();
 }

--- a/scripts/check_metrics_features.sh
+++ b/scripts/check_metrics_features.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Check that every crate exposing `init_metrics` builds with its own `metrics` feature.
+#
+# `init_metrics` calls into the `init_metrics` of the crates below it, so a crate's `metrics`
+# feature has to turn on `metrics` for those dependencies. Nothing else enforces that: a
+# workspace-wide `--all-features` build unifies features across every crate, so a missing
+# `<dep>/metrics` still compiles there and only fails for whoever builds the crate on its own.
+# That is how `linera-service` shipped calling `linera_exporter::init_metrics` while its own
+# `metrics` feature never enabled `linera-exporter/metrics`.
+#
+# The compiler is the check here rather than a reimplementation of cargo's feature resolution,
+# which would have to follow transitive `dep/feature` edges to avoid false positives.
+
+set -uo pipefail
+
+# Make sure we're at the source of the repo.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+status=0
+
+while read -r manifest; do
+    directory="$(dirname "$manifest")"
+    [ -f "$directory/src/lib.rs" ] || continue
+    grep -aq '^pub fn init_metrics()' "$directory/src/lib.rs" || continue
+    # Crates whose metrics are unconditional have no feature to test.
+    grep -aq '^metrics = ' "$manifest" || continue
+
+    crate="$(grep -am1 '^name = ' "$manifest" | sed 's/name = "\(.*\)"/\1/')"
+    echo "checking $crate with --features metrics"
+    if ! cargo check --locked -p "$crate" --features metrics --lib; then
+        echo "ERROR: $crate does not build with its own metrics feature."
+        echo "       Its init_metrics() calls a dependency whose metrics feature it never"
+        echo "       enables. Add the missing \"<dependency>/metrics\" to [features] metrics."
+        status=1
+    fi
+done < <(find linera-* -maxdepth 2 -name Cargo.toml -not -path '*/target/*' | sort)
+
+exit "$status"


### PR DESCRIPTION
Backport of #6727 to `testnet_conway`.

## Motivation

#6703 made each crate's `init_metrics` call the `init_metrics` of the crates below it. Two
things that depends on were never enforced, and two of them were live on this branch:

- **A call into a cfg-gated module needs the same cfg.** `linera-rpc::init_metrics` called
  `cross_chain_message_queue::metrics::init_metrics()` while that module is
  `#![cfg(with_server)]`, so `cargo check -p linera-rpc --features metrics` did not compile.
- **A crate's `metrics` feature has to turn on `metrics` for the dependencies it
  initializes.** `linera-exporter/metrics` enabled only `linera-base/metrics` even though its
  `init_metrics` calls `linera_rpc::init_metrics`, so `cargo check -p linera-exporter
  --features metrics` did not compile either.

Neither shows up in a workspace `--all-features` build, which unifies features across every
crate and always turns on a wasm runtime — they only fail for whoever builds one of these
crates on its own.

The equivalent `with_wasm_runtime` guard and the `linera-service` → `linera-exporter`
propagation already landed here with #6721; this brings the rest.

## Proposal

Same as #6727:

1. Guard the `cross_chain_message_queue` init behind `with_server`.
2. Add `linera-rpc/metrics` to `linera-exporter`'s `metrics` feature — the one edge that was
   actually missing; the rest arrive transitively.
3. **`scripts/check_metrics_features.sh` + a `lint-metrics-features` CI job**, deriving the
   crate list the same way `check_metrics_registration.sh` does and running
   `cargo check -p <crate> --features metrics --lib` on each. The compiler is the check rather
   than a reimplementation of cargo's feature resolution, which would have to follow
   transitive `dep/feature` edges to avoid false positives.
4. **Name the metric when registration fails**: `cannot register metric {name}: {error}`
   instead of `IntCounter can be created`. `.expect` cannot carry the name — `.expect(&format!(..))`
   trips `clippy::expect_fun_call`, which is on by default and would fail this repo's
   `-D warnings`; its own suggested fix is the `unwrap_or_else(|_| panic!(..))` used here.

## Difference from the `main` version

One conflict. `main` carries a second copy of `register_int_counter_with_subsystem` that this
branch does not — #6721 dropped the duplicate because this branch already had its own. The
cherry-pick therefore tried to update a copy that is not here; resolved by keeping this
branch's single copy and applying the same message change to it directly.

Verified afterwards: 0 remaining `expect("… can be created")`, 15 `registration_failure` call
sites, exactly 1 definition of the helper and 1 of `register_int_counter_with_subsystem`.

## Test Plan

```
scripts/check_metrics_features.sh                                    -> exit 0 (11 crates)
scripts/check_metrics_registration.sh                                -> exit 0
cargo fmt -- --check                                                 -> exit 0
taplo fmt --check --diff                                             -> exit 0
cargo test -p linera-base  --features metrics --lib                  -> 62 passed
cargo test -p linera-views --features metrics --lib                  -> 130 passed
```

Tests were run as full binaries rather than filtered: a filtered run hides cross-test state,
which is how a duplicate-registration failure slipped past local verification in #6721.

The workspace clippy (`--exclude linera-web`) is **not** reported clean here: this sandbox's
build is unreliable for it, failing on a different third-party crate each run
(`alloy-json-abi`, then `reqwest`/`linera-wasmer-compiler`), none of them touched by this
change. CI runs it on a clean runner and is the authority.

## Release Plan

- Nothing to do / These changes follow the usual deployment cycle.

## Links

- #6727 — the `main` change this backports
- #6703 / #6721 — eager metric registration and its backport, which these follow up
