### PR TITLE
Batch the ByteMapView entries resolver into a single multi_get

### DIFF
--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -2219,15 +2219,13 @@ mod graphql {
                 self.keys().await?
             };
 
-            let mut entries = vec![];
-            for key in keys {
-                entries.push(Entry {
-                    value: self.get(&key).await?,
-                    key,
-                })
-            }
+            let values = self.multi_get(keys.clone()).await?;
 
-            Ok(entries)
+            Ok(keys
+                .into_iter()
+                .zip(values)
+                .map(|(key, value)| Entry { key, value })
+                .collect())
         }
     }
 


### PR DESCRIPTION
## Motivation

The GraphQL `entries` resolver on `ByteMapView` fetched one key at a time:

```rust
for key in keys {
    entries.push(Entry { value: self.get(&key).await?, key })
}
```

Each `get` that misses the in-memory updates issues its own `read_value_bytes`, so a query
for N keys costs N storage round trips. `multi_get` already exists on the same type and
resolves the whole set with a single `read_multi_values_bytes`.

This was the only N+1 left in the view GraphQL layer; the other views' resolvers already
batch.

## Proposal

Use `multi_get` and zip the results back onto the keys. `multi_get` returns values in the
order of the keys it was given, so the pairing is positional.

## Test Plan

`cargo clippy -p linera-views --features metrics --all-targets -- -D warnings` and
`cargo test -p linera-views --features metrics` (375 passing). `with_graphql` is enabled by
default off the web target, so the resolver is covered by the ordinary build.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
