### PR TITLE
Stop allocating a key buffer per row in the KeyValueStoreView prefix scans

### DIFF
--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -880,7 +880,7 @@ impl<C: Context> KeyValueStoreView<C> {
             key_prefix.len() <= self.max_key_size(),
             ViewError::KeyTooLong
         );
-        let len = key_prefix.len();
+        let key_prefix_len = key_prefix.len();
         let key_prefix_full = self
             .context
             .base_key()
@@ -894,7 +894,6 @@ impl<C: Context> KeyValueStoreView<C> {
         if !self.deletion_set.delete_storage_first {
             let mut suffix_closed_set =
                 SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
-            let has_deleted_prefixes = !self.deletion_set.deleted_prefixes.is_empty();
             let mut key_with_prefix = key_prefix.to_vec();
             for key in self
                 .context
@@ -905,23 +904,20 @@ impl<C: Context> KeyValueStoreView<C> {
                 loop {
                     match update {
                         Some((update_key, update_value))
-                            if &update_key[len..] <= key.as_slice() =>
+                            if &update_key[key_prefix_len..] <= key.as_slice() =>
                         {
                             if let Update::Set(_) = update_value {
-                                keys.push(update_key[len..].to_vec());
+                                keys.push(update_key[key_prefix_len..].to_vec());
                             }
                             update = updates.next();
-                            if update_key[len..] == key[..] {
+                            if update_key[key_prefix_len..] == key[..] {
                                 break;
                             }
                         }
                         _ => {
-                            let deleted = has_deleted_prefixes && {
-                                key_with_prefix.truncate(len);
-                                key_with_prefix.extend_from_slice(&key);
-                                suffix_closed_set.find_key(&key_with_prefix)
-                            };
-                            if !deleted {
+                            key_with_prefix.truncate(key_prefix_len);
+                            key_with_prefix.extend_from_slice(&key);
+                            if !suffix_closed_set.find_key(&key_with_prefix) {
                                 keys.push(key);
                             }
                             break;
@@ -932,7 +928,7 @@ impl<C: Context> KeyValueStoreView<C> {
         }
         while let Some((update_key, update_value)) = update {
             if let Update::Set(_) = update_value {
-                let update_key = update_key[len..].to_vec();
+                let update_key = update_key[key_prefix_len..].to_vec();
                 keys.push(update_key);
             }
             update = updates.next();
@@ -966,7 +962,7 @@ impl<C: Context> KeyValueStoreView<C> {
             key_prefix.len() <= self.max_key_size(),
             ViewError::KeyTooLong
         );
-        let len = key_prefix.len();
+        let key_prefix_len = key_prefix.len();
         let key_prefix_full = self
             .context
             .base_key()
@@ -980,7 +976,6 @@ impl<C: Context> KeyValueStoreView<C> {
         if !self.deletion_set.delete_storage_first {
             let mut suffix_closed_set =
                 SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
-            let has_deleted_prefixes = !self.deletion_set.deleted_prefixes.is_empty();
             let mut key_with_prefix = key_prefix.to_vec();
             for entry in self
                 .context
@@ -991,23 +986,23 @@ impl<C: Context> KeyValueStoreView<C> {
                 let (key, value) = entry;
                 loop {
                     match update {
-                        Some((update_key, update_value)) if update_key[len..] <= key[..] => {
+                        Some((update_key, update_value))
+                            if update_key[key_prefix_len..] <= key[..] =>
+                        {
                             if let Update::Set(update_value) = update_value {
-                                let key_value = (update_key[len..].to_vec(), update_value.to_vec());
+                                let key_value =
+                                    (update_key[key_prefix_len..].to_vec(), update_value.to_vec());
                                 key_values.push(key_value);
                             }
                             update = updates.next();
-                            if update_key[len..] == key[..] {
+                            if update_key[key_prefix_len..] == key[..] {
                                 break;
                             }
                         }
                         _ => {
-                            let deleted = has_deleted_prefixes && {
-                                key_with_prefix.truncate(len);
-                                key_with_prefix.extend_from_slice(&key);
-                                suffix_closed_set.find_key(&key_with_prefix)
-                            };
-                            if !deleted {
+                            key_with_prefix.truncate(key_prefix_len);
+                            key_with_prefix.extend_from_slice(&key);
+                            if !suffix_closed_set.find_key(&key_with_prefix) {
                                 key_values.push((key, value));
                             }
                             break;
@@ -1018,7 +1013,7 @@ impl<C: Context> KeyValueStoreView<C> {
         }
         while let Some((update_key, update_value)) = update {
             if let Update::Set(update_value) = update_value {
-                let key_value = (update_key[len..].to_vec(), update_value.to_vec());
+                let key_value = (update_key[key_prefix_len..].to_vec(), update_value.to_vec());
                 key_values.push(key_value);
             }
             update = updates.next();

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -894,6 +894,7 @@ impl<C: Context> KeyValueStoreView<C> {
         if !self.deletion_set.delete_storage_first {
             let mut suffix_closed_set =
                 SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
+            let has_deleted_prefixes = !self.deletion_set.deleted_prefixes.is_empty();
             let mut key_with_prefix = key_prefix.to_vec();
             for key in self
                 .context
@@ -915,9 +916,14 @@ impl<C: Context> KeyValueStoreView<C> {
                             }
                         }
                         _ => {
-                            key_with_prefix.truncate(key_prefix_len);
-                            key_with_prefix.extend_from_slice(&key);
-                            if !suffix_closed_set.find_key(&key_with_prefix) {
+                            let deleted = if has_deleted_prefixes {
+                                key_with_prefix.truncate(key_prefix_len);
+                                key_with_prefix.extend_from_slice(&key);
+                                suffix_closed_set.find_key(&key_with_prefix)
+                            } else {
+                                false
+                            };
+                            if !deleted {
                                 keys.push(key);
                             }
                             break;
@@ -976,6 +982,7 @@ impl<C: Context> KeyValueStoreView<C> {
         if !self.deletion_set.delete_storage_first {
             let mut suffix_closed_set =
                 SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
+            let has_deleted_prefixes = !self.deletion_set.deleted_prefixes.is_empty();
             let mut key_with_prefix = key_prefix.to_vec();
             for entry in self
                 .context
@@ -1000,9 +1007,14 @@ impl<C: Context> KeyValueStoreView<C> {
                             }
                         }
                         _ => {
-                            key_with_prefix.truncate(key_prefix_len);
-                            key_with_prefix.extend_from_slice(&key);
-                            if !suffix_closed_set.find_key(&key_with_prefix) {
+                            let deleted = if has_deleted_prefixes {
+                                key_with_prefix.truncate(key_prefix_len);
+                                key_with_prefix.extend_from_slice(&key);
+                                suffix_closed_set.find_key(&key_with_prefix)
+                            } else {
+                                false
+                            };
+                            if !deleted {
                                 key_values.push((key, value));
                             }
                             break;

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -894,6 +894,8 @@ impl<C: Context> KeyValueStoreView<C> {
         if !self.deletion_set.delete_storage_first {
             let mut suffix_closed_set =
                 SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
+            let has_deleted_prefixes = !self.deletion_set.deleted_prefixes.is_empty();
+            let mut key_with_prefix = key_prefix.to_vec();
             for key in self
                 .context
                 .store()
@@ -914,9 +916,12 @@ impl<C: Context> KeyValueStoreView<C> {
                             }
                         }
                         _ => {
-                            let mut key_with_prefix = key_prefix.to_vec();
-                            key_with_prefix.extend_from_slice(&key);
-                            if !suffix_closed_set.find_key(&key_with_prefix) {
+                            let deleted = has_deleted_prefixes && {
+                                key_with_prefix.truncate(len);
+                                key_with_prefix.extend_from_slice(&key);
+                                suffix_closed_set.find_key(&key_with_prefix)
+                            };
+                            if !deleted {
                                 keys.push(key);
                             }
                             break;
@@ -975,6 +980,8 @@ impl<C: Context> KeyValueStoreView<C> {
         if !self.deletion_set.delete_storage_first {
             let mut suffix_closed_set =
                 SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
+            let has_deleted_prefixes = !self.deletion_set.deleted_prefixes.is_empty();
+            let mut key_with_prefix = key_prefix.to_vec();
             for entry in self
                 .context
                 .store()
@@ -995,9 +1002,12 @@ impl<C: Context> KeyValueStoreView<C> {
                             }
                         }
                         _ => {
-                            let mut key_with_prefix = key_prefix.to_vec();
-                            key_with_prefix.extend_from_slice(&key);
-                            if !suffix_closed_set.find_key(&key_with_prefix) {
+                            let deleted = has_deleted_prefixes && {
+                                key_with_prefix.truncate(len);
+                                key_with_prefix.extend_from_slice(&key);
+                                suffix_closed_set.find_key(&key_with_prefix)
+                            };
+                            if !deleted {
                                 key_values.push((key, value));
                             }
                             break;


### PR DESCRIPTION
## Motivation

`KeyValueStoreView::find_keys_by_prefix` and `find_key_values_by_prefix` allocated a fresh
`Vec<u8>` for **every row returned by storage**, purely to ask whether that row is covered by
a deleted prefix:

```rust
let mut key_with_prefix = key_prefix.to_vec();
key_with_prefix.extend_from_slice(&key);
if !suffix_closed_set.find_key(&key_with_prefix) { ... }
```

A scan returning N rows therefore performed N allocations and N frees on top of the scan
itself. The buffer's contents are the same prefix every time, so nothing required it to be
rebuilt from scratch per row.

## Proposal

Hoist one reusable buffer out of the loop and reset it with `truncate` instead of
reallocating. Per scan this goes from N allocations to one, and the buffer holds exactly the
same bytes on each iteration as the per-row `Vec` did.

Skip the work entirely when there is nothing to check. `deleted_prefixes` is only ever
populated by `remove_by_prefix`, so it is empty for the overwhelming majority of views, and in
that case `SuffixClosedSetIterator::find_key` returns `false` immediately
(`common.rs:178-184`) after the caller has already paid for the copy:

```rust
let deleted = if has_deleted_prefixes {
    key_with_prefix.truncate(key_prefix_len);
    key_with_prefix.extend_from_slice(&key);
    suffix_closed_set.find_key(&key_with_prefix)
} else {
    false
};
```

The behaviour is unchanged: `false` is what `find_key` already returned for an empty set.

Also renames `len` to `key_prefix_len` in both functions, since `len` alone was ambiguous
alongside the several `.len()` calls in the same scope.

The sibling `for_each_index_while` / `for_each_index_value_while` do not need this — they scan
from an empty prefix and pass the storage key to `find_key` directly, with no buffer involved.

## Test Plan

`cargo test -p linera-views --features metrics` — 375 passing, and
`cargo clippy -p linera-views --features metrics --all-targets -- -D warnings` is clean.

The path this touches is covered by `linera-views/tests/random_container_tests.rs`, which
drives a `KeyValueStoreView` through randomized `remove_by_prefix` and prefix-query sequences
and compares the results against a reference `BTreeMap` — so the non-empty `deleted_prefixes`
branch is exercised differentially, not just smoke-tested.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
