### PR TITLE
Rename KeyValueStoreView::count to iterative_count

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -819,7 +819,7 @@ where
             } => {
                 let view = self.state.users.try_load_entry(&application).await?;
                 let result = match view {
-                    Some(view) => view.count().await? == 0,
+                    Some(view) => view.iterative_count().await? == 0,
                     None => true,
                 };
                 callback.respond(result);

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -567,11 +567,11 @@ impl<C: Context> KeyValueStoreView<C> {
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![0]).await.unwrap();
     /// view.insert(vec![0, 2], vec![0]).await.unwrap();
-    /// let count = view.count().await.unwrap();
+    /// let count = view.iterative_count().await.unwrap();
     /// assert_eq!(count, 2);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
         let mut count = 0;
         self.for_each_index(|_index| {
             count += 1;

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -161,7 +161,7 @@ async fn key_value_store_view_mutability() -> Result<()> {
         let mut new_state_vec = state_vec.clone();
         for _ in 0..count_oper {
             let choice = rng.gen_range(0..5);
-            let entry_count = view.store.count().await?;
+            let entry_count = view.store.iterative_count().await?;
             if choice == 0 {
                 // inserting random stuff
                 let n_ins = rng.gen_range(0..10);


### PR DESCRIPTION
## Motivation

`KeyValueStoreView::count()` is not a cheap accessor. It runs `for_each_index`, which issues a
full `find_keys_by_prefix` against storage and transfers every key's bytes, only to increment a
counter. Its name suggests otherwise.

The rest of the crate already distinguishes the two. `SetView`, `MapView`, `CollectionView` and
`ReentrantCollectionView` all expose this operation as `iterative_count()`, while the genuinely
O(1) accessors on `LogView`, `QueueView` and `BucketQueueView` — which read a stored counter —
keep the plain name `count()`. `KeyValueStoreView` was the sole outlier, sitting on the
expensive side of that line with the cheap name.

The one production caller shows what the name invites:

```rust
Some(view) => view.count().await? == 0,
```

`execution_state_actor.rs`, `HasEmptyStorage` — an emptiness test paying for a full scan.

## Proposal

Rename `KeyValueStoreView::count` to `iterative_count`, matching the existing convention. Three
call sites: the definition, the `HasEmptyStorage` handler in `linera-execution`, and a
randomized test in `linera-views`.

This is a rename only. Making the operation actually cheap would need a counting primitive on
the store trait, and short-circuiting `HasEmptyStorage` would not help on its own — the
underlying `find_keys_by_prefix` has already materialised every key by the time the loop runs,
so the scan, not the counting, is the cost.

## Test Plan

`cargo clippy --locked --all-targets --all-features --workspace` — clean. Note the plain
`cargo check --workspace` misses the test call site; `--all-targets` is what catches it.

`cargo test -p linera-views --features metrics` — 375 passing. Nightly `cargo fmt --check`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

Note this renames a public method on `linera-views`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
