### PR TITLE
Borrow keys instead of copying them twice per ScyllaDB multi-key query

### DIFF
--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -392,11 +392,11 @@ impl ScyllaDbClient {
     }
 
     fn get_occurrences_map(
-        keys: Vec<Vec<u8>>,
-    ) -> Result<HashMap<Vec<u8>, Vec<usize>>, ScyllaDbStoreInternalError> {
-        let mut map = HashMap::<Vec<u8>, Vec<usize>>::new();
-        for (i_key, key) in keys.into_iter().enumerate() {
-            Self::check_key_size(&key)?;
+        keys: &[Vec<u8>],
+    ) -> Result<HashMap<&[u8], Vec<usize>>, ScyllaDbStoreInternalError> {
+        let mut map = HashMap::<&[u8], Vec<usize>>::new();
+        for (i_key, key) in keys.iter().enumerate() {
+            Self::check_key_size(key)?;
             map.entry(key).or_default().push(i_key);
         }
         Ok(map)
@@ -405,20 +405,20 @@ impl ScyllaDbClient {
     async fn read_multi_values_internal(
         &self,
         root_key: &[u8],
-        keys: Vec<Vec<u8>>,
+        keys: &[Vec<u8>],
     ) -> Result<Vec<Option<Vec<u8>>>, ScyllaDbStoreInternalError> {
         let mut values = vec![None; keys.len()];
         let map = Self::get_occurrences_map(keys)?;
         let statement = self.get_multi_key_values_statement(map.len()).await?;
-        let mut inputs = vec![root_key.to_vec()];
-        inputs.extend(map.keys().cloned());
+        let mut inputs = vec![root_key];
+        inputs.extend(map.keys().copied());
         let mut rows = Box::pin(self.session.execute_iter(statement, &inputs))
             .await?
             .rows_stream::<(Vec<u8>, Vec<u8>)>()?;
 
         while let Some(row) = rows.next().await {
             let (key, value) = row?;
-            if let Some((&last, rest)) = map[&key].split_last() {
+            if let Some((&last, rest)) = map[key.as_slice()].split_last() {
                 for position in rest {
                     values[*position] = Some(value.clone());
                 }
@@ -431,20 +431,20 @@ impl ScyllaDbClient {
     async fn contains_keys_internal(
         &self,
         root_key: &[u8],
-        keys: Vec<Vec<u8>>,
+        keys: &[Vec<u8>],
     ) -> Result<Vec<bool>, ScyllaDbStoreInternalError> {
         let mut values = vec![false; keys.len()];
         let map = Self::get_occurrences_map(keys)?;
         let statement = self.get_multi_keys_statement(map.len()).await?;
-        let mut inputs = vec![root_key.to_vec()];
-        inputs.extend(map.keys().cloned());
+        let mut inputs = vec![root_key];
+        inputs.extend(map.keys().copied());
         let mut rows = Box::pin(self.session.execute_iter(statement, &inputs))
             .await?
             .rows_stream::<(Vec<u8>,)>()?;
 
         while let Some(row) = rows.next().await {
             let (key,) = row?;
-            for i_key in &map[&key] {
+            for i_key in &map[key.as_slice()] {
                 values[*i_key] = true;
             }
         }
@@ -869,7 +869,7 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
         let _guard = self.acquire().await;
         let handles = keys
             .chunks(MAX_MULTI_KEYS)
-            .map(|keys| store.contains_keys_internal(&self.root_key, keys.to_vec()));
+            .map(|keys| store.contains_keys_internal(&self.root_key, keys));
         let results: Vec<_> = join_all(handles)
             .await
             .into_iter()
@@ -888,7 +888,7 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
         let _guard = self.acquire().await;
         let handles = keys
             .chunks(MAX_MULTI_KEYS)
-            .map(|keys| store.read_multi_values_internal(&self.root_key, keys.to_vec()));
+            .map(|keys| store.read_multi_values_internal(&self.root_key, keys));
         let results: Vec<_> = join_all(handles)
             .await
             .into_iter()


### PR DESCRIPTION
## Motivation

Every key in a ScyllaDB multi-key query was copied twice before reaching the driver.

`read_multi_values_bytes` and `contains_keys` split the caller's `&[Vec<u8>]` into
`MAX_MULTI_KEYS` chunks and cloned each chunk into an owned `Vec<Vec<u8>>`:

```rust
.map(|keys| store.read_multi_values_internal(&self.root_key, keys.to_vec()));
```

`get_occurrences_map` then moved those keys into its `HashMap`, and the query inputs cloned
them a second time:

```rust
inputs.extend(map.keys().cloned());
```

So a multi-get of N keys performed 2N key allocations and copies on top of the query itself.
`read_multi_values_bytes` is the batching primitive behind every view that loads more than one
entry, so this is on the common read path.

## Proposal

Borrow throughout. `get_occurrences_map` now returns `HashMap<&[u8], Vec<usize>>` keyed on
slices of the caller's buffer, the two `*_internal` functions take `&[Vec<u8>]`, and the query
inputs become `Vec<&[u8]>` — `scylla` implements `SerializeValue for &[u8]`, so the driver
serialises straight from the caller's memory.

Chunks are then passed through directly with no `to_vec()`, taking the count from 2N
allocations to zero. Row lookups index the map with `key.as_slice()`.

The futures now borrow the caller's key slice, which is fine: `join_all` is awaited inside the
same function that owns the slice.

## Test Plan

`cargo clippy -p linera-views --features scylladb,metrics --all-targets -- -D warnings` — clean.
`cargo test -p linera-views --features metrics` — 375 passing. Nightly `cargo fmt --check`.

`linera-views/**` triggers `.github/workflows/scylladb.yml`, so the multi-key paths this
touches are exercised against a real ScyllaDB by `test_read_multi_values_scylla_db` and the
rest of the suite.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
