### PR TITLE
Take web-thread 0.2.3, which keeps the JavaScript error cause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11770,9 +11770,9 @@ dependencies = [
 
 [[package]]
 name = "web-thread"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060cfc12637ebaf48b344331cea64fe6d13fed9a1381fb6cce10c3c7495778b4"
+checksum = "530b2c4dae7b3ce941d735a2be6c5759290b57fa64d354fd5560bb24046b87e9"
 dependencies = [
  "futures",
  "pin-project-lite",


### PR DESCRIPTION
## Motivation

`web-thread` 0.2.2 had an inverted `Option::filter` in `From<JsValue> for Error`:

```rust
source: Some(error.cause())
    .filter(JsValue::is_undefined)
    .map(|x| Box::new(Error::from(x))),
```

`Option::filter` keeps the value when the predicate is `true`, so the `cause` was retained only when it *was* `undefined`. Every error therefore ended up with a source chain exactly one node long, and that node was the junk `could not cast value of type "undefined" to Error` produced by recursing into `undefined` — while any real `cause` was dropped.

linera-io/web-thread#2 fixed it, and 0.2.3 is that fix and nothing else: diffing the published crates, 0.2.2 and 0.2.3 differ only in `src/error.rs` and the version number.

## Proposal

Lockfile-only. `web-thread` is not a direct dependency — it arrives via `web-thread-pool` → `web-thread-select`, whose requirement is `^0.2.0` and so already admits 0.2.3. The whole change is `cargo update -p web-thread --precise 0.2.3`.

The blast radius is small in two ways worth stating:

- `web-thread` is an **optional** dependency of `web-thread-select`, enabled by its `web` feature. Host builds never compile it, so only the wasm web client is affected.
- **Nothing observable changes today.** The crate's `Display` prints only the description, so the `cause` reaches a message solely through `Debug`, and the one place that happens is `ExecutionError::Thread` (`#[error("Worker thread failure: {0:?}")]`, `linera-execution/src/lib.rs:328`). `WorkerError::Thread` uses `{0}` and is unaffected. A 90-day search of the web client's Sentry project returns zero issues matching `could not cast value of type`, bare `cast`, or `Worker thread failure`, against a control query that returns results — so `ExecutionError::Thread` is not reaching users at all.

This is a latent-correctness bump: it stops a wrong source chain being handed to anything that starts walking one.

## Test Plan

- `cargo clippy --lib` for `linera-web` on `wasm32-unknown-unknown` with the pinned nightly, run from `web/` so the target's `rustflags` apply.
- Host builds are unaffected by construction, since the crate is not compiled without `web-thread-select/web`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- linera-io/web-thread#2 — the upstream fix.
- Found while working on #6722, which fixes the same class of discarded-error problem in the Web `Signer` bridge.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
