### PR TITLE
Backport #6733 to testnet_conway: take web-thread 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11614,9 +11614,9 @@ dependencies = [
 
 [[package]]
 name = "web-thread"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060cfc12637ebaf48b344331cea64fe6d13fed9a1381fb6cce10c3c7495778b4"
+checksum = "530b2c4dae7b3ce941d735a2be6c5759290b57fa64d354fd5560bb24046b87e9"
 dependencies = [
  "futures",
  "pin-project-lite",


### PR DESCRIPTION
## Motivation

Backport of #6733 to `testnet_conway`.

`web-thread` 0.2.2 had an inverted `Option::filter` in `From<JsValue> for Error`:

```rust
source: Some(error.cause())
    .filter(JsValue::is_undefined)
    .map(|x| Box::new(Error::from(x))),
```

`Option::filter` keeps the value when the predicate is `true`, so the `cause` was retained only when it *was* `undefined`. Every error therefore ended up with a source chain exactly one node long, holding the junk `could not cast value of type "undefined" to Error` produced by recursing into `undefined`, while any real `cause` was dropped.

linera-io/web-thread#2 fixed it. 0.2.3 is that fix and nothing else: diffing the published crates, 0.2.2 and 0.2.3 differ only in `src/error.rs` and the version number, and their dependency metadata in the registry index is identical — same requirements, no declared MSRV. So nothing here interacts with this branch's older toolchain pin.

This branch carries both affected sites unchanged from `main`: `ExecutionError::Thread` (`linera-execution/src/lib.rs:360`) and `WorkerError::Thread` (`linera-core/src/worker.rs:427`).

## Proposal

Lockfile-only, and produced by re-running the same command on this branch rather than cherry-picking:

```
cargo update -p web-thread --precise 0.2.3
```

No manifest change: `web-thread` is not a direct dependency but arrives via `web-thread-pool` → `web-thread-select`, whose requirement is `^0.2.0` and already admits 0.2.3.

As on `main`, the blast radius is small in two ways:

- `web-thread` is an **optional** dependency of `web-thread-select`, enabled by its `web` feature, so host builds never compile it. Only the wasm web client is affected.
- **Nothing observable changes.** The crate's `Display` prints only the description, so the `cause` reaches a message solely through `Debug`, and the one place that happens is `ExecutionError::Thread`'s `{0:?}`. `WorkerError::Thread` uses `{0}` and is unaffected. A 90-day search of the web client's Sentry project found zero issues matching `could not cast value of type`, bare `cast`, or `Worker thread failure`, against a control query that returns results.

A latent-correctness bump: it stops a wrong source chain being handed to anything that starts walking one.

## Test Plan

- `cargo check --lib` for `linera-web` on `wasm32-unknown-unknown` with this branch's pinned nightly, run from `web/` so the target's `rustflags` apply.
- Host builds are unaffected by construction, since the crate is not compiled without `web-thread-select/web`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6733 — the same change on `main`.
- linera-io/web-thread#2 — the upstream fix.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
