### PR TITLE
Make background certificate sync measurable: widen latency buckets, add volume metrics

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -85,6 +85,13 @@ pub(crate) mod metrics {
                 exponential_bucket_interval(1.0, 10_000.0),
             );
 
+        pub static RECEIVED_LOG_QUERY_ENTRIES: Histogram =
+            register_histogram(
+                "received_log_query_entries",
+                "Number of received-log entries returned per chain info query that asks for them",
+                exponential_bucket_interval(1.0, 100_000.0),
+            );
+
         pub static BLOCK_PROPOSALS_RECEIVED_TOTAL: IntCounter =
             register_int_counter(
                 "block_proposals_received_total",
@@ -2652,6 +2659,8 @@ where
                 .saturating_add(max_received_log_entries)
                 .min(chain.received_log.count());
             info.requested_received_log = chain.received_log.read(start..end).await?;
+            #[cfg(with_metrics)]
+            metrics::RECEIVED_LOG_QUERY_ENTRIES.observe(info.requested_received_log.len() as f64);
         }
         if query.request_manager_values {
             info.manager.add_values(&chain.manager);

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1061,9 +1061,15 @@ impl<Env: Environment> ChainClient<Env> {
             std::mem::take(received_log_batches.as_mut())
         };
 
+        let received_logs_total = received_logs.iter().map(|x| x.1.len()).sum::<usize>();
+        #[cfg(with_metrics)]
+        super::metrics::FIND_RECEIVED_CERTIFICATES_LOG_ENTRIES
+            .with_label_values(&[])
+            .observe(received_logs_total as f64);
+
         debug!(
             received_logs_len = %received_logs.len(),
-            received_logs_total = %received_logs.iter().map(|x| x.1.len()).sum::<usize>(),
+            %received_logs_total,
             "collected received logs"
         );
 
@@ -1073,6 +1079,15 @@ impl<Env: Environment> ChainClient<Env> {
                 ValidatorTrackers::new(received_logs, &trackers),
             )
         };
+
+        #[cfg(with_metrics)]
+        {
+            super::metrics::FIND_RECEIVED_CERTIFICATES_SENDER_CHAINS
+                .with_label_values(&[])
+                .observe(received_logs.num_chains() as f64);
+            super::metrics::SENDER_CERTIFICATES_DISCOVERED_TOTAL
+                .inc_by(received_logs.num_certs() as u64);
+        }
 
         debug!(
             num_chains = %received_logs.num_chains(),
@@ -1140,6 +1155,9 @@ impl<Env: Environment> ChainClient<Env> {
             .await?;
 
         validator_trackers.filter_out_already_known(&mut received_logs, &local_next_heights);
+
+        #[cfg(with_metrics)]
+        super::metrics::SENDER_CERTIFICATES_MISSING_TOTAL.inc_by(received_logs.num_certs() as u64);
 
         debug!(
             remaining_total_certificates = %received_logs.num_certs(),

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -80,9 +80,10 @@ mod validator_trackers;
 #[cfg(with_metrics)]
 pub(crate) mod metrics {
     use linera_base::prometheus_util::{
-        exponential_bucket_latencies, register_histogram_vec, register_int_counter_vec,
+        exponential_bucket_interval, exponential_bucket_latencies, register_histogram_vec,
+        register_int_counter, register_int_counter_vec,
     };
-    use prometheus::{HistogramVec, IntCounterVec};
+    use prometheus::{HistogramVec, IntCounter, IntCounterVec};
 
     linera_base::declare_metrics! {
         pub static PROCESS_INBOX_WITHOUT_PREPARE_LATENCY: HistogramVec =
@@ -90,7 +91,7 @@ pub(crate) mod metrics {
                 "process_inbox_latency",
                 "process_inbox latency",
                 &[],
-                exponential_bucket_latencies(10_000.0),
+                exponential_bucket_latencies(60_000.0),
             );
 
         pub static PREPARE_CHAIN_LATENCY: HistogramVec =
@@ -98,7 +99,7 @@ pub(crate) mod metrics {
                 "prepare_chain_latency",
                 "prepare_chain latency",
                 &[],
-                exponential_bucket_latencies(10_000.0),
+                exponential_bucket_latencies(60_000.0),
             );
 
         pub static SYNCHRONIZE_CHAIN_STATE_LATENCY: HistogramVec =
@@ -106,7 +107,7 @@ pub(crate) mod metrics {
                 "synchronize_chain_state_latency",
                 "synchronize_chain_state latency",
                 &[],
-                exponential_bucket_latencies(10_000.0),
+                exponential_bucket_latencies(600_000.0),
             );
 
         pub static EXECUTE_BLOCK_LATENCY: HistogramVec =
@@ -122,7 +123,35 @@ pub(crate) mod metrics {
                 "find_received_certificates_latency",
                 "find_received_certificates latency",
                 &[],
-                exponential_bucket_latencies(10_000.0),
+                exponential_bucket_latencies(600_000.0),
+            );
+
+        pub static FIND_RECEIVED_CERTIFICATES_LOG_ENTRIES: HistogramVec =
+            register_histogram_vec(
+                "find_received_certificates_log_entries",
+                "Number of received-log entries collected from the validators, per call",
+                &[],
+                exponential_bucket_interval(1.0, 1_000_000.0),
+            );
+
+        pub static FIND_RECEIVED_CERTIFICATES_SENDER_CHAINS: HistogramVec =
+            register_histogram_vec(
+                "find_received_certificates_sender_chains",
+                "Number of distinct sender chains to synchronize, per call",
+                &[],
+                exponential_bucket_interval(1.0, 100_000.0),
+            );
+
+        pub static SENDER_CERTIFICATES_DISCOVERED_TOTAL: IntCounter =
+            register_int_counter(
+                "sender_certificates_discovered_total",
+                "Total number of sender certificates advertised by the validators' received logs",
+            );
+
+        pub static SENDER_CERTIFICATES_MISSING_TOTAL: IntCounter =
+            register_int_counter(
+                "sender_certificates_missing_total",
+                "Total number of sender certificates not already known locally, hence downloaded",
             );
 
         pub static BLOCK_STAGING_FAILURES_TOTAL: IntCounterVec =

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -123,7 +123,7 @@ pub(crate) mod metrics {
                 "find_received_certificates_latency",
                 "find_received_certificates latency",
                 &[],
-                exponential_bucket_latencies(600_000.0),
+                exponential_bucket_latencies(3_600_000.0),
             );
 
         pub static FIND_RECEIVED_CERTIFICATES_LOG_ENTRIES: HistogramVec =


### PR DESCRIPTION
## Motivation

Measuring what the chain listener's background sync actually costs in production
(`testnet_conway`, the `pm-infra` node services) runs into two blind spots.

**The client-side latency histograms top out far below the real values.** All of them use
`exponential_bucket_latencies(10_000.0)`, so the last finite bucket is 10 s. Over the last
7 days on the pm-infra workers:

| histogram | share of calls above the 10 s bucket | mean |
|---|---|---|
| `find_received_certificates_latency` | **47.4%** | 352 s |
| `synchronize_chain_state_latency` | 7.1% | 2.4 s |
| `process_inbox_latency` | 0.14% | 169 ms |
| `execute_block_latency` | 0.003% | 91 ms |

`find_received_certificates` has a valid p50 (3.7 s) and nothing usable above p52.5 — every
quantile that matters lands in `+Inf`. Only `_sum / _count` is meaningful today.

**Nothing records how much work a sync call did.** A 500 s call that fetched 5 certificates
and one that fetched 20,000 are indistinguishable, because the chain and certificate counts
only exist as `debug!` fields, which are off in production. On the validator side the same
gap appears one level down: a received-log query is just a `ChainInfoQuery` with
`request_received_log_excluding_first_n` set, so it cannot be separated from the ~57 req/s
of ordinary chain info queries the shards serve.

## Proposal

Widen the buckets where the data says they overflow, and leave `execute_block_latency`
alone:

- `find_received_certificates_latency`, `synchronize_chain_state_latency`: 10 s → 10 min
- `process_inbox_latency`, `prepare_chain_latency`: 10 s → 1 min

Add four client-side volume metrics, at the points that already emit the corresponding
`debug!` fields:

- `linera_find_received_certificates_log_entries` — received-log entries collected from the
  validators, per call
- `linera_find_received_certificates_sender_chains` — distinct sender chains to sync, per call
- `linera_sender_certificates_discovered_total` — certificates advertised by the received logs
- `linera_sender_certificates_missing_total` — those not already known locally, i.e. the ones
  actually downloaded

`receive_sender_certificates` is only reachable from `find_received_certificates`, so the
last counter is exactly background-sync work. The discovered/missing ratio is the direct
measure of how much of a sync pass is redundant.

Add one validator-side histogram, `linera_received_log_query_entries`, observed where the
worker answers a received-log query. Its `_count` separates received-log queries from every
other `ChainInfoQuery`, and its distribution shows how often clients are paging (the client
loops until a response comes back short of `CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES`).

No behavioural change; all new observations are behind `cfg(with_metrics)`.

## Test Plan

CI. Locally, in the sandbox:

```
cargo clippy -p linera-core --lib -- -D warnings                      -> exit 0
cargo clippy -p linera-core --lib --features metrics -- -D warnings   -> exit 0
cargo clippy -p linera-core --all-targets -- -D warnings              -> exit 0
cargo +nightly-2026-05-11 fmt --all -- --check                        -> exit 0
scripts/check_metrics_registration.sh                                 -> exit 0
scripts/check_metrics_features.sh                                     -> exit 0
```

The new metrics sit inside the existing `declare_metrics!` blocks of `client::metrics` and
`chain_worker::state::metrics`, both already reached from `linera_core::init_metrics`, so
they are registered at startup rather than on first use.

The bucket counts grow modestly: `exponential_bucket_interval` uses factor 3 from 0.001 ms,
so a 10 s → 10 min cap adds 3 buckets to a 16-bucket histogram, and 10 s → 1 min adds 2.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

The numbers above come from `testnet_conway` in production, which is where the metrics are
most useful; the backport is a hand-port, since `main` wraps these registrations in
`declare_metrics!` (#6727) and `testnet_conway` does not.

## Links

- #6727 — the metrics registration wiring and CI checks these build on
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
