### PR TITLE
Report an invalid stream ID as such rather than as an invalid blob ID

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -704,7 +704,7 @@ impl std::str::FromStr for StreamId {
                 stream_name,
             })
         } else {
-            Err(anyhow!("Invalid blob ID: {s}"))
+            Err(anyhow!("Invalid stream ID: {s}"))
         }
     }
 }


### PR DESCRIPTION
## Motivation

`StreamId::from_str` reports a malformed stream ID as `Invalid blob ID: <s>` — the message
belongs to `BlobId::from_str`, a few hundred lines up, and looks like a copy-paste slip.
It sends anyone debugging a bad stream ID looking at blobs instead.

This turned up while adding a stream-reading API to `@linera/client`
(linera-io/linera-protocol#6740), where the parse error is surfaced straight to the
caller.

## Proposal

Say `Invalid stream ID` instead. Message only; no behaviour changes, and nothing asserts
the old text.

## Test Plan

CI. Locally: `cargo check -p linera-base` and `cargo fmt --check -p linera-base` under the
pinned nightly.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- linera-io/linera-protocol#6740, which surfaced it
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
