### PR TITLE
Isolate task groups from one another, and report a group that runs long instead of killing it

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -829,6 +829,9 @@ Run a GraphQL service to explore and extend the chains of the wallet
 * `--task-retry-delay-secs <TASK_RETRY_DELAY_SECS>` — Delay in seconds before retrying a failed operator task batch. Only relevant when operators are configured via `--operator-application-ids` or `--controller-id`
 
   Default value: `5`
+* `--slow-task-group-secs <SLOW_TASK_GROUP_SECS>` — Number of seconds after which a still-running operator task group is logged and counted as slow. The group is not interrupted: it is reported so that one which never returns does not stall its chain silently. Only relevant when operators are configured via `--operator-application-ids` or `--controller-id`
+
+  Default value: `300`
 * `--read-only` — Run in read-only mode: disallow mutations and prevent queries from scheduling operations. Use this when exposing the service to untrusted clients
 * `--query-cache-size <QUERY_CACHE_SIZE>` — Enable the application query response cache with the given per-chain capacity. Each entry stores a serialized GraphQL response keyed by (application_id, request_bytes). Incompatible with `--long-lived-services`
 * `--allow-subscription <ALLOWED_SUBSCRIPTIONS>` — Allow a named GraphQL subscription query. The operation name is extracted from the query string. Repeatable. Example: `--allow-subscription 'query CounterValue { getCounter { value } }'`

--- a/CLI.md
+++ b/CLI.md
@@ -829,7 +829,7 @@ Run a GraphQL service to explore and extend the chains of the wallet
 * `--task-retry-delay-secs <TASK_RETRY_DELAY_SECS>` — Delay in seconds before retrying a failed operator task batch. Only relevant when operators are configured via `--operator-application-ids` or `--controller-id`
 
   Default value: `5`
-* `--slow-task-group-secs <SLOW_TASK_GROUP_SECS>` — Number of seconds after which a still-running operator task group is logged and counted as slow. The group is not interrupted: it is reported so that one which never returns does not stall its chain silently. Only relevant when operators are configured via `--operator-application-ids` or `--controller-id`
+* `--slow-task-group-secs <SLOW_TASK_GROUP_SECS>` — Number of seconds after which a still-running operator task group is logged and counted as slow. The group is not interrupted and runs to completion. Only relevant when operators are configured via `--operator-application-ids` or `--controller-id`
 
   Default value: `300`
 * `--read-only` — Run in read-only mode: disallow mutations and prevent queries from scheduling operations. Use this when exposing the service to untrusted clients

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -810,8 +810,7 @@ pub enum ClientCommand {
         task_retry_delay_secs: u64,
 
         /// Number of seconds after which a still-running operator task group is logged and
-        /// counted as slow. The group is not interrupted: it is reported so that one which never
-        /// returns does not stall its chain silently.
+        /// counted as slow. The group is not interrupted and runs to completion.
         /// Only relevant when operators are configured via `--operator-application-ids`
         /// or `--controller-id`.
         #[arg(long, default_value = "300")]

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -809,12 +809,13 @@ pub enum ClientCommand {
         #[arg(long, default_value = "5")]
         task_retry_delay_secs: u64,
 
-        /// Maximum number of seconds a single operator invocation may run before it is killed
-        /// and its task retried. Bounds how long one slow operator can hold up its task group.
+        /// Number of seconds after which a still-running operator task group is logged and
+        /// counted as slow. The group is not interrupted: it is reported so that one which never
+        /// returns does not stall its chain silently.
         /// Only relevant when operators are configured via `--operator-application-ids`
         /// or `--controller-id`.
-        #[arg(long, default_value = "60")]
-        task_timeout_secs: u64,
+        #[arg(long, default_value = "300")]
+        slow_task_group_secs: u64,
 
         /// Run in read-only mode: disallow mutations and prevent queries from scheduling
         /// operations. Use this when exposing the service to untrusted clients.

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -809,6 +809,13 @@ pub enum ClientCommand {
         #[arg(long, default_value = "5")]
         task_retry_delay_secs: u64,
 
+        /// Maximum number of seconds a single operator invocation may run before it is killed
+        /// and its task retried. Bounds how long one slow operator can hold up its task group.
+        /// Only relevant when operators are configured via `--operator-application-ids`
+        /// or `--controller-id`.
+        #[arg(long, default_value = "60")]
+        task_timeout_secs: u64,
+
         /// Run in read-only mode: disallow mutations and prevent queries from scheduling
         /// operations. Use this when exposing the service to untrusted clients.
         #[arg(long)]

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1306,7 +1306,7 @@ impl Runnable for Job {
                 operators,
                 controller_application_id,
                 task_retry_delay_secs,
-                task_timeout_secs,
+                slow_task_group_secs,
                 read_only,
                 query_cache_size,
                 allowed_subscriptions,
@@ -1338,7 +1338,7 @@ impl Runnable for Job {
                 // Start the task processor if operator applications are specified.
                 let task_config = TaskProcessorConfig {
                     retry_delay: TimeDelta::from_secs(task_retry_delay_secs),
-                    task_timeout: TimeDelta::from_secs(task_timeout_secs),
+                    slow_group_threshold: TimeDelta::from_secs(slow_task_group_secs),
                 };
 
                 if !operator_application_ids.is_empty() {

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -79,7 +79,7 @@ use linera_service::{
     node_service::NodeService,
     project::{self, Project},
     storage::{Runnable, RunnableWithStore, StorageCacheConfig},
-    task_processor::TaskProcessor,
+    task_processor::{TaskProcessor, TaskProcessorConfig},
     util,
 };
 use linera_storage::{DbStorage, Storage};
@@ -1306,6 +1306,7 @@ impl Runnable for Job {
                 operators,
                 controller_application_id,
                 task_retry_delay_secs,
+                task_timeout_secs,
                 read_only,
                 query_cache_size,
                 allowed_subscriptions,
@@ -1335,7 +1336,10 @@ impl Runnable for Job {
                 let operators = Arc::new(operators);
 
                 // Start the task processor if operator applications are specified.
-                let retry_delay = TimeDelta::from_secs(task_retry_delay_secs);
+                let task_config = TaskProcessorConfig {
+                    retry_delay: TimeDelta::from_secs(task_retry_delay_secs),
+                    task_timeout: TimeDelta::from_secs(task_timeout_secs),
+                };
 
                 if !operator_application_ids.is_empty() {
                     let chain_client = context.make_chain_client(chain_id).await?;
@@ -1345,7 +1349,7 @@ impl Runnable for Job {
                         chain_client,
                         cancellation_token.clone(),
                         operators.clone(),
-                        retry_delay,
+                        task_config,
                         None,
                     );
                     tokio::spawn(processor.run());
@@ -1366,7 +1370,7 @@ impl Runnable for Job {
                         chain_client,
                         cancellation_token.clone(),
                         operators,
-                        retry_delay,
+                        task_config,
                         command_sender,
                     );
 

--- a/linera-service/src/controller.rs
+++ b/linera-service/src/controller.rs
@@ -8,7 +8,7 @@ use std::{
 
 use futures::{lock::Mutex, stream::StreamExt, FutureExt};
 use linera_base::{
-    data_types::{MessagePolicy, TimeDelta},
+    data_types::MessagePolicy,
     identifiers::{ApplicationId, ChainId, GenericApplicationId},
 };
 use linera_client::chain_listener::{ClientContext, ListenerCommand};
@@ -28,7 +28,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
-use crate::task_processor::{OperatorMap, TaskProcessor};
+use crate::task_processor::{OperatorMap, TaskProcessor, TaskProcessorConfig};
 
 /// An update message sent to a TaskProcessor to change its set of applications.
 #[derive(Debug)]
@@ -50,7 +50,7 @@ pub struct Controller<Ctx: ClientContext> {
     cancellation_token: CancellationToken,
     notifications: NotificationStream,
     operators: OperatorMap,
-    retry_delay: TimeDelta,
+    config: TaskProcessorConfig,
     processors: BTreeMap<ChainId, ProcessorHandle>,
     listened_local_chains: BTreeSet<ChainId>,
     current_message_policies: BTreeMap<ChainId, MessagePolicy>,
@@ -79,7 +79,7 @@ where
         chain_client: ChainClient<Ctx::Environment>,
         cancellation_token: CancellationToken,
         operators: OperatorMap,
-        retry_delay: TimeDelta,
+        config: TaskProcessorConfig,
         command_sender: UnboundedSender<ListenerCommand>,
     ) -> Self {
         let notifications = chain_client.subscribe().expect("client subscription");
@@ -91,7 +91,7 @@ where
             cancellation_token,
             notifications,
             operators,
-            retry_delay,
+            config,
             processors: BTreeMap::new(),
             listened_local_chains: BTreeSet::new(),
             current_message_policies: BTreeMap::new(),
@@ -439,7 +439,7 @@ where
             chain_client,
             self.cancellation_token.child_token(),
             self.operators.clone(),
-            self.retry_delay,
+            self.config,
             Some(update_receiver),
         );
 

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -44,4 +44,5 @@ pub fn init_metrics() {
     linera_storage::init_metrics();
     linera_views::init_metrics();
     node_service::query_cache_metrics::init_metrics();
+    task_processor::metrics::init_metrics();
 }

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -8,7 +8,7 @@
 
 use std::{
     cmp::Reverse,
-    collections::{BTreeMap, BTreeSet, BinaryHeap},
+    collections::{BTreeMap, BTreeSet, BinaryHeap, HashSet},
     path::PathBuf,
     sync::Arc,
 };
@@ -212,12 +212,18 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         }
     }
 
+    /// Returns the applications whose deadlines have come, ordered by deadline and without
+    /// repetitions: an application has one state to read, so polling it twice in a row would
+    /// query it a second time for the same answer.
     fn process_events(&mut self) -> Vec<ApplicationId> {
         let now = Timestamp::now();
         let mut application_ids = Vec::new();
+        let mut seen = HashSet::new();
         while let Some(deadline) = self.deadlines.pop() {
             if let Reverse((_, Some(id))) = deadline {
-                application_ids.push(id);
+                if seen.insert(id) {
+                    application_ids.push(id);
+                }
             }
             let Some(Reverse((ts, _))) = self.deadlines.peek() else {
                 break;

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -26,9 +26,28 @@ use linera_core::{
 use serde_json::json;
 use tokio::{io::AsyncWriteExt, process::Command, select, sync::mpsc};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::controller::Update;
+
+#[cfg(with_metrics)]
+mod metrics {
+    use linera_base::prometheus_util::register_int_counter;
+    use prometheus::IntCounter;
+
+    linera_base::declare_metrics! {
+        /// Task groups that have outlived [`TaskProcessorConfig::slow_group_threshold`].
+        ///
+        /// The group is still running when this is incremented and may well succeed: a batch
+        /// catching up on a backlog takes far longer than a steady-state one. What makes it worth
+        /// alerting on is that nothing else reports it — the process stays healthy and its chain
+        /// simply stops advancing, so a group that never returns is otherwise silent.
+        pub static SLOW_TASK_GROUPS: IntCounter = register_int_counter(
+            "slow_task_groups_total",
+            "Number of task groups that outlived the slow-group threshold"
+        );
+    }
+}
 
 /// A map from operator names to their binary paths.
 pub type OperatorMap = Arc<BTreeMap<String, PathBuf>>;
@@ -50,12 +69,14 @@ type Deadline = Reverse<(Timestamp, Option<ApplicationId>)>;
 pub struct TaskProcessorConfig {
     /// How long to wait before retrying a task group that failed.
     pub retry_delay: TimeDelta,
-    /// Maximum wall-clock time for a single operator invocation.
+    /// How long a task group may run before it is reported as slow.
     ///
-    /// An operator that is merely slow cannot be told apart from one that will never return, and
-    /// nothing else bounds it: its group holds a slot for as long as it runs. Past this the
-    /// process is killed and the task is retried like any other failure.
-    pub task_timeout: TimeDelta,
+    /// Reported only: the group is never interrupted. An operator that is merely slow cannot be
+    /// told apart from one that will never return, and killing it would abort work that was about
+    /// to succeed — a batch catching up on a backlog legitimately runs far longer than a
+    /// steady-state one. Since a task that is cut short is retried, a limit set below what the
+    /// work needs never completes it, it only repeats it.
+    pub slow_group_threshold: TimeDelta,
 }
 
 /// Message sent from a background task group to the main loop on completion.
@@ -271,10 +292,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                         operators,
                         config,
                     ));
-                    let retry_at = handle.await.unwrap_or_else(|error| {
-                        error!(%application_id, ?group, %error, "Task group panicked");
-                        Some(Timestamp::now().saturating_add(config.retry_delay))
-                    });
+                    let retry_at = await_group(application_id, &group, handle, config).await;
                     if result_sender
                         .send(GroupResult {
                             application_id,
@@ -314,7 +332,6 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 application_id,
                 task,
                 operators.clone(),
-                config.task_timeout,
             )));
         }
         for handle in handles {
@@ -435,12 +452,11 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
     }
 }
 
-/// Runs one task's operator binary to completion, bounded by `task_timeout`.
+/// Runs one task's operator binary to completion.
 async fn execute_task(
     application_id: ApplicationId,
     task: Task,
     operators: OperatorMap,
-    task_timeout: TimeDelta,
 ) -> Result<TaskOutcome, anyhow::Error> {
     let Task {
         id,
@@ -454,20 +470,13 @@ async fn execute_task(
     let mut child = Command::new(binary_path)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        // Timing out below drops this `Child`. Without this the operator would go on running,
-        // detached, still holding whatever the timeout was meant to release.
-        .kill_on_drop(true)
         .spawn()?;
 
     let mut stdin = child.stdin.take().expect("stdin should be configured");
     stdin.write_all(input.as_bytes()).await?;
     drop(stdin);
 
-    let timeout = task_timeout.as_duration();
-    let Ok(output) = tokio::time::timeout(timeout, child.wait_with_output()).await else {
-        anyhow::bail!("operator {operator} timed out after {timeout:?}");
-    };
-    let output = output?;
+    let output = child.wait_with_output().await?;
     anyhow::ensure!(
         output.status.success(),
         "operator {} exited with status: {}",
@@ -481,6 +490,36 @@ async fn execute_task(
     };
     debug!("Done executing task for {application_id}");
     Ok(outcome)
+}
+
+/// Awaits a task group, reporting it once if it outlives `slow_group_threshold`.
+///
+/// Reporting only — the group keeps running afterwards. Cutting it short would abort work that may
+/// be about to succeed, and since the task would then be retried, a threshold below what the work
+/// needs would repeat it forever instead of ever completing it.
+async fn await_group(
+    application_id: ApplicationId,
+    group: &Option<String>,
+    mut handle: tokio::task::JoinHandle<Option<Timestamp>>,
+    config: TaskProcessorConfig,
+) -> Option<Timestamp> {
+    let on_panic = |error| {
+        error!(%application_id, ?group, %error, "Task group panicked");
+        Some(Timestamp::now().saturating_add(config.retry_delay))
+    };
+    let threshold = config.slow_group_threshold.as_duration();
+    match tokio::time::timeout(threshold, &mut handle).await {
+        Ok(result) => result.unwrap_or_else(on_panic),
+        Err(_) => {
+            warn!(
+                %application_id, ?group,
+                "Task group still running after {threshold:?}; leaving it to finish"
+            );
+            #[cfg(with_metrics)]
+            metrics::SLOW_TASK_GROUPS.inc();
+            handle.await.unwrap_or_else(on_panic)
+        }
+    }
 }
 
 /// Groups the tasks of a batch by id, keeping their relative order.
@@ -607,30 +646,28 @@ mod tests {
     async fn execute_task_returns_the_operator_output() {
         let dir = tempfile::tempdir().unwrap();
         let operators = operator_running("echo done", &dir);
-        let outcome = execute_task(app_id(), timed_task(), operators, TimeDelta::from_secs(60))
+        let outcome = execute_task(app_id(), timed_task(), operators)
             .await
             .unwrap();
         assert_eq!(outcome.output.trim(), "done");
     }
 
     #[tokio::test]
-    async fn execute_task_gives_up_on_an_operator_that_outruns_its_timeout() {
-        let dir = tempfile::tempdir().unwrap();
-        // Sleeps far past the timeout: without a bound this call would never return, and the
-        // group would stay in flight for as long as the process lived.
-        let operators = operator_running("sleep 300", &dir);
-        let error = execute_task(
-            app_id(),
-            timed_task(),
-            operators,
-            TimeDelta::from_millis(200),
-        )
-        .await
-        .unwrap_err();
-        assert!(
-            error.to_string().contains("timed out"),
-            "unexpected error: {error}"
-        );
+    async fn a_group_that_outlives_the_threshold_is_reported_but_still_awaited() {
+        let expected = Some(Timestamp::from(4_242));
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+            expected
+        });
+        let config = TaskProcessorConfig {
+            retry_delay: TimeDelta::from_secs(5),
+            // Far below what the group takes, so the slow path is the one exercised.
+            slow_group_threshold: TimeDelta::from_millis(10),
+        };
+        // The point of the assertion: crossing the threshold reports the group, it does not cut
+        // it short, so the result it was about to produce still comes back.
+        let retry_at = await_group(app_id(), &Some("group".to_string()), handle, config).await;
+        assert_eq!(retry_at, expected);
     }
 
     #[test]

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -58,10 +58,12 @@ pub struct TaskProcessorConfig {
     pub task_timeout: TimeDelta,
 }
 
-/// Message sent from a background batch task to the main loop on completion.
-struct BatchResult {
+/// Message sent from a background task group to the main loop on completion.
+struct GroupResult {
     application_id: ApplicationId,
-    /// If set, the batch failed and should be retried at this timestamp.
+    /// The group's id, as returned by [`group_tasks`].
+    group: Option<String>,
+    /// If set, the group failed and should be retried at this timestamp.
     retry_at: Option<Timestamp>,
 }
 
@@ -73,13 +75,16 @@ pub struct TaskProcessor<Env: linera_core::Environment> {
     chain_client: ChainClient<Env>,
     cancellation_token: CancellationToken,
     notifications: NotificationStream,
-    batch_sender: mpsc::UnboundedSender<BatchResult>,
-    batch_receiver: mpsc::UnboundedReceiver<BatchResult>,
+    result_sender: mpsc::UnboundedSender<GroupResult>,
+    result_receiver: mpsc::UnboundedReceiver<GroupResult>,
     update_receiver: mpsc::UnboundedReceiver<Update>,
     deadlines: BinaryHeap<Deadline>,
     operators: OperatorMap,
     config: TaskProcessorConfig,
-    in_flight_apps: BTreeSet<ApplicationId>,
+    /// The groups currently running, so that a second copy is never started while one is in
+    /// flight. Keyed by group rather than by application: a group that is slow or stuck must not
+    /// keep its siblings from being polled.
+    in_flight_groups: BTreeSet<(ApplicationId, Option<String>)>,
 }
 
 impl<Env: linera_core::Environment> TaskProcessor<Env> {
@@ -94,7 +99,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         update_receiver: Option<mpsc::UnboundedReceiver<Update>>,
     ) -> Self {
         let notifications = chain_client.subscribe().expect("client subscription");
-        let (batch_sender, batch_receiver) = mpsc::unbounded_channel();
+        let (result_sender, result_receiver) = mpsc::unbounded_channel();
         let update_receiver = update_receiver.unwrap_or_else(|| mpsc::unbounded_channel().1);
         Self {
             chain_id,
@@ -103,13 +108,13 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
             chain_client,
             cancellation_token,
             notifications,
-            batch_sender,
-            batch_receiver,
+            result_sender,
+            result_receiver,
             update_receiver,
             deadlines: BinaryHeap::new(),
             operators,
             config,
-            in_flight_apps: BTreeSet::new(),
+            in_flight_groups: BTreeSet::new(),
         }
     }
 
@@ -130,8 +135,8 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                     let application_ids = self.process_events();
                     self.process_actions(application_ids).await;
                 }
-                Some(result) = self.batch_receiver.recv() => {
-                    self.in_flight_apps.remove(&result.application_id);
+                Some(result) = self.result_receiver.recv() => {
+                    self.in_flight_groups.remove(&(result.application_id, result.group));
                     // The application could have been unassigned from this processor
                     // in the meantime - do not retry if that is the case.
                     if self.application_ids.contains(&result.application_id) {
@@ -176,8 +181,8 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
 
         self.cursors
             .retain(|app_id, _| new_app_set.contains(app_id));
-        self.in_flight_apps
-            .retain(|app_id| new_app_set.contains(app_id));
+        self.in_flight_groups
+            .retain(|(app_id, _)| new_app_set.contains(app_id));
 
         // Update the application_ids
         self.application_ids = update.application_ids;
@@ -217,10 +222,6 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 debug!("Skipping {application_id}: it's no longer assigned to this processor");
                 continue;
             }
-            if self.in_flight_apps.contains(&application_id) {
-                debug!("Skipping {application_id}: tasks already in flight");
-                continue;
-            }
             debug!("Processing actions for {application_id}");
             let now = Timestamp::now();
             let app_cursor = self.cursors.get(&application_id).cloned();
@@ -243,47 +244,46 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
             if let Some(cursor) = actions.set_cursor {
                 self.cursors.insert(application_id, cursor);
             }
-            if !actions.execute_tasks.is_empty() {
-                self.in_flight_apps.insert(application_id);
+            // Start each group that is not already running. Groups are independent: their
+            // outcomes commute, so one that is slow, stuck or failing must neither delay the
+            // others nor keep this application from being polled again for their sake.
+            for (group, tasks) in group_tasks(actions.execute_tasks) {
+                if !self
+                    .in_flight_groups
+                    .insert((application_id, group.clone()))
+                {
+                    debug!(%application_id, ?group, "Skipping group: tasks already in flight");
+                    continue;
+                }
                 let chain_client = self.chain_client.clone();
-                let batch_sender = self.batch_sender.clone();
+                let result_sender = self.result_sender.clone();
                 let config = self.config;
                 let operators = self.operators.clone();
                 tokio::spawn(async move {
-                    // Run each group concurrently, so that a slow or failing group never
-                    // delays the outcomes of the others.
-                    let mut handles = Vec::new();
-                    for (group, tasks) in group_tasks(actions.execute_tasks) {
-                        handles.push((
-                            group.clone(),
-                            tokio::spawn(Self::process_group(
-                                application_id,
-                                group,
-                                tasks,
-                                chain_client.clone(),
-                                operators.clone(),
-                                config,
-                            )),
-                        ));
-                    }
-                    // `None` sorts before any timestamp, so the maximum is the latest retry
-                    // any group asked for: a task failing on every attempt cannot shorten the
-                    // delay protecting the operator.
-                    let mut retry_at = None;
-                    for (group, handle) in handles {
-                        retry_at = retry_at.max(handle.await.unwrap_or_else(|error| {
-                            error!(%application_id, ?group, %error, "Task group panicked");
-                            Some(Timestamp::now().saturating_add(config.retry_delay))
-                        }));
-                    }
-                    if batch_sender
-                        .send(BatchResult {
+                    // Run the group on its own task so that a panic inside it is reported and
+                    // turned into a retry, rather than losing the result message and leaving the
+                    // group marked in flight forever.
+                    let handle = tokio::spawn(Self::process_group(
+                        application_id,
+                        group.clone(),
+                        tasks,
+                        chain_client,
+                        operators,
+                        config,
+                    ));
+                    let retry_at = handle.await.unwrap_or_else(|error| {
+                        error!(%application_id, ?group, %error, "Task group panicked");
+                        Some(Timestamp::now().saturating_add(config.retry_delay))
+                    });
+                    if result_sender
+                        .send(GroupResult {
                             application_id,
+                            group,
                             retry_at,
                         })
                         .is_err()
                     {
-                        error!(%application_id, "Batch receiver dropped");
+                        error!(%application_id, "Result receiver dropped");
                     }
                 });
             }
@@ -310,7 +310,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
     ) -> Option<Timestamp> {
         let mut handles = Vec::with_capacity(tasks.len());
         for task in tasks {
-            handles.push(tokio::spawn(Self::execute_task(
+            handles.push(tokio::spawn(execute_task(
                 application_id,
                 task,
                 operators.clone(),
@@ -329,61 +329,18 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                     return Some(Timestamp::now().saturating_add(config.retry_delay));
                 }
             };
-            if let Err(timestamp) =
-                Self::submit_task_outcome(&chain_client, application_id, &outcome, config.retry_delay)
-                    .await
+            if let Err(timestamp) = Self::submit_task_outcome(
+                &chain_client,
+                application_id,
+                &outcome,
+                config.retry_delay,
+            )
+            .await
             {
                 return Some(timestamp);
             }
         }
         None
-    }
-
-    async fn execute_task(
-        application_id: ApplicationId,
-        task: Task,
-        operators: OperatorMap,
-        task_timeout: TimeDelta,
-    ) -> Result<TaskOutcome, anyhow::Error> {
-        let Task {
-            id,
-            operator,
-            input,
-        } = task;
-        let binary_path = operators
-            .get(&operator)
-            .ok_or_else(|| anyhow::anyhow!("unsupported operator: {operator}"))?;
-        debug!("Executing task {operator} ({binary_path:?}) for {application_id}");
-        let mut child = Command::new(binary_path)
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            // Timing out below drops this `Child`. Without this the operator would go on running,
-            // detached, still holding whatever the timeout was meant to release.
-            .kill_on_drop(true)
-            .spawn()?;
-
-        let mut stdin = child.stdin.take().expect("stdin should be configured");
-        stdin.write_all(input.as_bytes()).await?;
-        drop(stdin);
-
-        let timeout = task_timeout.as_duration();
-        let Ok(output) = tokio::time::timeout(timeout, child.wait_with_output()).await else {
-            anyhow::bail!("operator {operator} timed out after {timeout:?}");
-        };
-        let output = output?;
-        anyhow::ensure!(
-            output.status.success(),
-            "operator {} exited with status: {}",
-            operator,
-            output.status
-        );
-        let outcome = TaskOutcome {
-            id,
-            operator,
-            output: String::from_utf8_lossy(&output.stdout).into(),
-        };
-        debug!("Done executing task for {application_id}");
-        Ok(outcome)
     }
 
     // Keeping `&mut self` avoids borrowing `TaskProcessor` through `&self` across `.await`,
@@ -476,6 +433,54 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         }
         Ok(())
     }
+}
+
+/// Runs one task's operator binary to completion, bounded by `task_timeout`.
+async fn execute_task(
+    application_id: ApplicationId,
+    task: Task,
+    operators: OperatorMap,
+    task_timeout: TimeDelta,
+) -> Result<TaskOutcome, anyhow::Error> {
+    let Task {
+        id,
+        operator,
+        input,
+    } = task;
+    let binary_path = operators
+        .get(&operator)
+        .ok_or_else(|| anyhow::anyhow!("unsupported operator: {operator}"))?;
+    debug!("Executing task {operator} ({binary_path:?}) for {application_id}");
+    let mut child = Command::new(binary_path)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        // Timing out below drops this `Child`. Without this the operator would go on running,
+        // detached, still holding whatever the timeout was meant to release.
+        .kill_on_drop(true)
+        .spawn()?;
+
+    let mut stdin = child.stdin.take().expect("stdin should be configured");
+    stdin.write_all(input.as_bytes()).await?;
+    drop(stdin);
+
+    let timeout = task_timeout.as_duration();
+    let Ok(output) = tokio::time::timeout(timeout, child.wait_with_output()).await else {
+        anyhow::bail!("operator {operator} timed out after {timeout:?}");
+    };
+    let output = output?;
+    anyhow::ensure!(
+        output.status.success(),
+        "operator {} exited with status: {}",
+        operator,
+        output.status
+    );
+    let outcome = TaskOutcome {
+        id,
+        operator,
+        output: String::from_utf8_lossy(&output.stdout).into(),
+    };
+    debug!("Done executing task for {application_id}");
+    Ok(outcome)
 }
 
 /// Groups the tasks of a batch by id, keeping their relative order.
@@ -571,6 +576,60 @@ mod tests {
                 group(Some("dup"), &["first", "third"]),
                 group(Some("other"), &["second"])
             ]
+        );
+    }
+
+    /// Writes an executable shell script and returns an operator map pointing at it.
+    fn operator_running(script: &str, dir: &tempfile::TempDir) -> OperatorMap {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let path = dir.path().join("operator");
+        std::fs::write(&path, format!("#!/bin/sh\n{script}\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        Arc::new(BTreeMap::from([("op".to_string(), path)]))
+    }
+
+    /// A syntactically valid application id. `CryptoHash`'s `FromStr` is hex over 32 bytes and,
+    /// unlike `test_hash`, is not gated behind `with_testing`.
+    fn app_id() -> ApplicationId {
+        ApplicationId::new("00".repeat(32).parse().unwrap())
+    }
+
+    fn timed_task() -> Task {
+        Task {
+            id: None,
+            operator: "op".to_string(),
+            input: String::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_task_returns_the_operator_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let operators = operator_running("echo done", &dir);
+        let outcome = execute_task(app_id(), timed_task(), operators, TimeDelta::from_secs(60))
+            .await
+            .unwrap();
+        assert_eq!(outcome.output.trim(), "done");
+    }
+
+    #[tokio::test]
+    async fn execute_task_gives_up_on_an_operator_that_outruns_its_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        // Sleeps far past the timeout: without a bound this call would never return, and the
+        // group would stay in flight for as long as the process lived.
+        let operators = operator_running("sleep 300", &dir);
+        let error = execute_task(
+            app_id(),
+            timed_task(),
+            operators,
+            TimeDelta::from_millis(200),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("timed out"),
+            "unexpected error: {error}"
         );
     }
 

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -45,6 +45,19 @@ pub fn parse_operator(s: &str) -> Result<(String, PathBuf), String> {
 
 type Deadline = Reverse<(Timestamp, Option<ApplicationId>)>;
 
+/// Timing limits applied to operator tasks.
+#[derive(Clone, Copy, Debug)]
+pub struct TaskProcessorConfig {
+    /// How long to wait before retrying a task group that failed.
+    pub retry_delay: TimeDelta,
+    /// Maximum wall-clock time for a single operator invocation.
+    ///
+    /// An operator that is merely slow cannot be told apart from one that will never return, and
+    /// nothing else bounds it: its group holds a slot for as long as it runs. Past this the
+    /// process is killed and the task is retried like any other failure.
+    pub task_timeout: TimeDelta,
+}
+
 /// Message sent from a background batch task to the main loop on completion.
 struct BatchResult {
     application_id: ApplicationId,
@@ -65,7 +78,7 @@ pub struct TaskProcessor<Env: linera_core::Environment> {
     update_receiver: mpsc::UnboundedReceiver<Update>,
     deadlines: BinaryHeap<Deadline>,
     operators: OperatorMap,
-    retry_delay: TimeDelta,
+    config: TaskProcessorConfig,
     in_flight_apps: BTreeSet<ApplicationId>,
 }
 
@@ -77,7 +90,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         chain_client: ChainClient<Env>,
         cancellation_token: CancellationToken,
         operators: OperatorMap,
-        retry_delay: TimeDelta,
+        config: TaskProcessorConfig,
         update_receiver: Option<mpsc::UnboundedReceiver<Update>>,
     ) -> Self {
         let notifications = chain_client.subscribe().expect("client subscription");
@@ -95,7 +108,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
             update_receiver,
             deadlines: BinaryHeap::new(),
             operators,
-            retry_delay,
+            config,
             in_flight_apps: BTreeSet::new(),
         }
     }
@@ -234,7 +247,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 self.in_flight_apps.insert(application_id);
                 let chain_client = self.chain_client.clone();
                 let batch_sender = self.batch_sender.clone();
-                let retry_delay = self.retry_delay;
+                let config = self.config;
                 let operators = self.operators.clone();
                 tokio::spawn(async move {
                     // Run each group concurrently, so that a slow or failing group never
@@ -249,7 +262,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                                 tasks,
                                 chain_client.clone(),
                                 operators.clone(),
-                                retry_delay,
+                                config,
                             )),
                         ));
                     }
@@ -260,7 +273,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                     for (group, handle) in handles {
                         retry_at = retry_at.max(handle.await.unwrap_or_else(|error| {
                             error!(%application_id, ?group, %error, "Task group panicked");
-                            Some(Timestamp::now().saturating_add(retry_delay))
+                            Some(Timestamp::now().saturating_add(config.retry_delay))
                         }));
                     }
                     if batch_sender
@@ -293,7 +306,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         tasks: Vec<Task>,
         chain_client: ChainClient<Env>,
         operators: OperatorMap,
-        retry_delay: TimeDelta,
+        config: TaskProcessorConfig,
     ) -> Option<Timestamp> {
         let mut handles = Vec::with_capacity(tasks.len());
         for task in tasks {
@@ -301,6 +314,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 application_id,
                 task,
                 operators.clone(),
+                config.task_timeout,
             )));
         }
         for handle in handles {
@@ -308,15 +322,15 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 Ok(Ok(outcome)) => outcome,
                 Ok(Err(error)) => {
                     error!(%application_id, ?group, %error, "Error executing task");
-                    return Some(Timestamp::now().saturating_add(retry_delay));
+                    return Some(Timestamp::now().saturating_add(config.retry_delay));
                 }
                 Err(error) => {
                     error!(%application_id, ?group, %error, "Task panicked");
-                    return Some(Timestamp::now().saturating_add(retry_delay));
+                    return Some(Timestamp::now().saturating_add(config.retry_delay));
                 }
             };
             if let Err(timestamp) =
-                Self::submit_task_outcome(&chain_client, application_id, &outcome, retry_delay)
+                Self::submit_task_outcome(&chain_client, application_id, &outcome, config.retry_delay)
                     .await
             {
                 return Some(timestamp);
@@ -329,6 +343,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         application_id: ApplicationId,
         task: Task,
         operators: OperatorMap,
+        task_timeout: TimeDelta,
     ) -> Result<TaskOutcome, anyhow::Error> {
         let Task {
             id,
@@ -342,13 +357,20 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         let mut child = Command::new(binary_path)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
+            // Timing out below drops this `Child`. Without this the operator would go on running,
+            // detached, still holding whatever the timeout was meant to release.
+            .kill_on_drop(true)
             .spawn()?;
 
         let mut stdin = child.stdin.take().expect("stdin should be configured");
         stdin.write_all(input.as_bytes()).await?;
         drop(stdin);
 
-        let output = child.wait_with_output().await?;
+        let timeout = task_timeout.as_duration();
+        let Ok(output) = tokio::time::timeout(timeout, child.wait_with_output()).await else {
+            anyhow::bail!("operator {operator} timed out after {timeout:?}");
+        };
+        let output = output?;
         anyhow::ensure!(
             output.status.success(),
             "operator {} exited with status: {}",

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -213,8 +213,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
     }
 
     /// Returns the applications whose deadlines have come, ordered by deadline and without
-    /// repetitions: an application has one state to read, so polling it twice in a row would
-    /// query it a second time for the same answer.
+    /// repetitions.
     fn process_events(&mut self) -> Vec<ApplicationId> {
         let now = Timestamp::now();
         let mut application_ids = Vec::new();

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -31,7 +31,7 @@ use tracing::{debug, error, info, warn};
 use crate::controller::Update;
 
 #[cfg(with_metrics)]
-mod metrics {
+pub(crate) mod metrics {
     use linera_base::prometheus_util::register_int_counter;
     use prometheus::IntCounter;
 

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -38,10 +38,9 @@ pub(crate) mod metrics {
     linera_base::declare_metrics! {
         /// Task groups that have outlived [`TaskProcessorConfig::slow_group_threshold`].
         ///
-        /// The group is still running when this is incremented and may well succeed: a batch
-        /// catching up on a backlog takes far longer than a steady-state one. What makes it worth
-        /// alerting on is that nothing else reports it — the process stays healthy and its chain
-        /// simply stops advancing, so a group that never returns is otherwise silent.
+        /// A group counted here is still running and may still succeed. It is worth alerting on
+        /// because nothing else reports it: the process stays healthy while the chain the group
+        /// serves stops advancing, so a group that never returns is otherwise silent.
         pub static SLOW_TASK_GROUPS: IntCounter = register_int_counter(
             "slow_task_groups_total",
             "Number of task groups that outlived the slow-group threshold"
@@ -69,13 +68,7 @@ type Deadline = Reverse<(Timestamp, Option<ApplicationId>)>;
 pub struct TaskProcessorConfig {
     /// How long to wait before retrying a task group that failed.
     pub retry_delay: TimeDelta,
-    /// How long a task group may run before it is reported as slow.
-    ///
-    /// Reported only: the group is never interrupted. An operator that is merely slow cannot be
-    /// told apart from one that will never return, and killing it would abort work that was about
-    /// to succeed — a batch catching up on a backlog legitimately runs far longer than a
-    /// steady-state one. Since a task that is cut short is retried, a limit set below what the
-    /// work needs never completes it, it only repeats it.
+    /// How long a task group may run before it is reported as slow. The group keeps running.
     pub slow_group_threshold: TimeDelta,
 }
 
@@ -103,8 +96,7 @@ pub struct TaskProcessor<Env: linera_core::Environment> {
     operators: OperatorMap,
     config: TaskProcessorConfig,
     /// The groups currently running, so that a second copy is never started while one is in
-    /// flight. Keyed by group rather than by application: a group that is slow or stuck must not
-    /// keep its siblings from being polled.
+    /// flight.
     in_flight_groups: BTreeSet<(ApplicationId, Option<String>)>,
 }
 
@@ -265,9 +257,9 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
             if let Some(cursor) = actions.set_cursor {
                 self.cursors.insert(application_id, cursor);
             }
-            // Start each group that is not already running. Groups are independent: their
-            // outcomes commute, so one that is slow, stuck or failing must neither delay the
-            // others nor keep this application from being polled again for their sake.
+            // Start each group that is not already running. Group outcomes commute, so a group
+            // that is slow, stuck or failing neither delays the others nor keeps this application
+            // from being polled again for their sake.
             for (group, tasks) in group_tasks(actions.execute_tasks) {
                 if !self
                     .in_flight_groups
@@ -281,9 +273,9 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 let config = self.config;
                 let operators = self.operators.clone();
                 tokio::spawn(async move {
-                    // Run the group on its own task so that a panic inside it is reported and
-                    // turned into a retry, rather than losing the result message and leaving the
-                    // group marked in flight forever.
+                    // Run the group on its own task: a panic inside it must surface here and
+                    // become a retry. An unreported panic sends no result message, and the group
+                    // then stays marked in flight forever.
                     let handle = tokio::spawn(Self::process_group(
                         application_id,
                         group.clone(),
@@ -492,11 +484,8 @@ async fn execute_task(
     Ok(outcome)
 }
 
-/// Awaits a task group, reporting it once if it outlives `slow_group_threshold`.
-///
-/// Reporting only — the group keeps running afterwards. Cutting it short would abort work that may
-/// be about to succeed, and since the task would then be retried, a threshold below what the work
-/// needs would repeat it forever instead of ever completing it.
+/// Awaits a task group, reporting it once if it outlives `slow_group_threshold` and then
+/// continuing to wait for it.
 async fn await_group(
     application_id: ApplicationId,
     group: &Option<String>,
@@ -664,8 +653,8 @@ mod tests {
             // Far below what the group takes, so the slow path is the one exercised.
             slow_group_threshold: TimeDelta::from_millis(10),
         };
-        // The point of the assertion: crossing the threshold reports the group, it does not cut
-        // it short, so the result it was about to produce still comes back.
+        // Crossing the threshold reports the group without cutting it short, so the value it
+        // produces still comes back.
         let retry_at = await_group(app_id(), &Some("group".to_string()), handle, config).await;
         assert_eq!(retry_at, expected);
     }


### PR DESCRIPTION
Closes #6741.

## Motivation

`ProcessorActions::execute_tasks` documents that the outcomes of distinct groups commute and that
"a task that fails is retried **without holding the other groups back**". That holds for a group
that fails quickly. It does not hold for one that is merely slow, because the in-flight bookkeeping
is per *application*:

- `in_flight_apps: BTreeSet<ApplicationId>` made `process_actions` skip the whole application while
  any batch was running, so no sibling group could even be polled.
- The spawned batch awaited *every* group handle before reporting, and `retry_at` was the `max` over
  groups, so the application was unblocked only by its slowest group.

Observed on `oracle-v2-71-1`, 2026-08-18 — two consumers of one oracle application:

```
21:29:01  ETH   submits ts 1787088540
          HYPE  group still running
21:30-21:43  no log line mentioning the chain at all
21:42:03  HYPE  returns ts 1787088540 — the same timestamp — successfully
21:42:04  ETH   catches up 13 points (21:30 -> 21:42)
```

Both consumers stuck on the identical timestamp is what identifies them as one batch. `ETH-1-lv` is
a dense, healthy symbol; it lost 13 minutes of block production behind an unrelated group.

Note what the HYPE group did at 21:42:03: it **returned a correct result**. It was slow, not stuck.

## Proposal

**Track in-flight groups individually.** `in_flight_groups: BTreeSet<(ApplicationId,
Option<String>)>`, with each group reporting its own `GroupResult` instead of the batch reporting one
aggregate. The application-level skip in `process_actions` is gone, so a slow group no longer stops
its siblings from being polled or delays their retry scheduling. A slow group is then just slow,
which is the right outcome when the work is genuinely slow.

### Why not a task timeout

An earlier revision of this PR capped each operator invocation and killed it past the limit. That is
the wrong shape, and this incident is the counter-example:

- The 13-minute task **succeeded**. A cap below it would have destroyed work that was about to
  complete.
- A task that is cut short is *retried*. If the cap is below what the work needs, no attempt ever
  finishes: the consumer's schedule can never advance past that timestamp, and every cycle repeats
  the load that caused the slowness. That is strictly worse than waiting.
- There is no safe value to pick. A backfill legitimately runs far longer than a steady-state batch,
  and the operator's own retry budget can dominate — the pm-app Coinbase provider spends up to
  `5+10+20+40+60x6 = 435s` in backoff for a *single* throttled request, and one task may issue
  several.

So the group is **reported, never interrupted**: a `warn!` and an incremented
`linera_slow_task_groups_total` when a group outlives `--slow-task-group-secs` (default 300), after
which it is awaited to completion exactly as before. Choosing "5 minutes is worth a look" is safe;
choosing "5 minutes means dead" is not.

That reporting is what group isolation costs us otherwise. Today a group that never returns stalls
every market on the oracle, which is at least conspicuous. Once groups are isolated, one chain stops
advancing while the others carry on — and since the process stays healthy and the pod stays `Ready`,
nothing else would say so.

`retry_delay` and `slow_group_threshold` are bundled into a `TaskProcessorConfig` rather than
threaded as two more positional arguments; `Controller::new` already carries
`#[expect(clippy::too_many_arguments)]`.

### Why re-polling an application with a group in flight is safe

`process_group` already documents the assumption: *"Tasks are assumed idempotent, so whatever is
left unsubmitted is recomputed by the next call to `nextActions`."* So a re-poll re-returns the
in-flight group's outstanding work, and `in_flight_groups.insert` drops the duplicate rather than
starting a second copy.

The group is spawned inside an outer task that awaits it, so a panic is still reported and converted
into a retry. Losing that would be worse than before: the `GroupResult` would never be sent and the
group would stay marked in flight forever.

## Test Plan

`execute_task` no longer touches `Env`, so it is now a free function and directly testable.

- `execute_task_returns_the_operator_output` — drives a real operator process end to end.
- `a_group_that_outlives_the_threshold_is_reported_but_still_awaited` — a group that runs well past
  the threshold still returns the value it was about to produce. This is the property the design
  argument rests on: crossing the threshold reports, it does not cut the work short.

The test helper builds its application id with `CryptoHash`'s `FromStr` rather than `test_hash`,
which is `#[cfg(with_testing)]` and would break the builds that compile without test features.

- `cargo test -p linera-service --lib task_processor` — 6 passed.
- `cargo clippy --locked --all-targets --all-features -p linera-service` — clean, and
  `cargo check -p linera-service --features metrics --all-targets` for the `with_metrics` module.
- `cargo fmt -- --check` under the pinned `nightly-2026-05-11` from `toolchains/nightly/` (the one
  `lint-cargo-fmt` uses; stable silently no-ops the unstable options in `rustfmt.toml`) — clean.

## Notes

The related *ordering* coupling was fixed by #6697/#6698 and is live and working: during a burst
where one group failed ~40 times in a row, its siblings kept publishing on schedule. That change
decoupled failure ordering; this one decouples duration.

The commit history contains the timeout and its removal; the final state is the two behaviours above.

A principled hard bound would be an *idle* timeout — cut off only when the operator has produced no
output for a while, since a backfill grinding through backoff keeps logging while a wedged socket
goes silent. That needs operators to emit progress, so it is a contract change rather than something
to fold in here.
