### PR TITLE
Backport #6737 to testnet_conway: load a collection entry in a single round trip

### DIFF
--- a/linera-views/src/views/collection_entry.rs
+++ b/linera-views/src/views/collection_entry.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The key layout of a collection entry, shared by the collection views.
+//!
+//! An entry is stored as an index marker recording that it exists, plus — under a separate tag —
+//! the key space of its subview. The marker is what distinguishes an absent entry from one that
+//! is present but has written no bytes of its own, so it cannot be inferred from the subview's
+//! keys. It is read in the same batch instead, which is what makes loading an entry cost a single
+//! round trip whether or not the entry exists.
+
+use crate::{
+    context::Context,
+    views::{View, ViewError, MIN_VIEW_TAG},
+};
+
+/// The prefixes of the keys of a collection.
+#[repr(u8)]
+pub(crate) enum KeyTag {
+    /// Prefix for specifying an index and serves to indicate the existence of an entry in the
+    /// collection.
+    Index = MIN_VIEW_TAG,
+    /// Prefix for specifying as the prefix for the sub-view.
+    Subview,
+}
+
+/// The key marking the existence of the entry at `short_key`.
+pub(crate) fn index_key<C: Context>(context: &C, short_key: &[u8]) -> Vec<u8> {
+    context
+        .base_key()
+        .base_tag_index(KeyTag::Index as u8, short_key)
+}
+
+/// The base key of the subview stored at `short_key`.
+pub(crate) fn subview_key<C: Context>(context: &C, short_key: &[u8]) -> Vec<u8> {
+    context
+        .base_key()
+        .base_tag_index(KeyTag::Subview as u8, short_key)
+}
+
+/// The context of the subview stored at `short_key`.
+pub(crate) fn subview_context<C: Context>(context: &C, short_key: &[u8]) -> C {
+    context.clone_with_base_key(subview_key(context, short_key))
+}
+
+/// The number of keys [`entry_keys`] produces for one entry.
+///
+/// Never zero, because of the marker: that is what makes `chunks_exact` safe when a batch of
+/// entries is split back up, even for a subview type with no initialization keys.
+pub(crate) fn entry_len<W: View>() -> usize {
+    1 + W::NUM_INIT_KEYS
+}
+
+/// The subview's context, and the keys that decide whether the entry at `short_key` exists and,
+/// if it does, load it: the index marker followed by the subview's initialization keys.
+pub(crate) fn entry_keys<W: View>(
+    context: &W::Context,
+    short_key: &[u8],
+) -> Result<(W::Context, Vec<Vec<u8>>), ViewError> {
+    let subview_context = subview_context(context, short_key);
+    let mut keys = Vec::with_capacity(entry_len::<W>());
+    keys.push(index_key(context, short_key));
+    keys.extend(W::pre_load(&subview_context)?);
+    Ok((subview_context, keys))
+}
+
+/// Builds the subview out of the values read for [`entry_keys`], or `None` when the index marker
+/// is absent.
+///
+/// The marker is stored with an empty value, so its presence and not its content is what decides.
+pub(crate) fn post_load_entry<W: View>(
+    subview_context: W::Context,
+    values: &[Option<Vec<u8>>],
+) -> Result<Option<W>, ViewError> {
+    let Some((marker, init_values)) = values.split_first() else {
+        // The store returned fewer values than we gave it keys, which is a broken contract
+        // rather than an absent entry.
+        return Err(ViewError::MissingEntries(format!(
+            "{:?}",
+            subview_context.base_key().bytes
+        )));
+    };
+    if marker.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(W::post_load(subview_context, init_values)?))
+}

--- a/linera-views/src/views/collection_entry.rs
+++ b/linera-views/src/views/collection_entry.rs
@@ -8,6 +8,11 @@
 //! is present but has written no bytes of its own, so it cannot be inferred from the subview's
 //! keys. It is read in the same batch instead, which is what makes loading an entry cost a single
 //! round trip whether or not the entry exists.
+//!
+//! The tags are what keep those two key spaces apart. Sub-views in a collection share a common
+//! key prefix, like in other view types, so appending a sub-view's own keys straight to that
+//! prefix would leave a child sub-view's key indistinguishable from a grandchild's — consider a
+//! collection stored inside a collection.
 
 use crate::{
     context::Context,
@@ -72,14 +77,8 @@ pub(crate) fn post_load_entry<W: View>(
     subview_context: W::Context,
     values: &[Option<Vec<u8>>],
 ) -> Result<Option<W>, ViewError> {
-    let Some((marker, init_values)) = values.split_first() else {
-        // The store returned fewer values than we gave it keys, which is a broken contract
-        // rather than an absent entry.
-        return Err(ViewError::MissingEntries(format!(
-            "{:?}",
-            subview_context.base_key().bytes
-        )));
-    };
+    // Fewer values than keys is a broken store contract rather than an absent entry.
+    let (marker, init_values) = values.split_first().ok_or(ViewError::PostLoadValuesError)?;
     if marker.is_none() {
         return Ok(None);
     }

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -102,13 +102,6 @@ impl<W> std::ops::Deref for ReadGuardedView<'_, W> {
     }
 }
 
-/// We need to find new base keys in order to implement `CollectionView`.
-/// We do this by appending a value to the base key.
-///
-/// Sub-views in a collection share a common key prefix, like in other view types. However,
-/// just concatenating the shared prefix with sub-view keys makes it impossible to distinguish if a
-/// given key belongs to child sub-view or a grandchild sub-view (consider for example if a
-/// collection is stored inside the collection).
 impl<W: View> View for ByteCollectionView<W::Context, W> {
     const NUM_INIT_KEYS: usize = 0;
 

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -23,7 +23,7 @@ use crate::{
     hashable_wrapper::WrappedHashableContainerView,
     historical_hash_wrapper::HistoricallyHashableView,
     store::ReadableKeyValueStore as _,
-    views::{ClonableView, HashableView, Hasher, View, ViewError, MIN_VIEW_TAG},
+    views::{collection_entry, ClonableView, HashableView, Hasher, View, ViewError},
 };
 
 #[cfg(with_metrics)]
@@ -109,14 +109,6 @@ impl<W> std::ops::Deref for ReadGuardedView<'_, W> {
 /// just concatenating the shared prefix with sub-view keys makes it impossible to distinguish if a
 /// given key belongs to child sub-view or a grandchild sub-view (consider for example if a
 /// collection is stored inside the collection).
-#[repr(u8)]
-enum KeyTag {
-    /// Prefix for specifying an index and serves to indicate the existence of an entry in the collection.
-    Index = MIN_VIEW_TAG,
-    /// Prefix for specifying as the prefix for the sub-view.
-    Subview,
-}
-
 impl<W: View> View for ByteCollectionView<W::Context, W> {
     const NUM_INIT_KEYS: usize = 0;
 
@@ -226,57 +218,12 @@ impl<W: ClonableView> ClonableView for ByteCollectionView<W::Context, W> {
 }
 
 impl<W: View> ByteCollectionView<W::Context, W> {
-    /// The context of the subview stored at `short_key`.
-    fn subview_context(context: &W::Context, short_key: &[u8]) -> W::Context {
-        let key = context
-            .base_key()
-            .base_tag_index(KeyTag::Subview as u8, short_key);
-        context.clone_with_base_key(key)
-    }
-
-    /// The keys deciding whether the entry at `short_key` exists and, if it does, loading its
-    /// subview: the index marker followed by the subview's initialization keys.
-    fn entry_keys(
-        context: &W::Context,
-        subview_context: &W::Context,
-        short_key: &[u8],
-    ) -> Result<Vec<Vec<u8>>, ViewError> {
-        let mut keys = Vec::with_capacity(1 + W::NUM_INIT_KEYS);
-        keys.push(
-            context
-                .base_key()
-                .base_tag_index(KeyTag::Index as u8, short_key),
-        );
-        keys.extend(W::pre_load(subview_context)?);
-        Ok(keys)
-    }
-
-    /// Builds the subview out of the values read for `entry_keys`, or `None` when the index
-    /// marker is absent. The marker is stored with an empty value, so its presence and not
-    /// its content is what decides.
-    fn post_load_entry(
-        subview_context: W::Context,
-        values: &[Option<Vec<u8>>],
-    ) -> Result<Option<W>, ViewError> {
-        let Some((marker, init_values)) = values.split_first() else {
-            return Ok(None);
-        };
-        if marker.is_none() {
-            return Ok(None);
-        }
-        Ok(Some(W::post_load(subview_context, init_values)?))
-    }
-
     fn get_index_key(&self, index: &[u8]) -> Vec<u8> {
-        self.context
-            .base_key()
-            .base_tag_index(KeyTag::Index as u8, index)
+        collection_entry::index_key(&self.context, index)
     }
 
     fn get_subview_key(&self, index: &[u8]) -> Vec<u8> {
-        self.context
-            .base_key()
-            .base_tag_index(KeyTag::Subview as u8, index)
+        collection_entry::subview_key(&self.context, index)
     }
 
     fn add_index(&self, batch: &mut Batch, index: &[u8]) {
@@ -369,11 +316,11 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                 }
                 // The index marker and the subview's initialization keys are read together, so
                 // that loading an entry costs a single round trip whether or not it exists.
-                let subview_context = Self::subview_context(&self.context, short_key);
-                let keys = Self::entry_keys(&self.context, &subview_context, short_key)?;
+                let (subview_context, keys) =
+                    collection_entry::entry_keys::<W>(&self.context, short_key)?;
                 let values = self.context.store().read_multi_values_bytes(&keys).await?;
                 Ok(
-                    Self::post_load_entry(subview_context, &values)?.map(|view| {
+                    collection_entry::post_load_entry::<W>(subview_context, &values)?.map(|view| {
                         ReadGuardedView::NotLoaded {
                             _updates: updates,
                             view,
@@ -438,16 +385,13 @@ impl<W: View> ByteCollectionView<W::Context, W> {
         if !entries_to_load.is_empty() {
             // The index markers and the subviews' initialization keys are read together, so
             // that loading entries costs a single round trip whether or not they exist.
-            let entry_len = 1 + W::NUM_INIT_KEYS;
+            let entry_len = collection_entry::entry_len::<W>();
             let mut keys = Vec::with_capacity(entries_to_load.len() * entry_len);
             let mut subview_contexts = Vec::with_capacity(entries_to_load.len());
             for (_, short_key) in &entries_to_load {
-                let subview_context = Self::subview_context(&self.context, short_key);
-                keys.extend(Self::entry_keys(
-                    &self.context,
-                    &subview_context,
-                    short_key,
-                )?);
+                let (subview_context, entry) =
+                    collection_entry::entry_keys::<W>(&self.context, short_key)?;
+                keys.extend(entry);
                 subview_contexts.push(subview_context);
             }
             let values = self.context.store().read_multi_values_bytes(&keys).await?;
@@ -455,7 +399,9 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                 .into_iter()
                 .zip(values.chunks_exact(entry_len).zip(subview_contexts))
             {
-                if let Some(view) = Self::post_load_entry(subview_context, entry_values)? {
+                if let Some(view) =
+                    collection_entry::post_load_entry::<W>(subview_context, entry_values)?
+                {
                     results[position] = Some(ReadGuardedView::NotLoaded {
                         _updates: self.updates.read().await,
                         view,
@@ -512,10 +458,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                     // Therefore we have `self.delete_storage_first = false`.
                     assert!(!self.delete_storage_first);
                     results.push((short_key.clone(), None));
-                    let key = self
-                        .context
-                        .base_key()
-                        .base_tag_index(KeyTag::Subview as u8, short_key);
+                    let key = collection_entry::subview_key(&self.context, short_key);
                     let subview_context = self.context.clone_with_base_key(key);
                     keys_to_load.extend(W::pre_load(&subview_context)?);
                     keys_to_load_metadata.push((position, subview_context, short_key.clone()));
@@ -568,10 +511,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
     /// # })
     /// ```
     pub fn reset_entry_to_default(&mut self, short_key: &[u8]) -> Result<(), ViewError> {
-        let key = self
-            .context
-            .base_key()
-            .base_tag_index(KeyTag::Subview as u8, short_key);
+        let key = collection_entry::subview_key(&self.context, short_key);
         let context = self.context.clone_with_base_key(key);
         let view = W::new(context)?;
         self.updates
@@ -605,10 +545,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                 _entry @ Update::Removed => false,
             },
             None => {
-                let key_index = self
-                    .context
-                    .base_key()
-                    .base_tag_index(KeyTag::Index as u8, short_key);
+                let key_index = collection_entry::index_key(&self.context, short_key);
                 !self.delete_storage_first && self.context.store().contains_key(&key_index).await?
             }
         })
@@ -653,10 +590,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                 match entry {
                     Update::Set(view) => Ok(view),
                     Update::Removed => {
-                        let key = self
-                            .context
-                            .base_key()
-                            .base_tag_index(KeyTag::Subview as u8, short_key);
+                        let key = collection_entry::subview_key(&self.context, short_key);
                         let context = self.context.clone_with_base_key(key);
                         // Obtain a view and set its pending state to the default (e.g. empty) state
                         let view = W::new(context)?;
@@ -669,10 +603,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                 }
             }
             btree_map::Entry::Vacant(entry) => {
-                let key = self
-                    .context
-                    .base_key()
-                    .base_tag_index(KeyTag::Subview as u8, short_key);
+                let key = collection_entry::subview_key(&self.context, short_key);
                 let context = self.context.clone_with_base_key(key);
                 let view = if self.delete_storage_first {
                     W::new(context)?
@@ -864,10 +795,7 @@ impl<W: HashableView> HashableView for ByteCollectionView<W::Context, W> {
                     view.hash_mut().await?
                 }
                 None => {
-                    let key = self
-                        .context
-                        .base_key()
-                        .base_tag_index(KeyTag::Subview as u8, &key);
+                    let key = collection_entry::subview_key(&self.context, &key);
                     let context = self.context.clone_with_base_key(key);
                     let mut view = W::load(context).await?;
                     view.hash_mut().await?
@@ -896,10 +824,7 @@ impl<W: HashableView> HashableView for ByteCollectionView<W::Context, W> {
                     view.hash().await?
                 }
                 None => {
-                    let key = self
-                        .context
-                        .base_key()
-                        .base_tag_index(KeyTag::Subview as u8, &key);
+                    let key = collection_entry::subview_key(&self.context, &key);
                     let context = self.context.clone_with_base_key(key);
                     let view = W::load(context).await?;
                     view.hash().await?

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -226,6 +226,47 @@ impl<W: ClonableView> ClonableView for ByteCollectionView<W::Context, W> {
 }
 
 impl<W: View> ByteCollectionView<W::Context, W> {
+    /// The context of the subview stored at `short_key`.
+    fn subview_context(context: &W::Context, short_key: &[u8]) -> W::Context {
+        let key = context
+            .base_key()
+            .base_tag_index(KeyTag::Subview as u8, short_key);
+        context.clone_with_base_key(key)
+    }
+
+    /// The keys deciding whether the entry at `short_key` exists and, if it does, loading its
+    /// subview: the index marker followed by the subview's initialization keys.
+    fn entry_keys(
+        context: &W::Context,
+        subview_context: &W::Context,
+        short_key: &[u8],
+    ) -> Result<Vec<Vec<u8>>, ViewError> {
+        let mut keys = Vec::with_capacity(1 + W::NUM_INIT_KEYS);
+        keys.push(
+            context
+                .base_key()
+                .base_tag_index(KeyTag::Index as u8, short_key),
+        );
+        keys.extend(W::pre_load(subview_context)?);
+        Ok(keys)
+    }
+
+    /// Builds the subview out of the values read for `entry_keys`, or `None` when the index
+    /// marker is absent. The marker is stored with an empty value, so its presence and not
+    /// its content is what decides.
+    fn post_load_entry(
+        subview_context: W::Context,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Option<W>, ViewError> {
+        let Some((marker, init_values)) = values.split_first() else {
+            return Ok(None);
+        };
+        if marker.is_none() {
+            return Ok(None);
+        }
+        Ok(Some(W::post_load(subview_context, init_values)?))
+    }
+
     fn get_index_key(&self, index: &[u8]) -> Vec<u8> {
         self.context
             .base_key()
@@ -323,26 +364,22 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                 })),
             },
             None => {
-                let key_index = self
-                    .context
-                    .base_key()
-                    .base_tag_index(KeyTag::Index as u8, short_key);
-                if !self.delete_storage_first
-                    && self.context.store().contains_key(&key_index).await?
-                {
-                    let key = self
-                        .context
-                        .base_key()
-                        .base_tag_index(KeyTag::Subview as u8, short_key);
-                    let context = self.context.clone_with_base_key(key);
-                    let view = W::load(context).await?;
-                    Ok(Some(ReadGuardedView::NotLoaded {
-                        _updates: updates,
-                        view,
-                    }))
-                } else {
-                    Ok(None)
+                if self.delete_storage_first {
+                    return Ok(None);
                 }
+                // The index marker and the subview's initialization keys are read together, so
+                // that loading an entry costs a single round trip whether or not it exists.
+                let subview_context = Self::subview_context(&self.context, short_key);
+                let keys = Self::entry_keys(&self.context, &subview_context, short_key)?;
+                let values = self.context.store().read_multi_values_bytes(&keys).await?;
+                Ok(
+                    Self::post_load_entry(subview_context, &values)?.map(|view| {
+                        ReadGuardedView::NotLoaded {
+                            _updates: updates,
+                            view,
+                        }
+                    }),
+                )
             }
         }
     }
@@ -372,8 +409,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
         short_keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<ReadGuardedView<'_, W>>>, ViewError> {
         let mut results = Vec::with_capacity(short_keys.len());
-        let mut keys_to_check = Vec::new();
-        let mut keys_to_check_metadata = Vec::new();
+        let mut entries_to_load = Vec::new();
         let updates = self.updates.read().await;
 
         for (position, short_key) in short_keys.into_iter().enumerate() {
@@ -393,49 +429,39 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                 None => {
                     results.push(None); // Placeholder, may be updated later
                     if !self.delete_storage_first {
-                        let key = self
-                            .context
-                            .base_key()
-                            .base_tag_index(KeyTag::Subview as u8, &short_key);
-                        let subview_context = self.context.clone_with_base_key(key);
-                        let key = self
-                            .context
-                            .base_key()
-                            .base_tag_index(KeyTag::Index as u8, &short_key);
-                        keys_to_check.push(key);
-                        keys_to_check_metadata.push((position, subview_context));
+                        entries_to_load.push((position, short_key));
                     }
                 }
             }
         }
 
-        let found_keys = self.context.store().contains_keys(&keys_to_check).await?;
-        let entries_to_load = keys_to_check_metadata
-            .into_iter()
-            .zip(found_keys)
-            .filter_map(|(metadata, found)| found.then_some(metadata))
-            .collect::<Vec<_>>();
-
-        let mut keys_to_load = Vec::with_capacity(entries_to_load.len() * W::NUM_INIT_KEYS);
-        for (_, context) in &entries_to_load {
-            keys_to_load.extend(W::pre_load(context)?);
-        }
-        let values = self
-            .context
-            .store()
-            .read_multi_values_bytes(&keys_to_load)
-            .await?;
-
-        for (loaded_values, (position, context)) in values
-            .chunks_exact_or_repeat(W::NUM_INIT_KEYS)
-            .zip(entries_to_load)
-        {
-            let view = W::post_load(context, loaded_values)?;
-            let updates = self.updates.read().await;
-            results[position] = Some(ReadGuardedView::NotLoaded {
-                _updates: updates,
-                view,
-            });
+        if !entries_to_load.is_empty() {
+            // The index markers and the subviews' initialization keys are read together, so
+            // that loading entries costs a single round trip whether or not they exist.
+            let entry_len = 1 + W::NUM_INIT_KEYS;
+            let mut keys = Vec::with_capacity(entries_to_load.len() * entry_len);
+            let mut subview_contexts = Vec::with_capacity(entries_to_load.len());
+            for (_, short_key) in &entries_to_load {
+                let subview_context = Self::subview_context(&self.context, short_key);
+                keys.extend(Self::entry_keys(
+                    &self.context,
+                    &subview_context,
+                    short_key,
+                )?);
+                subview_contexts.push(subview_context);
+            }
+            let values = self.context.store().read_multi_values_bytes(&keys).await?;
+            for ((position, _), (entry_values, subview_context)) in entries_to_load
+                .into_iter()
+                .zip(values.chunks_exact(entry_len).zip(subview_contexts))
+            {
+                if let Some(view) = Self::post_load_entry(subview_context, entry_values)? {
+                    results[position] = Some(ReadGuardedView::NotLoaded {
+                        _updates: self.updates.read().await,
+                        view,
+                    });
+                }
+            }
         }
 
         Ok(results)

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -319,14 +319,12 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                 let (subview_context, keys) =
                     collection_entry::entry_keys::<W>(&self.context, short_key)?;
                 let values = self.context.store().read_multi_values_bytes(&keys).await?;
-                Ok(
-                    collection_entry::post_load_entry::<W>(subview_context, &values)?.map(|view| {
-                        ReadGuardedView::NotLoaded {
-                            _updates: updates,
-                            view,
-                        }
-                    }),
-                )
+                let subview = collection_entry::post_load_entry::<W>(subview_context, &values)?;
+                let entry = subview.map(|view| ReadGuardedView::NotLoaded {
+                    _updates: updates,
+                    view,
+                });
+                Ok(entry)
             }
         }
     }
@@ -539,7 +537,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
     /// ```
     pub async fn contains_key(&self, short_key: &[u8]) -> Result<bool, ViewError> {
         let updates = self.updates.read().await;
-        Ok(match updates.get(short_key) {
+        let contains = match updates.get(short_key) {
             Some(entry) => match entry {
                 Update::Set(_view) => true,
                 _entry @ Update::Removed => false,
@@ -548,7 +546,8 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                 let key_index = collection_entry::index_key(&self.context, short_key);
                 !self.delete_storage_first && self.context.store().contains_key(&key_index).await?
             }
-        })
+        };
+        Ok(contains)
     }
 
     /// Marks the entry as removed. If absent then nothing is done.

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -36,6 +36,8 @@ pub mod map_view;
 /// The `SetView` implements a set with ordered entries.
 pub mod set_view;
 
+mod collection_entry;
+
 /// The `CollectionView` implements a map structure whose keys are ordered and the values are views.
 pub mod collection_view;
 

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -334,10 +334,7 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
         delete_storage_first: bool,
         short_key: &[u8],
     ) -> Result<Arc<RwLock<W>>, ViewError> {
-        let key = context
-            .base_key()
-            .base_tag_index(KeyTag::Subview as u8, short_key);
-        let context = context.clone_with_base_key(key);
+        let context = Self::subview_context(context, short_key);
         // Obtain a view and set its pending state to the default (e.g. empty) state
         let view = if delete_storage_first {
             W::new(context)?

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -297,7 +297,7 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
     /// If the entry is missing, then it is set to default.
     async fn try_load_view_mut(&mut self, short_key: &[u8]) -> Result<Arc<RwLock<W>>, ViewError> {
         use btree_map::Entry::*;
-        Ok(match self.updates.entry(short_key.to_owned()) {
+        let view = match self.updates.entry(short_key.to_owned()) {
             Occupied(mut entry) => match entry.get_mut() {
                 Update::Set(view) => view.clone(),
                 entry @ Update::Removed => {
@@ -312,14 +312,15 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
                 entry.insert(Update::Set(wrapped_view.clone()));
                 wrapped_view
             }
-        })
+        };
+        Ok(view)
     }
 
     /// Load the view from the update is available.
     /// If missing, then the entry is loaded from storage and if
     /// missing there an error is reported.
     async fn try_load_view(&self, short_key: &[u8]) -> Result<Option<Arc<RwLock<W>>>, ViewError> {
-        Ok(if let Some(entry) = self.updates.get(short_key) {
+        let view = if let Some(entry) = self.updates.get(short_key) {
             match entry {
                 Update::Set(view) => Some(view.clone()),
                 _entry @ Update::Removed => None,
@@ -334,7 +335,8 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
             let values = self.context.store().read_multi_values_bytes(&keys).await?;
             collection_entry::post_load_entry::<W>(subview_context, &values)?
                 .map(|view| Arc::new(RwLock::new(view)))
-        })
+        };
+        Ok(view)
     }
 
     /// Loads a subview for the data at the given index in the collection. If an entry
@@ -414,7 +416,7 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
     /// # })
     /// ```
     pub async fn contains_key(&self, short_key: &[u8]) -> Result<bool, ViewError> {
-        Ok(if let Some(entry) = self.updates.get(short_key) {
+        let contains = if let Some(entry) = self.updates.get(short_key) {
             match entry {
                 Update::Set(_view) => true,
                 Update::Removed => false,
@@ -424,7 +426,8 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
         } else {
             let key_index = collection_entry::index_key(&self.context, short_key);
             self.context.store().contains_key(&key_index).await?
-        })
+        };
+        Ok(contains)
     }
 
     /// Removes an entry. If absent then nothing happens.

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -287,6 +287,47 @@ impl<C: Context, W> ReentrantByteCollectionView<C, W> {
 }
 
 impl<W: View> ReentrantByteCollectionView<W::Context, W> {
+    /// The context of the subview stored at `short_key`.
+    fn subview_context(context: &W::Context, short_key: &[u8]) -> W::Context {
+        let key = context
+            .base_key()
+            .base_tag_index(KeyTag::Subview as u8, short_key);
+        context.clone_with_base_key(key)
+    }
+
+    /// The keys deciding whether the entry at `short_key` exists and, if it does, loading its
+    /// subview: the index marker followed by the subview's initialization keys.
+    fn entry_keys(
+        context: &W::Context,
+        subview_context: &W::Context,
+        short_key: &[u8],
+    ) -> Result<Vec<Vec<u8>>, ViewError> {
+        let mut keys = Vec::with_capacity(1 + W::NUM_INIT_KEYS);
+        keys.push(
+            context
+                .base_key()
+                .base_tag_index(KeyTag::Index as u8, short_key),
+        );
+        keys.extend(W::pre_load(subview_context)?);
+        Ok(keys)
+    }
+
+    /// Builds the subview out of the values read for `entry_keys`, or `None` when the index
+    /// marker is absent. The marker is stored with an empty value, so its presence and not
+    /// its content is what decides.
+    fn post_load_entry(
+        subview_context: W::Context,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Option<W>, ViewError> {
+        let Some((marker, init_values)) = values.split_first() else {
+            return Ok(None);
+        };
+        if marker.is_none() {
+            return Ok(None);
+        }
+        Ok(Some(W::post_load(subview_context, init_values)?))
+    }
+
     /// Reads the view and if missing returns the default view
     async fn wrapped_view(
         context: &W::Context,
@@ -340,16 +381,12 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
         } else if self.delete_storage_first {
             None
         } else {
-            let key_index = self
-                .context
-                .base_key()
-                .base_tag_index(KeyTag::Index as u8, short_key);
-            if self.context.store().contains_key(&key_index).await? {
-                let view = Self::wrapped_view(&self.context, false, short_key).await?;
-                Some(view)
-            } else {
-                None
-            }
+            // The index marker and the subview's initialization keys are read together, so
+            // that loading an entry costs a single round trip whether or not it exists.
+            let subview_context = Self::subview_context(&self.context, short_key);
+            let keys = Self::entry_keys(&self.context, &subview_context, short_key)?;
+            let values = self.context.store().read_multi_values_bytes(&keys).await?;
+            Self::post_load_entry(subview_context, &values)?.map(|view| Arc::new(RwLock::new(view)))
         })
     }
 
@@ -626,8 +663,7 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
         short_keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<ReadGuardedView<W>>>, ViewError> {
         let mut results = vec![None; short_keys.len()];
-        let mut keys_to_check = Vec::new();
-        let mut keys_to_check_metadata = Vec::new();
+        let mut entries_to_load = Vec::new();
 
         for (position, short_key) in short_keys.into_iter().enumerate() {
             if let Some(update) = self.updates.get(&short_key) {
@@ -635,46 +671,33 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
                     results[position] = Some((short_key, view.clone()));
                 }
             } else if !self.delete_storage_first {
-                let key_index = self
-                    .context
-                    .base_key()
-                    .base_tag_index(KeyTag::Index as u8, &short_key);
-                keys_to_check.push(key_index);
-                keys_to_check_metadata.push((position, short_key));
+                entries_to_load.push((position, short_key));
             }
         }
 
-        let found_keys = self.context.store().contains_keys(&keys_to_check).await?;
-        let entries_to_load = keys_to_check_metadata
-            .into_iter()
-            .zip(found_keys)
-            .filter_map(|(metadata, found)| found.then_some(metadata))
-            .map(|(position, short_key)| {
-                let subview_key = self
-                    .context
-                    .base_key()
-                    .base_tag_index(KeyTag::Subview as u8, &short_key);
-                let subview_context = self.context.clone_with_base_key(subview_key);
-                (position, short_key.to_owned(), subview_context)
-            })
-            .collect::<Vec<_>>();
         if !entries_to_load.is_empty() {
-            let mut keys_to_load = Vec::with_capacity(entries_to_load.len() * W::NUM_INIT_KEYS);
-            for (_, _, context) in &entries_to_load {
-                keys_to_load.extend(W::pre_load(context)?);
+            // The index markers and the subviews' initialization keys are read together, so
+            // that loading entries costs a single round trip whether or not they exist.
+            let entry_len = 1 + W::NUM_INIT_KEYS;
+            let mut keys = Vec::with_capacity(entries_to_load.len() * entry_len);
+            let mut subview_contexts = Vec::with_capacity(entries_to_load.len());
+            for (_, short_key) in &entries_to_load {
+                let subview_context = Self::subview_context(&self.context, short_key);
+                keys.extend(Self::entry_keys(
+                    &self.context,
+                    &subview_context,
+                    short_key,
+                )?);
+                subview_contexts.push(subview_context);
             }
-            let values = self
-                .context
-                .store()
-                .read_multi_values_bytes(&keys_to_load)
-                .await?;
-            for (loaded_values, (position, short_key, context)) in values
-                .chunks_exact_or_repeat(W::NUM_INIT_KEYS)
-                .zip(entries_to_load)
+            let values = self.context.store().read_multi_values_bytes(&keys).await?;
+            for ((position, short_key), (entry_values, subview_context)) in entries_to_load
+                .into_iter()
+                .zip(values.chunks_exact(entry_len).zip(subview_contexts))
             {
-                let view = W::post_load(context, loaded_values)?;
-                let wrapped_view = Arc::new(RwLock::new(view));
-                results[position] = Some((short_key, wrapped_view));
+                if let Some(view) = Self::post_load_entry(subview_context, entry_values)? {
+                    results[position] = Some((short_key, Arc::new(RwLock::new(view))));
+                }
             }
         }
 

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -24,7 +24,9 @@ use crate::{
     hashable_wrapper::WrappedHashableContainerView,
     historical_hash_wrapper::HistoricallyHashableView,
     store::ReadableKeyValueStore as _,
-    views::{ClonableView, HashableView, Hasher, ReplaceContext, View, ViewError, MIN_VIEW_TAG},
+    views::{
+        collection_entry, ClonableView, HashableView, Hasher, ReplaceContext, View, ViewError,
+    },
 };
 
 #[cfg(with_metrics)]
@@ -146,14 +148,6 @@ where
 /// just concatenating the shared prefix with sub-view keys makes it impossible to distinguish if a
 /// given key belongs to a child sub-view or a grandchild sub-view (consider for example if a
 /// collection is stored inside the collection).
-#[repr(u8)]
-enum KeyTag {
-    /// Prefix for specifying an index and serves to indicate the existence of an entry in the collection.
-    Index = MIN_VIEW_TAG,
-    /// Prefix for specifying as the prefix for the sub-view.
-    Subview,
-}
-
 impl<W: View> View for ReentrantByteCollectionView<W::Context, W> {
     const NUM_INIT_KEYS: usize = 0;
 
@@ -269,15 +263,11 @@ impl<W: ClonableView> ClonableView for ReentrantByteCollectionView<W::Context, W
 
 impl<C: Context, W> ReentrantByteCollectionView<C, W> {
     fn get_index_key(&self, index: &[u8]) -> Vec<u8> {
-        self.context
-            .base_key()
-            .base_tag_index(KeyTag::Index as u8, index)
+        collection_entry::index_key(&self.context, index)
     }
 
     fn get_subview_key(&self, index: &[u8]) -> Vec<u8> {
-        self.context
-            .base_key()
-            .base_tag_index(KeyTag::Subview as u8, index)
+        collection_entry::subview_key(&self.context, index)
     }
 
     fn add_index(&self, batch: &mut Batch, index: &[u8]) {
@@ -287,54 +277,13 @@ impl<C: Context, W> ReentrantByteCollectionView<C, W> {
 }
 
 impl<W: View> ReentrantByteCollectionView<W::Context, W> {
-    /// The context of the subview stored at `short_key`.
-    fn subview_context(context: &W::Context, short_key: &[u8]) -> W::Context {
-        let key = context
-            .base_key()
-            .base_tag_index(KeyTag::Subview as u8, short_key);
-        context.clone_with_base_key(key)
-    }
-
-    /// The keys deciding whether the entry at `short_key` exists and, if it does, loading its
-    /// subview: the index marker followed by the subview's initialization keys.
-    fn entry_keys(
-        context: &W::Context,
-        subview_context: &W::Context,
-        short_key: &[u8],
-    ) -> Result<Vec<Vec<u8>>, ViewError> {
-        let mut keys = Vec::with_capacity(1 + W::NUM_INIT_KEYS);
-        keys.push(
-            context
-                .base_key()
-                .base_tag_index(KeyTag::Index as u8, short_key),
-        );
-        keys.extend(W::pre_load(subview_context)?);
-        Ok(keys)
-    }
-
-    /// Builds the subview out of the values read for `entry_keys`, or `None` when the index
-    /// marker is absent. The marker is stored with an empty value, so its presence and not
-    /// its content is what decides.
-    fn post_load_entry(
-        subview_context: W::Context,
-        values: &[Option<Vec<u8>>],
-    ) -> Result<Option<W>, ViewError> {
-        let Some((marker, init_values)) = values.split_first() else {
-            return Ok(None);
-        };
-        if marker.is_none() {
-            return Ok(None);
-        }
-        Ok(Some(W::post_load(subview_context, init_values)?))
-    }
-
     /// Reads the view and if missing returns the default view
     async fn wrapped_view(
         context: &W::Context,
         delete_storage_first: bool,
         short_key: &[u8],
     ) -> Result<Arc<RwLock<W>>, ViewError> {
-        let context = Self::subview_context(context, short_key);
+        let context = collection_entry::subview_context(context, short_key);
         // Obtain a view and set its pending state to the default (e.g. empty) state
         let view = if delete_storage_first {
             W::new(context)?
@@ -380,10 +329,11 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
         } else {
             // The index marker and the subview's initialization keys are read together, so
             // that loading an entry costs a single round trip whether or not it exists.
-            let subview_context = Self::subview_context(&self.context, short_key);
-            let keys = Self::entry_keys(&self.context, &subview_context, short_key)?;
+            let (subview_context, keys) =
+                collection_entry::entry_keys::<W>(&self.context, short_key)?;
             let values = self.context.store().read_multi_values_bytes(&keys).await?;
-            Self::post_load_entry(subview_context, &values)?.map(|view| Arc::new(RwLock::new(view)))
+            collection_entry::post_load_entry::<W>(subview_context, &values)?
+                .map(|view| Arc::new(RwLock::new(view)))
         })
     }
 
@@ -472,10 +422,7 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
         } else if self.delete_storage_first {
             false
         } else {
-            let key_index = self
-                .context
-                .base_key()
-                .base_tag_index(KeyTag::Index as u8, short_key);
+            let key_index = collection_entry::index_key(&self.context, short_key);
             self.context.store().contains_key(&key_index).await?
         })
     }
@@ -529,10 +476,7 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
     /// # })
     /// ```
     pub fn try_reset_entry_to_default(&mut self, short_key: &[u8]) -> Result<(), ViewError> {
-        let key = self
-            .context
-            .base_key()
-            .base_tag_index(KeyTag::Subview as u8, short_key);
+        let key = collection_entry::subview_key(&self.context, short_key);
         let context = self.context.clone_with_base_key(key);
         let view = W::new(context)?;
         let view = Arc::new(RwLock::new(view));
@@ -578,10 +522,7 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
         let mut short_keys_to_load = Vec::new();
         let mut keys = Vec::new();
         for short_key in &short_keys {
-            let key = self
-                .context
-                .base_key()
-                .base_tag_index(KeyTag::Subview as u8, short_key);
+            let key = collection_entry::subview_key(&self.context, short_key);
             let context = self.context.clone_with_base_key(key);
             match self.updates.entry(short_key.to_vec()) {
                 btree_map::Entry::Occupied(mut entry) => {
@@ -608,10 +549,7 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
             .chunks_exact_or_repeat(W::NUM_INIT_KEYS)
             .zip(short_keys_to_load)
         {
-            let key = self
-                .context
-                .base_key()
-                .base_tag_index(KeyTag::Subview as u8, &short_key);
+            let key = collection_entry::subview_key(&self.context, &short_key);
             let context = self.context.clone_with_base_key(key);
             let view = W::post_load(context, loaded_values)?;
             let wrapped_view = Arc::new(RwLock::new(view));
@@ -675,16 +613,13 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
         if !entries_to_load.is_empty() {
             // The index markers and the subviews' initialization keys are read together, so
             // that loading entries costs a single round trip whether or not they exist.
-            let entry_len = 1 + W::NUM_INIT_KEYS;
+            let entry_len = collection_entry::entry_len::<W>();
             let mut keys = Vec::with_capacity(entries_to_load.len() * entry_len);
             let mut subview_contexts = Vec::with_capacity(entries_to_load.len());
             for (_, short_key) in &entries_to_load {
-                let subview_context = Self::subview_context(&self.context, short_key);
-                keys.extend(Self::entry_keys(
-                    &self.context,
-                    &subview_context,
-                    short_key,
-                )?);
+                let (subview_context, entry) =
+                    collection_entry::entry_keys::<W>(&self.context, short_key)?;
+                keys.extend(entry);
                 subview_contexts.push(subview_context);
             }
             let values = self.context.store().read_multi_values_bytes(&keys).await?;
@@ -692,7 +627,9 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
                 .into_iter()
                 .zip(values.chunks_exact(entry_len).zip(subview_contexts))
             {
-                if let Some(view) = Self::post_load_entry(subview_context, entry_values)? {
+                if let Some(view) =
+                    collection_entry::post_load_entry::<W>(subview_context, entry_values)?
+                {
                     results[position] = Some((short_key, Arc::new(RwLock::new(view))));
                 }
             }
@@ -739,10 +676,7 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
             let mut short_keys_and_indexes = Vec::new();
             for (index, short_key) in short_keys.iter().enumerate() {
                 if !self.updates.contains_key(short_key) {
-                    let key = self
-                        .context
-                        .base_key()
-                        .base_tag_index(KeyTag::Subview as u8, short_key);
+                    let key = collection_entry::subview_key(&self.context, short_key);
                     let context = self.context.clone_with_base_key(key);
                     keys.extend(W::pre_load(&context)?);
                     short_keys_and_indexes.push((short_key.to_vec(), index));
@@ -753,10 +687,7 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
                 .chunks_exact_or_repeat(W::NUM_INIT_KEYS)
                 .zip(short_keys_and_indexes)
             {
-                let key = self
-                    .context
-                    .base_key()
-                    .base_tag_index(KeyTag::Subview as u8, &short_key);
+                let key = collection_entry::subview_key(&self.context, &short_key);
                 let context = self.context.clone_with_base_key(key);
                 let view = W::post_load(context, loaded_values)?;
                 let wrapped_view = Arc::new(RwLock::new(view));
@@ -812,10 +743,7 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
 
             for short_key in &short_keys {
                 if !self.updates.contains_key(short_key) {
-                    let key = self
-                        .context
-                        .base_key()
-                        .base_tag_index(KeyTag::Subview as u8, short_key);
+                    let key = collection_entry::subview_key(&self.context, short_key);
                     let context = self.context.clone_with_base_key(key);
                     keys.extend(W::pre_load(&context)?);
                     short_keys_to_load.push(short_key.to_vec());
@@ -827,10 +755,7 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
                 .chunks_exact_or_repeat(W::NUM_INIT_KEYS)
                 .zip(short_keys_to_load)
             {
-                let key = self
-                    .context
-                    .base_key()
-                    .base_tag_index(KeyTag::Subview as u8, &short_key);
+                let key = collection_entry::subview_key(&self.context, &short_key);
                 let context = self.context.clone_with_base_key(key);
                 let view = W::post_load(context, loaded_values)?;
                 let wrapped_view = Arc::new(RwLock::new(view));
@@ -1030,10 +955,7 @@ impl<W: HashableView> HashableView for ReentrantByteCollectionView<W::Context, W
                     .ok_or_else(|| ViewError::TryLockError(key))?;
                 view.hash_mut().await?
             } else {
-                let key = self
-                    .context
-                    .base_key()
-                    .base_tag_index(KeyTag::Subview as u8, &key);
+                let key = collection_entry::subview_key(&self.context, &key);
                 let context = self.context.clone_with_base_key(key);
                 let mut view = W::load(context).await?;
                 view.hash_mut().await?
@@ -1061,10 +983,7 @@ impl<W: HashableView> HashableView for ReentrantByteCollectionView<W::Context, W
                     .ok_or_else(|| ViewError::TryLockError(key))?;
                 view.hash().await?
             } else {
-                let key = self
-                    .context
-                    .base_key()
-                    .base_tag_index(KeyTag::Subview as u8, &key);
+                let key = collection_entry::subview_key(&self.context, &key);
                 let context = self.context.clone_with_base_key(key);
                 let view = W::load(context).await?;
                 view.hash().await?

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -141,13 +141,6 @@ where
     }
 }
 
-/// We need to find new base keys in order to implement the collection view.
-/// We do this by appending a value to the base key.
-///
-/// Sub-views in a collection share a common key prefix, like in other view types. However,
-/// just concatenating the shared prefix with sub-view keys makes it impossible to distinguish if a
-/// given key belongs to a child sub-view or a grandchild sub-view (consider for example if a
-/// collection is stored inside the collection).
 impl<W: View> View for ReentrantByteCollectionView<W::Context, W> {
     const NUM_INIT_KEYS: usize = 0;
 

--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -14,6 +14,7 @@ use crate::scylla_db::ScyllaDbDatabase;
 use crate::store::{KeyValueDatabase, TestKeyValueDatabase};
 use crate::{
     batch::Batch,
+    collection_view::CollectionView,
     context::{Context, MemoryContext},
     lazy_register_view::LazyRegisterView,
     queue_view::QueueView,
@@ -452,6 +453,96 @@ async fn test_reentrant_collection_view_has_pending_changes_after_try_load_entri
     assert!(!entries[1].has_pending_changes().await);
 
     assert!(view.has_pending_changes().await);
+
+    Ok(())
+}
+
+/// Checks that a [`CollectionView`] batch load serves every index from storage in order when
+/// some of them are absent. Index 3 exists but was never written to, so only its index marker
+/// is stored.
+#[tokio::test]
+async fn test_collection_view_try_load_entries_with_absent_entries() -> anyhow::Result<()> {
+    let context = MemoryContext::new_for_testing(());
+    let mut view = CollectionView::<_, u8, RegisterView<_, String>>::load(context.clone()).await?;
+
+    view.load_entry_mut(&1).await?.set("first".to_owned());
+    view.load_entry_mut(&3).await?;
+    view.load_entry_mut(&5).await?.set("fifth".to_owned());
+    save_view(&context, &mut view).await?;
+
+    // Reopening the collection empties the pending updates, so the entries below are all read
+    // back from storage rather than served from memory.
+    let view = CollectionView::<_, u8, RegisterView<_, String>>::load(context.clone()).await?;
+    let expected = [
+        None,
+        Some("first".to_owned()),
+        None,
+        Some(String::new()),
+        None,
+        Some("fifth".to_owned()),
+        None,
+    ];
+
+    let entries = view.try_load_entries([&0, &1, &2, &3, &4, &5, &6]).await?;
+    let read = entries
+        .iter()
+        .map(|entry| entry.as_ref().map(|entry| entry.get().clone()))
+        .collect::<Vec<_>>();
+    assert_eq!(read, expected);
+
+    drop(entries);
+    for (index, expected) in (0..=6).zip(expected) {
+        let entry = view.try_load_entry(&index).await?;
+        assert_eq!(entry.map(|entry| entry.get().clone()), expected);
+    }
+
+    Ok(())
+}
+
+/// Checks that a [`ReentrantCollectionView`] batch load serves every index from storage in order
+/// when some of them are absent. Index 3 exists but was never written to, so only its index
+/// marker is stored.
+#[tokio::test]
+async fn test_reentrant_collection_view_try_load_entries_with_absent_entries() -> anyhow::Result<()>
+{
+    let context = MemoryContext::new_for_testing(());
+    let mut view =
+        ReentrantCollectionView::<_, u8, RegisterView<_, String>>::load(context.clone()).await?;
+
+    populate_reentrant_collection_view(
+        &mut view,
+        [(1, "first".to_owned()), (5, "fifth".to_owned())],
+    )
+    .await?;
+    view.try_load_entry_mut(&3).await?;
+    save_view(&context, &mut view).await?;
+
+    // Reopening the collection empties the pending updates, so the entries below are all read
+    // back from storage rather than served from memory.
+    let view =
+        ReentrantCollectionView::<_, u8, RegisterView<_, String>>::load(context.clone()).await?;
+    let expected = [
+        None,
+        Some("first".to_owned()),
+        None,
+        Some(String::new()),
+        None,
+        Some("fifth".to_owned()),
+        None,
+    ];
+
+    let entries = view.try_load_entries([&0, &1, &2, &3, &4, &5, &6]).await?;
+    let read = entries
+        .iter()
+        .map(|entry| entry.as_ref().map(|entry| entry.get().clone()))
+        .collect::<Vec<_>>();
+    assert_eq!(read, expected);
+
+    drop(entries);
+    for (index, expected) in (0..=6).zip(expected) {
+        let entry = view.try_load_entry(&index).await?;
+        assert_eq!(entry.map(|entry| entry.get().clone()), expected);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

Backport of #6737 to `testnet_conway`.

Loading an entry from a collection costs two **sequential** round trips: `try_load_entry` asks
whether the entry exists, and only then loads the subview. The existence marker is
`Index`-tagged and the subview's initialization keys are `Subview`-tagged, so the second read
cannot start until the first returns. The batch variants have the same shape: `contains_keys`,
then `read_multi_values_bytes`.

Both `ReentrantByteCollectionView` and `ByteCollectionView` are affected, in both their
single-entry and batch paths. `ChainStateView::inboxes` and `outboxes` are
`ReentrantCollectionView`s, so on this branch every inbox and outbox access pays both.

## Proposal

Read the index marker and the subview's initialization keys in one `read_multi_values_bytes`,
then use the marker to decide whether to build the subview. The marker cannot be eliminated —
it is what distinguishes an absent entry from a present-but-empty one — but it can be fetched
in the same batch.

Never worse in round trips, and better whenever the entry exists:

| | before | after |
|---|---|---|
| entry exists | 2 round trips (1 key, then `NUM_INIT_KEYS`) | 1 round trip (`1 + NUM_INIT_KEYS` keys) |
| entry absent | 1 round trip (1 key) | 1 round trip (`1 + NUM_INIT_KEYS` keys) |

On a miss the extra initialization keys resolve to `None`, so the cost is a slightly wider
batched query rather than an additional round trip.

Clean cherry-pick of the two `main` commits, with no adjustments. Both collection files have
diverged from `main` on this branch, but not in the functions this touches — the applied hunks
are identical to the ones on `main`.

## Test Plan

Everything below on this branch's pinned toolchains (Rust 1.86, nightly-2025-04-03), not
`main`'s:

- `cargo clippy -p linera-views --features metrics --all-targets -- -D warnings` — clean.
- `cargo test -p linera-views --features metrics` — 223 passing.
- `cargo test -p linera-chain` — 52 passing; this is what exercises the inbox and outbox
  collections.
- `cargo +nightly-2025-04-03 fmt --all -- --check`.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- #6737 — the `main` PR this backports.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
