### PR TITLE
[testnet_conway] Report an invalid stream ID as such rather than as an invalid blob ID (#6742)

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -656,7 +656,7 @@ impl std::str::FromStr for StreamId {
                 stream_name,
             })
         } else {
-            Err(anyhow!("Invalid blob ID: {s}"))
+            Err(anyhow!("Invalid stream ID: {s}"))
         }
     }
 }


### PR DESCRIPTION
Backport of #6742 to `testnet_conway`.

## Motivation

`StreamId::from_str` reports a malformed stream ID as `Invalid blob ID: <s>` — the message
belongs to `BlobId::from_str` a few hundred lines up, and looks like a copy-paste slip. It
sends anyone debugging a bad stream ID looking at blobs instead.

This matters more on this branch than on `main`: #6740 adds `Chain.events()` to
`@linera/client` here, and that API surfaces this parse error straight to the JavaScript
caller.

## Proposal

Clean cherry-pick of 4ef126379921f97c103ef89b722dcd8f647f741a. One string literal; no
behaviour changes, and nothing asserts the old text.

## Test Plan

CI. Locally, on this branch's pinned toolchains: `cargo check -p linera-base`, and
`cargo fmt --check -p linera-base` under `nightly-2025-04-03`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

This is a developer-facing message with no protocol or storage impact, so it should ride
the next SDK/validator cut rather than prompt one.

## Links

- #6742, the `main` PR this backports
- #6740, which surfaced it

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
