### PR TITLE
Drop thiserror-context and fold its annotations into error variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5226,7 +5226,6 @@ dependencies = [
  "test-log",
  "test-strategy",
  "thiserror 1.0.69",
- "thiserror-context",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5463,7 +5462,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "thiserror-context",
 ]
 
 [[package]]
@@ -5668,7 +5666,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "thiserror-context",
  "tracing",
  "trait-variant",
 ]
@@ -10277,12 +10274,6 @@ checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl 2.0.17",
 ]
-
-[[package]]
-name = "thiserror-context"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4cf778b0694c0adf030668380054b3a382f1e5e6a2e9a0b54bc5e677045bca"
 
 [[package]]
 name = "thiserror-impl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,7 +270,6 @@ test-log = { version = "0.2.15", default-features = false, features = [
 ] }
 test-strategy = "0.3.1"
 thiserror = "1.0.65"
-thiserror-context = "0.1.1"
 tokio = "1.36.0"
 tokio-stream = "0.1.14"
 tokio-test = "0.4.3"

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -4165,7 +4165,6 @@ dependencies = [
  "serde_yaml 0.8.26",
  "serde_yaml 0.9.34+deprecated",
  "thiserror 1.0.69",
- "thiserror-context",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4263,7 +4262,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "thiserror-context",
 ]
 
 [[package]]
@@ -4278,7 +4276,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "thiserror-context",
  "tracing",
  "trait-variant",
 ]
@@ -7510,12 +7507,6 @@ checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl 2.0.18",
 ]
-
-[[package]]
-name = "thiserror-context"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4cf778b0694c0adf030668380054b3a382f1e5e6a2e9a0b54bc5e677045bca"
 
 [[package]]
 name = "thiserror-impl"

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -67,7 +67,6 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 serde_yaml_08 = { package = "serde_yaml", version = "0.8" }
 thiserror.workspace = true
-thiserror-context.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -112,7 +112,7 @@ pub trait ClientContext {
                 .get(chain_id)
                 .make_sync()
                 .await
-                .map_err(error::Inner::wallet)?
+                .map_err(error::Error::wallet)?
                 .unwrap_or_default();
             let follow_only = chain.is_follow_only();
             Ok(self.client().create_chain_client(
@@ -148,7 +148,7 @@ pub trait ClientContextExt: ClientContext {
         use futures::stream::TryStreamExt as _;
         self.wallet()
             .chain_ids()
-            .map_err(|e| error::Inner::wallet(e).into())
+            .map_err(error::Error::wallet)
             .and_then(|chain_id| self.make_chain_client(chain_id))
             .try_collect()
             .await
@@ -211,7 +211,7 @@ pub trait ClientContextExt: ClientContext {
         self.wallet()
             .modify(chain_id, |chain| chain.owner = Some(new_owner))
             .await
-            .map_err(error::Inner::wallet)?;
+            .map_err(error::Error::wallet)?;
         Ok(())
     }
 }
@@ -398,7 +398,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                 .collect::<Result<BTreeMap<_, _>, _>>()
                 .map_err(
                     |e: <<C::Environment as Environment>::Wallet as Wallet>::Error| {
-                        crate::error::Inner::Wallet(Box::new(e) as _)
+                        crate::error::Error::Wallet(Box::new(e) as _)
                     },
                 )?;
             // If the admin chain is not in the wallet, add it as follow-only since we
@@ -909,7 +909,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                         .wallet()
                         .modify(chain_id, |chain| chain.owner = Some(owner))
                         .await
-                        .map_err(error::Inner::wallet)?;
+                        .map_err(error::Error::wallet)?;
                     // If the chain didn't exist, insert a new entry.
                     if modified.is_none() {
                         let chain_description = context_guard
@@ -930,7 +930,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                                 },
                             )
                             .await
-                            .map_err(error::Inner::wallet)?;
+                            .map_err(error::Error::wallet)?;
                     }
 
                     chains.insert(chain_id, ListeningMode::FullChain);

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -25,7 +25,6 @@ use linera_core::{
 use linera_rpc::node_provider::{NodeOptions, NodeProvider};
 use linera_storage::Storage as _;
 use linera_version::VersionInfo;
-use thiserror_context::Context;
 use tracing::{debug, info, warn};
 #[cfg(not(web))]
 use {
@@ -319,7 +318,7 @@ where
             })
             .try_collect()
             .await
-            .map_err(error::Inner::wallet)?;
+            .map_err(error::Error::wallet)?;
         let name = match chain_modes.len() {
             0 => "Client node".to_string(),
             1 => format!("Client node for {:.8}", chain_modes[0].0),
@@ -447,7 +446,7 @@ impl<Env: Environment> ClientContext<Env> {
             .wallet()
             .get(chain_id)
             .await
-            .map_err(error::Inner::wallet)?
+            .map_err(error::Error::wallet)?
             .and_then(|chain| chain.owner);
 
         // Only persist proposals that were made in the fast round: they need to be
@@ -465,7 +464,7 @@ impl<Env: Environment> ClientContext<Env> {
         self.wallet()
             .insert(chain_id, new_chain)
             .await
-            .map_err(error::Inner::wallet)?;
+            .map_err(error::Error::wallet)?;
 
         Ok(())
     }
@@ -484,7 +483,7 @@ impl<Env: Environment> ClientContext<Env> {
                 linera_core::wallet::Chain::new(owner, epoch, timestamp),
             )
             .await
-            .map_err(error::Inner::wallet)?;
+            .map_err(error::Error::wallet)?;
         Ok(())
     }
 
@@ -510,7 +509,7 @@ impl<Env: Environment> ClientContext<Env> {
                 ),
             )
             .await
-            .map_err(error::Inner::wallet)?;
+            .map_err(error::Error::wallet)?;
         self.client
             .extend_chain_mode(chain_id, ListeningMode::FullChain);
         Ok(())
@@ -564,7 +563,7 @@ impl<Env: Environment> ClientContext<Env> {
         let client = self.make_chain_client(chain_id).await?;
         let info = client.prepare_for_owner(owner).await.map_err(|error| {
             tracing::error!(%chain_id, %owner, %error, "Chain is not owned");
-            error::Inner::ChainOwnership
+            error::Error::ChainOwnership
         })?;
 
         // Try to modify existing chain entry, setting the owner.
@@ -572,7 +571,7 @@ impl<Env: Environment> ClientContext<Env> {
             .wallet()
             .modify(chain_id, |chain| chain.owner = Some(owner))
             .await
-            .map_err(error::Inner::wallet)?;
+            .map_err(error::Error::wallet)?;
         // If the chain didn't exist, insert a new entry.
         if modified.is_none() {
             self.wallet()
@@ -586,8 +585,7 @@ impl<Env: Environment> ClientContext<Env> {
                     },
                 )
                 .await
-                .map_err(error::Inner::wallet)
-                .context("assigning new chain")?;
+                .map_err(|error| Error::AssignChain(Box::new(error)))?;
         }
         Ok(())
     }
@@ -664,7 +662,7 @@ impl<Env: Environment> ClientContext<Env> {
 
         if ownership.super_owners.is_empty() && ownership.owners.is_empty() {
             tracing::error!("At least one owner or super owner of the chain has to be set.");
-            return Err(error::Inner::ChainOwnership.into());
+            return Err(error::Error::ChainOwnership);
         }
 
         let certificate = self
@@ -675,8 +673,7 @@ impl<Env: Environment> ClientContext<Env> {
                     chain_client
                         .change_ownership(ownership)
                         .await
-                        .map_err(Error::from)
-                        .context("Failed to change ownership")
+                        .map_err(|error| Error::ChangeOwnership(Box::new(error)))
                 }
             })
             .await?;
@@ -718,16 +715,14 @@ impl<Env: Environment> ClientContext<Env> {
                 );
                 Ok(version_info)
             }
-            Ok(version_info) => Err(error::Inner::UnexpectedVersionInfo {
+            Ok(version_info) => Err(error::Error::UnexpectedVersionInfo {
                 remote: Box::new(version_info),
                 local: Box::new(linera_version::VERSION_INFO.clone()),
-            }
-            .into()),
-            Err(error) => Err(error::Inner::UnavailableVersionInfo {
+            }),
+            Err(error) => Err(error::Error::UnavailableVersionInfo {
                 address: address.to_string(),
                 error: Box::new(error),
-            }
-            .into()),
+            }),
         }
     }
 
@@ -743,18 +738,16 @@ impl<Env: Environment> ClientContext<Env> {
                 if description == network_description {
                     Ok(description.genesis_config_hash)
                 } else {
-                    Err(error::Inner::UnexpectedNetworkDescription {
+                    Err(error::Error::UnexpectedNetworkDescription {
                         remote: Box::new(description),
                         local: Box::new(network_description),
-                    }
-                    .into())
+                    })
                 }
             }
-            Err(error) => Err(error::Inner::UnavailableNetworkDescription {
+            Err(error) => Err(error::Error::UnavailableNetworkDescription {
                 address: address.to_string(),
                 error: Box::new(error),
-            }
-            .into()),
+            }),
         }
     }
 
@@ -777,22 +770,20 @@ impl<Env: Environment> ClientContext<Env> {
                     if response.check(*public_key).is_ok() {
                         debug!("Signature for public key {public_key} is OK.");
                     } else {
-                        return Err(error::Inner::InvalidSignature {
+                        return Err(error::Error::InvalidSignature {
                             public_key: *public_key,
-                        }
-                        .into());
+                        });
                     }
                 } else {
                     warn!("Not checking signature as public key was not given");
                 }
                 Ok(*response.info)
             }
-            Err(error) => Err(error::Inner::UnavailableChainInfo {
+            Err(error) => Err(error::Error::UnavailableChainInfo {
                 address: address.to_string(),
                 chain_id,
                 error: Box::new(error),
-            }
-            .into()),
+            }),
         }
     }
 
@@ -893,7 +884,7 @@ impl<Env: Environment> ClientContext<Env> {
                     chain_client
                         .publish_module_blobs(blobs, module_id)
                         .await
-                        .context("Failed to publish module")
+                        .map_err(|error| Error::PublishModule(Box::new(error)))
                 }
             })
             .await?;
@@ -927,7 +918,7 @@ impl<Env: Environment> ClientContext<Env> {
                 chain_client
                     .publish_data_blob(blob_bytes)
                     .await
-                    .context("Failed to publish data blob")
+                    .map_err(|error| Error::PublishDataBlob(Box::new(error)))
             }
         })
         .await?;
@@ -950,7 +941,7 @@ impl<Env: Environment> ClientContext<Env> {
                 chain_client
                     .read_data_blob(hash)
                     .await
-                    .context("Failed to verify data blob")
+                    .map_err(|error| Error::VerifyDataBlob(Box::new(error)))
             }
         })
         .await?;
@@ -1113,7 +1104,7 @@ impl<Env: Environment> ClientContext<Env> {
                         },
                     )
                     .await
-                    .map_err(error::Inner::wallet)?;
+                    .map_err(error::Error::wallet)?;
             }
         }
 
@@ -1126,7 +1117,7 @@ impl<Env: Environment> ClientContext<Env> {
         let chain_clients: Vec<_> = self
             .wallet()
             .owned_chain_ids()
-            .map_err(|e| error::Inner::wallet(e).into())
+            .map_err(error::Error::wallet)
             .and_then(|id| self.make_chain_client(id))
             .try_collect()
             .await
@@ -1185,7 +1176,7 @@ impl<Env: Environment> ClientContext<Env> {
         if !close_chains || wallet_only {
             let mut owned_chain_ids = std::pin::pin!(self.wallet().owned_chain_ids());
             while let Some(chain_id) = owned_chain_ids.next().await {
-                let chain_id = chain_id.map_err(error::Inner::wallet)?;
+                let chain_id = chain_id.map_err(error::Error::wallet)?;
                 if chains_found_in_wallet == num_chains {
                     break;
                 }
@@ -1213,13 +1204,9 @@ impl<Env: Environment> ClientContext<Env> {
 
         if num_chains_to_create > 0 {
             if wallet_only {
-                return Err(
-                    error::Inner::Benchmark(BenchmarkError::NotEnoughChainsInWallet(
-                        num_chains,
-                        chains_found_in_wallet,
-                    ))
-                    .into(),
-                );
+                return Err(error::Error::Benchmark(
+                    BenchmarkError::NotEnoughChainsInWallet(num_chains, chains_found_in_wallet),
+                ));
             }
             let mut pub_keys_iter = pub_keys.into_iter().take(num_chains_to_create);
             let operations_per_block = 900; // Over this we seem to hit the block size limits.
@@ -1283,7 +1270,7 @@ impl<Env: Environment> ClientContext<Env> {
         default_chain_client
             .retry_pending_outgoing_messages()
             .await
-            .context("outgoing messages to create the new chains should be delivered")?;
+            .map_err(|error| Error::DeliverNewChainMessages(Box::new(error)))?;
         info!("Processing default chain inbox");
         default_chain_client.process_inbox().await?;
 

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -11,88 +11,119 @@ use linera_version::VersionInfo;
 use crate::benchmark::BenchmarkError;
 use crate::util;
 
+/// The kinds of error that the client can return.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-pub(crate) enum Inner {
+pub enum Error {
+    /// An I/O operation failed.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+    /// A value could not be BCS-serialized or -deserialized.
     #[error("BCS error: {0}")]
     Bcs(#[from] bcs::Error),
+    /// An operation on a chain failed.
     #[error("chain error: {0}")]
     Chain(#[from] linera_chain::ChainError),
+    /// An operation performed through the chain client failed.
     #[error("chain client error: {0}")]
     ChainClient(#[from] linera_core::client::chain_client::Error),
+    /// The client options were invalid.
     #[error("options error: {0}")]
     Options(#[from] crate::client_options::Error),
+    /// An operation on the wallet backend failed.
     #[error("wallet error: {0}")]
     Wallet(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// An operation on a view failed.
     #[error("view error: {0}")]
     View(#[from] linera_views::ViewError),
+    /// An operation on the local node failed.
     #[error("error on the local node: {0}")]
     LocalNode(#[from] linera_core::LocalNodeError),
+    /// An operation on a remote validator failed.
     #[error("remote node operation failed: {0}")]
     RemoteNode(#[from] linera_core::node::NodeError),
+    /// An arithmetic operation overflowed.
     #[error("arithmetic error: {0}")]
     Arithmetic(#[from] linera_base::data_types::ArithmeticError),
+    /// The chain is not owned by the expected owner.
     #[error("incorrect chain ownership")]
     ChainOwnership,
+    /// A benchmark run failed.
     #[cfg(not(web))]
     #[error("Benchmark error: {0}")]
     Benchmark(#[from] BenchmarkError),
+    /// The new chain could not be assigned to the wallet.
+    #[error("failed to assign the new chain to the wallet: {0}")]
+    AssignChain(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// The chain's ownership could not be changed.
+    #[error("failed to change chain ownership: {0}")]
+    ChangeOwnership(#[source] Box<linera_core::client::chain_client::Error>),
+    /// The module could not be published.
+    #[error("failed to publish the module: {0}")]
+    PublishModule(#[source] Box<linera_core::client::chain_client::Error>),
+    /// The data blob could not be published.
+    #[error("failed to publish the data blob: {0}")]
+    PublishDataBlob(#[source] Box<linera_core::client::chain_client::Error>),
+    /// The data blob could not be read back after publishing.
+    #[error("failed to read back the data blob: {0}")]
+    VerifyDataBlob(#[source] Box<linera_core::client::chain_client::Error>),
+    /// The messages that create the new chains could not be delivered.
+    #[error("failed to deliver the outgoing messages that create the new chains: {0}")]
+    DeliverNewChainMessages(#[source] Box<linera_core::client::chain_client::Error>),
+    /// A validator is running an incompatible version.
     #[error("Validator version {remote} is not compatible with local version {local}.")]
     UnexpectedVersionInfo {
+        /// The validator's version.
         remote: Box<VersionInfo>,
+        /// Our own version.
         local: Box<VersionInfo>,
     },
+    /// A validator's version could not be retrieved.
     #[error("Failed to get version information for validator {address}: {error}")]
     UnavailableVersionInfo {
+        /// The validator's address.
         address: String,
+        /// The underlying failure.
         error: Box<NodeError>,
     },
+    /// A validator disagrees with us about the network.
     #[error("Validator's network description {remote:?} does not match our own: {local:?}.")]
     UnexpectedNetworkDescription {
+        /// The validator's network description.
         remote: Box<NetworkDescription>,
+        /// Our own network description.
         local: Box<NetworkDescription>,
     },
+    /// A validator's network description could not be retrieved.
     #[error("Failed to get network description for validator {address}: {error}")]
     UnavailableNetworkDescription {
+        /// The validator's address.
         address: String,
+        /// The underlying failure.
         error: Box<NodeError>,
     },
+    /// A validator's signature did not verify.
     #[error("Signature for public key {public_key} is invalid.")]
-    InvalidSignature { public_key: ValidatorPublicKey },
+    InvalidSignature {
+        /// The public key the signature was checked against.
+        public_key: ValidatorPublicKey,
+    },
+    /// A validator's information about a chain could not be retrieved.
     #[error("Failed to get chain info for validator {address} and chain {chain_id}: {error}")]
     UnavailableChainInfo {
+        /// The validator's address.
         address: String,
+        /// The chain that was queried.
         chain_id: ChainId,
+        /// The underlying failure.
         error: Box<NodeError>,
     },
 }
 
-impl Inner {
+impl Error {
+    /// Wraps an error from the wallet backend.
     pub fn wallet(error: impl std::error::Error + Send + Sync + 'static) -> Self {
         Self::Wallet(Box::new(error) as _)
-    }
-}
-
-mod context {
-    // `impl_context!` generates a public `Error` newtype (with accessors) that cannot carry
-    // doc comments, so this wrapper module is exempted from the crate's `missing_docs` policy.
-    // `expect` (rather than `allow`) flags this if the macro ever stops generating such items.
-    #![expect(missing_docs)]
-
-    use thiserror_context::Context;
-
-    use super::Inner;
-
-    thiserror_context::impl_context!(Error(Inner));
-}
-
-pub use context::Error;
-
-impl Error {
-    pub(crate) fn wallet(error: impl std::error::Error + Send + Sync + 'static) -> Self {
-        Inner::wallet(error).into()
     }
 }
 

--- a/linera-faucet/client/Cargo.toml
+++ b/linera-faucet/client/Cargo.toml
@@ -23,4 +23,3 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-thiserror-context.workspace = true

--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -17,12 +17,11 @@ use linera_base::{
 use linera_client::config::GenesisConfig;
 use linera_execution::{committee::ValidatorState, Committee, ResourceControlPolicy};
 use linera_version::VersionInfo;
-use thiserror_context::Context;
 
 /// The kinds of error that the faucet client can return.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-pub enum ErrorInner {
+pub enum Error {
     /// A response from the faucet could not be parsed as JSON.
     #[error("JSON parsing error: {0:?}")]
     Json(#[from] serde_json::Error),
@@ -35,21 +34,15 @@ pub enum ErrorInner {
     /// An arithmetic operation overflowed.
     #[error(transparent)]
     ArithmeticError(#[from] ArithmeticError),
-}
-
-pub use error::Error;
-
-mod error {
-    // `impl_context!` generates a public `Error` newtype (with accessors) that cannot carry
-    // doc comments, so this wrapper module is exempted from the crate's `missing_docs` policy.
-    // `expect` (rather than `allow`) flags this if the macro ever stops generating such items.
-    #![expect(missing_docs)]
-
-    use thiserror_context::Context;
-
-    use super::ErrorInner;
-
-    thiserror_context::impl_context!(Error(ErrorInner));
+    /// A GraphQL query could not be sent to the faucet.
+    #[error("failed to execute query {query:?}: {source}")]
+    Query {
+        /// The query that could not be sent.
+        query: String,
+        /// The underlying HTTP failure.
+        #[source]
+        source: reqwest::Error,
+    },
 }
 
 /// The result of a successful claim mutation.
@@ -117,7 +110,10 @@ impl Faucet {
             }))
             .send()
             .await
-            .with_context(|| format!("executing query {query:?}"))?
+            .map_err(|source| Error::Query {
+                query: query.to_string(),
+                source,
+            })?
             .error_for_status()?
             .json()
             .await?;
@@ -135,12 +131,11 @@ impl Faucet {
                 .collect::<Vec<_>>();
 
             if messages.is_empty() {
-                Err(ErrorInner::GraphQl(errors).into())
+                Err(Error::GraphQl(errors))
             } else {
-                Err(
-                    ErrorInner::GraphQl(vec![serde_json::Value::String(messages.join("; "))])
-                        .into(),
-                )
+                Err(Error::GraphQl(vec![serde_json::Value::String(
+                    messages.join("; "),
+                )]))
             }
         } else {
             Ok(response

--- a/linera-persistent/Cargo.toml
+++ b/linera-persistent/Cargo.toml
@@ -30,6 +30,5 @@ derive_more = { workspace = true, features = ["deref", "deref_mut"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-thiserror-context.workspace = true
 tracing.workspace = true
 trait-variant.workspace = true

--- a/linera-persistent/src/file.rs
+++ b/linera-persistent/src/file.rs
@@ -9,66 +9,68 @@ use std::{
 };
 
 use fs4::FileExt;
-use thiserror_context::Context;
 
 use super::Persist;
 
 /// A guard that keeps an exclusive lock on a file.
 struct Lock(fs_err::File);
 
+/// The kinds of error that persisting a value to a file can produce.
 #[derive(Debug, thiserror::Error)]
-enum ErrorInner {
+#[non_exhaustive]
+pub enum Error {
+    /// An I/O operation on the file failed.
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
+    /// The value could not be serialized to, or deserialized from, JSON.
     #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
+    /// The file could not be locked for exclusive access.
+    #[error("failed to lock {}: {source}", path.display())]
+    Lock {
+        /// The path that could not be locked.
+        path: std::path::PathBuf,
+        /// The underlying I/O failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// An operation failed, and so did the cleanup that followed it.
+    #[error("failed to clean up after an error: {cleanup}; the original error was: {original}")]
+    Cleanup {
+        /// The failure of the cleanup step itself.
+        #[source]
+        cleanup: Box<Error>,
+        /// The failure that prompted the cleanup.
+        original: Box<Error>,
+    },
 }
 
-pub use error::Error;
-
-mod error {
-    // `impl_context!` generates a public `Error` newtype (with accessors) that cannot carry
-    // doc comments, so this wrapper module is exempted from the crate's `missing_docs` policy.
-    // `expect` (rather than `allow`) flags this if the macro ever stops generating such items.
-    #![expect(missing_docs)]
-
-    use thiserror_context::Context;
-
-    use super::ErrorInner;
-
-    thiserror_context::impl_context!(Error(ErrorInner));
-}
-
-/// Utility: run a fallible cleanup function if an operation failed, attaching the
-/// original operation as context to its error.
+/// Utility: run a fallible cleanup function if an operation failed, reporting both
+/// failures if the cleanup fails too.
 trait CleanupExt {
+    /// The success type of the operation.
     type Ok;
-    type Error;
 
-    fn or_cleanup<E>(self, f: impl FnOnce() -> Result<(), E>) -> Result<Self::Ok, Self::Error>
-    where
-        E: Into<Self::Error>,
-        Result<(), E>: Context<Self::Error, Self::Ok, E>;
+    /// Runs `cleanup` if the operation failed.
+    fn or_cleanup<E: Into<Error>>(
+        self,
+        cleanup: impl FnOnce() -> Result<(), E>,
+    ) -> Result<Self::Ok, Error>;
 }
 
-impl<T, W> CleanupExt for Result<T, W>
-where
-    W: std::fmt::Display + Send + Sync + 'static,
-{
+impl<T> CleanupExt for Result<T, Error> {
     type Ok = T;
-    type Error = W;
 
-    fn or_cleanup<E>(self, cleanup: impl FnOnce() -> Result<(), E>) -> Self
-    where
-        E: Into<W>,
-        Result<(), E>: Context<W, T, E>,
-    {
-        self.or_else(|error| {
-            if let Err(cleanup_error) = cleanup() {
-                Err(cleanup_error).context(error)
-            } else {
-                Err(error)
-            }
+    fn or_cleanup<E: Into<Error>>(
+        self,
+        cleanup: impl FnOnce() -> Result<(), E>,
+    ) -> Result<T, Error> {
+        self.map_err(|original| match cleanup() {
+            Ok(()) => original,
+            Err(cleanup) => Error::Cleanup {
+                cleanup: Box::new(cleanup.into()),
+                original: Box::new(original),
+            },
         })
     }
 }
@@ -136,7 +138,10 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned> File<T> {
                     .create(true)
                     .open(path)?,
             )
-            .with_context(|| format!("locking path {}", path.display()))?,
+            .map_err(|source| Error::Lock {
+                path: path.into(),
+                source,
+            })?,
             path: path.into(),
             value,
         };


### PR DESCRIPTION
## Motivation

Closes #6735, taking option (b) from the discussion there.

`thiserror_context::impl_context!` generates an error newtype with three defects, reproduced against 0.1.2 in a standalone crate:

```
Display  : client error: chain client error: the signer threw: User rejected
Debug    : Mid(Chain(Thrown("User rejected")))

Caused by:
    0: assigning new chain

source() : None
```

- `source()` is `None`, because the macro emits a bare `impl std::error::Error for $out {}`. Every chain is truncated to one node.
- `Display` silently drops the context string: it routes through `AsRef`, which recurses straight past every `Context` node to the `Base`.
- `Debug` prints the root's *derived* `Debug` rather than its message, and files the context under `Caused by:`, inverting the relationship — context is the outer annotation, not the cause.

So neither formatter gives both the messages and the context, and every `.context()` call in the tree was invisible on the two paths that matter: the CLI (`main` returns `anyhow::Result`; anyhow prints `Display` plus a `source()` walk, and neither carries context) and the wasm boundary (`to_string()`).

The dependency also undercut the goal of #2374, which introduced it: that PR moved off `anyhow` precisely so errors could reach JavaScript properly, and this is what stopped a source chain from surviving the trip.

It is not a load-bearing dependency for anyone else either — 6 reverse dependencies on crates.io, three of which are ours, and upstream has had no commit since 2024-09-29 with two PRs open and unmerged since 2025.

## Proposal

Drop `thiserror-context`. At each of the three sites the private inner enum simply becomes the public `Error`, and the nine context annotations become error variants that say the same thing in `Display`.

**`linera-client`** — `Inner` becomes `Error`; six annotations become six variants: `AssignChain`, `ChangeOwnership`, `PublishModule`, `PublishDataBlob`, `VerifyDataBlob`, `DeliverNewChainMessages`. Each wraps the underlying error as `#[source]`, so the message reads as it used to and the chain is walkable:

```
failed to assign the new chain to the wallet: chain client error: the signer threw: User rejected
```

**`linera-faucet-client`** — `ErrorInner` becomes `Error`; `with_context(|| format!("executing query {query:?}"))` becomes a `Query { query, source }` variant, which keeps the query in the message rather than formatting it into a string that was then discarded.

**`linera-persistent`** — `ErrorInner` becomes `Error`; the `locking path` annotation becomes `Lock { path, source }`, and `CleanupExt::or_cleanup` gets a `Cleanup { cleanup, original }` variant instead of attaching the original error as a context string. `or_cleanup` also loses a layer of generics, since it no longer has to thread the `Context` trait bounds through.

A side benefit: the three enums can now carry doc comments, so the `mod error { #![expect(missing_docs)] … }` wrappers that existed only to placate `#![deny(missing_docs)]` are gone, and every variant is documented.

### Note for reviewers

This is a breaking change to three published crates. `linera_client::Error`, `linera_faucet_client::Error` and `linera_persistent::file::Error` were newtypes wrapping a private inner enum — nominally public, but with a payload nobody outside could name, so effectively opaque. They are now ordinary enums that callers can match on. All three keep `#[non_exhaustive]` (added to `linera-persistent`'s, which lacked it) so that adding variants stays non-breaking.

Anything constructing these errors through `From` or `?` is unaffected. Nothing in the tree used the newtype's `into_inner()`, `AsRef`, `Base` or `Context` API.

## Test Plan

- `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets`, and the test suite via CI.
- The replacement shape was checked against the reproduction above: `Display` now reads `failed to assign the new chain to the wallet: chain client error: the signer threw: User rejected` and `source()` walks two levels, where before the annotation was absent and the chain was empty.

## Release Plan

- These changes follow the usual release cycle.

As with #2374, this is a backwards-incompatible API change for `linera-client` (and now also `linera-faucet-client` and `linera-persistent`), so it should cause a major version bump.

## Links

- Closes #6735.
- #2374 introduced the dependency.
- #6722 dropped its stack-restoration work because of the `source()` defect; that becomes a small follow-up now.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
