### PR TITLE
Backport #6747 to testnet_conway: drop thiserror-context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5140,7 +5140,6 @@ dependencies = [
  "test-log",
  "test-strategy",
  "thiserror 1.0.69",
- "thiserror-context",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5374,7 +5373,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "thiserror-context",
 ]
 
 [[package]]
@@ -5586,7 +5584,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "thiserror-context",
  "tracing",
  "trait-variant",
 ]
@@ -10185,12 +10182,6 @@ checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl 2.0.17",
 ]
-
-[[package]]
-name = "thiserror-context"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4cf778b0694c0adf030668380054b3a382f1e5e6a2e9a0b54bc5e677045bca"
 
 [[package]]
 name = "thiserror-impl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,7 +270,6 @@ test-log = { version = "0.2.15", default-features = false, features = [
 ] }
 test-strategy = "0.3.1"
 thiserror = "1.0.65"
-thiserror-context = "0.1.1"
 tokio = "1.36.0"
 tokio-stream = "0.1.14"
 tokio-test = "0.4.3"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4074,7 +4074,6 @@ dependencies = [
  "serde_yaml 0.8.26",
  "serde_yaml 0.9.34+deprecated",
  "thiserror 1.0.65",
- "thiserror-context",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -6948,12 +6947,6 @@ checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl 2.0.17",
 ]
-
-[[package]]
-name = "thiserror-context"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4cf778b0694c0adf030668380054b3a382f1e5e6a2e9a0b54bc5e677045bca"
 
 [[package]]
 name = "thiserror-impl"

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -4040,7 +4040,6 @@ dependencies = [
  "serde_yaml 0.8.26",
  "serde_yaml 0.9.33",
  "thiserror 1.0.69",
- "thiserror-context",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4137,7 +4136,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "thiserror-context",
 ]
 
 [[package]]
@@ -4158,7 +4156,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "thiserror-context",
  "tracing",
  "trait-variant",
 ]
@@ -7362,12 +7359,6 @@ checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl 2.0.18",
 ]
-
-[[package]]
-name = "thiserror-context"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4cf778b0694c0adf030668380054b3a382f1e5e6a2e9a0b54bc5e677045bca"
 
 [[package]]
 name = "thiserror-impl"

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -67,7 +67,6 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 serde_yaml_08 = { package = "serde_yaml", version = "0.8" }
 thiserror.workspace = true
-thiserror-context.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -108,7 +108,7 @@ pub trait ClientContext {
                 .get(chain_id)
                 .make_sync()
                 .await
-                .map_err(error::Inner::wallet)?
+                .map_err(error::Error::wallet)?
                 .unwrap_or_default();
             Ok(self.client().create_chain_client(
                 chain_id,
@@ -142,7 +142,7 @@ pub trait ClientContextExt: ClientContext {
         use futures::stream::TryStreamExt as _;
         self.wallet()
             .chain_ids()
-            .map_err(|e| error::Inner::wallet(e).into())
+            .map_err(error::Error::wallet)
             .and_then(|chain_id| self.make_chain_client(chain_id))
             .try_collect()
             .await
@@ -331,7 +331,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                 .collect::<Result<BTreeMap<_, _>, _>>()
                 .map_err(
                     |e: <<C::Environment as Environment>::Wallet as Wallet>::Error| {
-                        crate::error::Inner::Wallet(Box::new(e) as _)
+                        crate::error::Error::Wallet(Box::new(e) as _)
                     },
                 )?;
             // If the admin chain is not in the wallet, add it as follow-only since we
@@ -750,7 +750,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                         .wallet()
                         .modify(chain_id, |chain| chain.owner = Some(owner))
                         .await
-                        .map_err(error::Inner::wallet)?;
+                        .map_err(error::Error::wallet)?;
                     // If the chain didn't exist, insert a new entry.
                     if modified.is_none() {
                         let chain_description = context_guard
@@ -771,7 +771,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                                 },
                             )
                             .await
-                            .map_err(error::Inner::wallet)?;
+                            .map_err(error::Error::wallet)?;
                     }
 
                     chains.insert(chain_id, ListeningMode::FullChain);

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -25,7 +25,6 @@ use linera_core::{
 use linera_rpc::node_provider::{NodeOptions, NodeProvider};
 use linera_storage::Storage as _;
 use linera_version::VersionInfo;
-use thiserror_context::Context;
 use tracing::{debug, info, warn};
 #[cfg(not(web))]
 use {
@@ -314,7 +313,7 @@ where
             .map_ok(|(id, _chain)| (id, ListeningMode::FullChain))
             .try_collect()
             .await
-            .map_err(error::Inner::wallet)?;
+            .map_err(error::Error::wallet)?;
         let name = match chain_modes.len() {
             0 => "Client node".to_string(),
             1 => format!("Client node for {:.8}", chain_modes[0].0),
@@ -441,7 +440,7 @@ impl<Env: Environment> ClientContext<Env> {
             .wallet()
             .get(info.chain_id)
             .await
-            .map_err(error::Inner::wallet)?
+            .map_err(error::Error::wallet)?
             .and_then(|chain| chain.owner);
 
         // Only persist proposals that were made in the fast round: they need to be
@@ -460,7 +459,7 @@ impl<Env: Environment> ClientContext<Env> {
                 },
             )
             .await
-            .map_err(error::Inner::wallet)?;
+            .map_err(error::Error::wallet)?;
 
         Ok(())
     }
@@ -479,7 +478,7 @@ impl<Env: Environment> ClientContext<Env> {
                 linera_core::wallet::Chain::new(owner, epoch, timestamp),
             )
             .await
-            .map_err(error::Inner::wallet)?;
+            .map_err(error::Error::wallet)?;
         Ok(())
     }
 
@@ -505,7 +504,7 @@ impl<Env: Environment> ClientContext<Env> {
                 ),
             )
             .await
-            .map_err(error::Inner::wallet)?;
+            .map_err(error::Error::wallet)?;
         self.client
             .extend_chain_mode(chain_id, ListeningMode::FullChain);
         Ok(())
@@ -573,7 +572,7 @@ impl<Env: Environment> ClientContext<Env> {
             .can_propose_in_multi_leader_round(&owner)
         {
             tracing::error!("Chain {chain_id} is not owned by {owner}.");
-            return Err(error::Inner::ChainOwnership.into());
+            return Err(error::Error::ChainOwnership);
         }
 
         // Try to modify existing chain entry, setting the owner.
@@ -581,7 +580,7 @@ impl<Env: Environment> ClientContext<Env> {
             .wallet()
             .modify(chain_id, |chain| chain.owner = Some(owner))
             .await
-            .map_err(error::Inner::wallet)?;
+            .map_err(error::Error::wallet)?;
         // If the chain didn't exist, insert a new entry.
         if modified.is_none() {
             self.wallet()
@@ -595,8 +594,7 @@ impl<Env: Environment> ClientContext<Env> {
                     },
                 )
                 .await
-                .map_err(error::Inner::wallet)
-                .context("assigning new chain")?;
+                .map_err(|error| Error::AssignChain(Box::new(error)))?;
         }
         Ok(())
     }
@@ -673,7 +671,7 @@ impl<Env: Environment> ClientContext<Env> {
 
         if ownership.super_owners.is_empty() && ownership.owners.is_empty() {
             tracing::error!("At least one owner or super owner of the chain has to be set.");
-            return Err(error::Inner::ChainOwnership.into());
+            return Err(error::Error::ChainOwnership);
         }
 
         let certificate = self
@@ -684,8 +682,7 @@ impl<Env: Environment> ClientContext<Env> {
                     chain_client
                         .change_ownership(ownership)
                         .await
-                        .map_err(Error::from)
-                        .context("Failed to change ownership")
+                        .map_err(|error| Error::ChangeOwnership(Box::new(error)))
                 }
             })
             .await?;
@@ -725,16 +722,14 @@ impl<Env: Environment> ClientContext<Env> {
                 );
                 Ok(version_info)
             }
-            Ok(version_info) => Err(error::Inner::UnexpectedVersionInfo {
+            Ok(version_info) => Err(error::Error::UnexpectedVersionInfo {
                 remote: Box::new(version_info),
                 local: Box::new(linera_version::VERSION_INFO.clone()),
-            }
-            .into()),
-            Err(error) => Err(error::Inner::UnavailableVersionInfo {
+            }),
+            Err(error) => Err(error::Error::UnavailableVersionInfo {
                 address: address.to_string(),
                 error: Box::new(error),
-            }
-            .into()),
+            }),
         }
     }
 
@@ -750,18 +745,16 @@ impl<Env: Environment> ClientContext<Env> {
                 if description == network_description {
                     Ok(description.genesis_config_hash)
                 } else {
-                    Err(error::Inner::UnexpectedNetworkDescription {
+                    Err(error::Error::UnexpectedNetworkDescription {
                         remote: Box::new(description),
                         local: Box::new(network_description),
-                    }
-                    .into())
+                    })
                 }
             }
-            Err(error) => Err(error::Inner::UnavailableNetworkDescription {
+            Err(error) => Err(error::Error::UnavailableNetworkDescription {
                 address: address.to_string(),
                 error: Box::new(error),
-            }
-            .into()),
+            }),
         }
     }
 
@@ -784,22 +777,20 @@ impl<Env: Environment> ClientContext<Env> {
                     if response.check(*public_key).is_ok() {
                         debug!("Signature for public key {public_key} is OK.");
                     } else {
-                        return Err(error::Inner::InvalidSignature {
+                        return Err(error::Error::InvalidSignature {
                             public_key: *public_key,
-                        }
-                        .into());
+                        });
                     }
                 } else {
                     warn!("Not checking signature as public key was not given");
                 }
                 Ok(*response.info)
             }
-            Err(error) => Err(error::Inner::UnavailableChainInfo {
+            Err(error) => Err(error::Error::UnavailableChainInfo {
                 address: address.to_string(),
                 chain_id,
                 error: Box::new(error),
-            }
-            .into()),
+            }),
         }
     }
 
@@ -875,7 +866,7 @@ impl<Env: Environment> ClientContext<Env> {
                     chain_client
                         .publish_module_blobs(blobs, module_id)
                         .await
-                        .context("Failed to publish module")
+                        .map_err(|error| Error::PublishModule(Box::new(error)))
                 }
             })
             .await?;
@@ -909,7 +900,7 @@ impl<Env: Environment> ClientContext<Env> {
                 chain_client
                     .publish_data_blob(blob_bytes)
                     .await
-                    .context("Failed to publish data blob")
+                    .map_err(|error| Error::PublishDataBlob(Box::new(error)))
             }
         })
         .await?;
@@ -932,7 +923,7 @@ impl<Env: Environment> ClientContext<Env> {
                 chain_client
                     .read_data_blob(hash)
                     .await
-                    .context("Failed to verify data blob")
+                    .map_err(|error| Error::VerifyDataBlob(Box::new(error)))
             }
         })
         .await?;
@@ -958,7 +949,7 @@ impl<Env: Environment> ClientContext<Env> {
     ) -> Result<ModuleId, Error> {
         let owner = chain_client
             .preferred_owner()
-            .ok_or(error::Inner::ChainOwnership)?;
+            .ok_or(error::Error::ChainOwnership)?;
         let (blobs, formats_blob_bytes, module_id, registry_op_bytes) = self
             .prepare_bcs_publication(owner, &contract, &service, vm_runtime, &formats)
             .await?;
@@ -973,7 +964,7 @@ impl<Env: Environment> ClientContext<Env> {
                 chain_client
                     .publish_data_blob(formats_blob_bytes)
                     .await
-                    .context("Failed to publish the formats data blob")
+                    .map_err(|error| Error::PublishFormatsBlob(Box::new(error)))
             }
         })
         .await?;
@@ -996,7 +987,7 @@ impl<Env: Environment> ClientContext<Env> {
                         blobs,
                     )
                     .await
-                    .context("Failed to publish module and register formats")
+                    .map_err(|error| Error::PublishModuleAndRegisterFormats(Box::new(error)))
             }
         })
         .await?;
@@ -1028,7 +1019,7 @@ impl<Env: Environment> ClientContext<Env> {
     ) -> Result<(ApplicationId, ModuleId), Error> {
         let owner = chain_client
             .preferred_owner()
-            .ok_or(error::Inner::ChainOwnership)?;
+            .ok_or(error::Error::ChainOwnership)?;
         let (blobs, formats_blob_bytes, module_id, registry_op_bytes) = self
             .prepare_bcs_publication(owner, &contract, &service, vm_runtime, &formats)
             .await?;
@@ -1043,7 +1034,7 @@ impl<Env: Environment> ClientContext<Env> {
                 chain_client
                     .publish_data_blob(formats_blob_bytes)
                     .await
-                    .context("Failed to publish the formats data blob")
+                    .map_err(|error| Error::PublishFormatsBlob(Box::new(error)))
             }
         })
         .await?;
@@ -1352,7 +1343,7 @@ impl<Env: Environment> ClientContext<Env> {
                         },
                     )
                     .await
-                    .map_err(error::Inner::wallet)?;
+                    .map_err(error::Error::wallet)?;
             }
         }
 
@@ -1365,7 +1356,7 @@ impl<Env: Environment> ClientContext<Env> {
         let chain_clients: Vec<_> = self
             .wallet()
             .owned_chain_ids()
-            .map_err(|e| error::Inner::wallet(e).into())
+            .map_err(error::Error::wallet)
             .and_then(|id| self.make_chain_client(id))
             .try_collect()
             .await
@@ -1424,7 +1415,7 @@ impl<Env: Environment> ClientContext<Env> {
         if !close_chains || wallet_only {
             let mut owned_chain_ids = std::pin::pin!(self.wallet().owned_chain_ids());
             while let Some(chain_id) = owned_chain_ids.next().await {
-                let chain_id = chain_id.map_err(error::Inner::wallet)?;
+                let chain_id = chain_id.map_err(error::Error::wallet)?;
                 if chains_found_in_wallet == num_chains {
                     break;
                 }
@@ -1452,13 +1443,9 @@ impl<Env: Environment> ClientContext<Env> {
 
         if num_chains_to_create > 0 {
             if wallet_only {
-                return Err(
-                    error::Inner::Benchmark(BenchmarkError::NotEnoughChainsInWallet(
-                        num_chains,
-                        chains_found_in_wallet,
-                    ))
-                    .into(),
-                );
+                return Err(error::Error::Benchmark(
+                    BenchmarkError::NotEnoughChainsInWallet(num_chains, chains_found_in_wallet),
+                ));
             }
             let mut pub_keys_iter = pub_keys.into_iter().take(num_chains_to_create);
             let operations_per_block = 900; // Over this we seem to hit the block size limits.
@@ -1521,7 +1508,7 @@ impl<Env: Environment> ClientContext<Env> {
         default_chain_client
             .retry_pending_outgoing_messages()
             .await
-            .context("outgoing messages to create the new chains should be delivered")?;
+            .map_err(|error| Error::DeliverNewChainMessages(Box::new(error)))?;
         info!("Processing default chain inbox");
         default_chain_client.process_inbox().await?;
 

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -11,88 +11,125 @@ use linera_version::VersionInfo;
 use crate::benchmark::BenchmarkError;
 use crate::util;
 
+/// The kinds of error that the client can return.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-pub(crate) enum Inner {
+pub enum Error {
+    /// An I/O operation failed.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+    /// A value could not be BCS-serialized or -deserialized.
     #[error("BCS error: {0}")]
     Bcs(#[from] bcs::Error),
+    /// An operation on a chain failed.
     #[error("chain error: {0}")]
     Chain(#[from] linera_chain::ChainError),
+    /// An operation performed through the chain client failed.
     #[error("chain client error: {0}")]
     ChainClient(#[from] linera_core::client::chain_client::Error),
+    /// The client options were invalid.
     #[error("options error: {0}")]
     Options(#[from] crate::client_options::Error),
+    /// An operation on the wallet backend failed.
     #[error("wallet error: {0}")]
     Wallet(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// An operation on a view failed.
     #[error("view error: {0}")]
     View(#[from] linera_views::ViewError),
+    /// An operation on the local node failed.
     #[error("error on the local node: {0}")]
     LocalNode(#[from] linera_core::LocalNodeError),
+    /// An operation on a remote validator failed.
     #[error("remote node operation failed: {0}")]
     RemoteNode(#[from] linera_core::node::NodeError),
+    /// An arithmetic operation overflowed.
     #[error("arithmetic error: {0}")]
     Arithmetic(#[from] linera_base::data_types::ArithmeticError),
+    /// The chain is not owned by the expected owner.
     #[error("incorrect chain ownership")]
     ChainOwnership,
+    /// A benchmark run failed.
     #[cfg(not(web))]
     #[error("Benchmark error: {0}")]
     Benchmark(#[from] BenchmarkError),
+    /// The new chain could not be assigned to the wallet.
+    #[error("failed to assign the new chain to the wallet: {0}")]
+    AssignChain(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// The chain's ownership could not be changed.
+    #[error("failed to change chain ownership: {0}")]
+    ChangeOwnership(#[source] Box<linera_core::client::chain_client::Error>),
+    /// The module could not be published.
+    #[error("failed to publish the module: {0}")]
+    PublishModule(#[source] Box<linera_core::client::chain_client::Error>),
+    /// The data blob could not be published.
+    #[error("failed to publish the data blob: {0}")]
+    PublishDataBlob(#[source] Box<linera_core::client::chain_client::Error>),
+    /// The data blob could not be read back after publishing.
+    #[error("failed to read back the data blob: {0}")]
+    VerifyDataBlob(#[source] Box<linera_core::client::chain_client::Error>),
+    /// The formats data blob could not be published.
+    #[error("failed to publish the formats data blob: {0}")]
+    PublishFormatsBlob(#[source] Box<linera_core::client::chain_client::Error>),
+    /// The module could not be published together with its format registration.
+    #[error("failed to publish the module and register its formats: {0}")]
+    PublishModuleAndRegisterFormats(#[source] Box<linera_core::client::chain_client::Error>),
+    /// The messages that create the new chains could not be delivered.
+    #[error("failed to deliver the outgoing messages that create the new chains: {0}")]
+    DeliverNewChainMessages(#[source] Box<linera_core::client::chain_client::Error>),
+    /// A validator is running an incompatible version.
     #[error("Validator version {remote} is not compatible with local version {local}.")]
     UnexpectedVersionInfo {
+        /// The validator's version.
         remote: Box<VersionInfo>,
+        /// Our own version.
         local: Box<VersionInfo>,
     },
+    /// A validator's version could not be retrieved.
     #[error("Failed to get version information for validator {address}: {error}")]
     UnavailableVersionInfo {
+        /// The validator's address.
         address: String,
+        /// The underlying failure.
         error: Box<NodeError>,
     },
+    /// A validator disagrees with us about the network.
     #[error("Validator's network description {remote:?} does not match our own: {local:?}.")]
     UnexpectedNetworkDescription {
+        /// The validator's network description.
         remote: Box<NetworkDescription>,
+        /// Our own network description.
         local: Box<NetworkDescription>,
     },
+    /// A validator's network description could not be retrieved.
     #[error("Failed to get network description for validator {address}: {error}")]
     UnavailableNetworkDescription {
+        /// The validator's address.
         address: String,
+        /// The underlying failure.
         error: Box<NodeError>,
     },
+    /// A validator's signature did not verify.
     #[error("Signature for public key {public_key} is invalid.")]
-    InvalidSignature { public_key: ValidatorPublicKey },
+    InvalidSignature {
+        /// The public key the signature was checked against.
+        public_key: ValidatorPublicKey,
+    },
+    /// A validator's information about a chain could not be retrieved.
     #[error("Failed to get chain info for validator {address} and chain {chain_id}: {error}")]
     UnavailableChainInfo {
+        /// The validator's address.
         address: String,
+        /// The chain that was queried.
         chain_id: ChainId,
+        /// The underlying failure.
         error: Box<NodeError>,
     },
 }
 
-impl Inner {
+impl Error {
+    /// Wraps an error from the wallet backend.
     pub fn wallet(error: impl std::error::Error + Send + Sync + 'static) -> Self {
         Self::Wallet(Box::new(error) as _)
-    }
-}
-
-mod context {
-    // `impl_context!` generates a public `Error` newtype (with accessors) that cannot carry
-    // doc comments, so this wrapper module is exempted from the crate's `missing_docs` policy.
-    // `expect` (rather than `allow`) flags this if the macro ever stops generating such items.
-    #![expect(missing_docs)]
-
-    use thiserror_context::Context;
-
-    use super::Inner;
-
-    thiserror_context::impl_context!(Error(Inner));
-}
-
-pub use context::Error;
-
-impl Error {
-    pub(crate) fn wallet(error: impl std::error::Error + Send + Sync + 'static) -> Self {
-        Inner::wallet(error).into()
     }
 }
 

--- a/linera-faucet/client/Cargo.toml
+++ b/linera-faucet/client/Cargo.toml
@@ -23,4 +23,3 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-thiserror-context.workspace = true

--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -17,12 +17,11 @@ use linera_base::{
 use linera_client::config::GenesisConfig;
 use linera_execution::{committee::ValidatorState, Committee, ResourceControlPolicy};
 use linera_version::VersionInfo;
-use thiserror_context::Context;
 
 /// The kinds of error that the faucet client can return.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-pub enum ErrorInner {
+pub enum Error {
     /// A response from the faucet could not be parsed as JSON.
     #[error("JSON parsing error: {0:?}")]
     Json(#[from] serde_json::Error),
@@ -32,21 +31,15 @@ pub enum ErrorInner {
     /// An HTTP request to the faucet failed.
     #[error("HTTP error: {0:?}")]
     Http(#[from] reqwest::Error),
-}
-
-pub use error::Error;
-
-mod error {
-    // `impl_context!` generates a public `Error` newtype (with accessors) that cannot carry
-    // doc comments, so this wrapper module is exempted from the crate's `missing_docs` policy.
-    // `expect` (rather than `allow`) flags this if the macro ever stops generating such items.
-    #![expect(missing_docs)]
-
-    use thiserror_context::Context;
-
-    use super::ErrorInner;
-
-    thiserror_context::impl_context!(Error(ErrorInner));
+    /// A GraphQL query could not be sent to the faucet.
+    #[error("failed to execute query {query:?}: {source}")]
+    Query {
+        /// The query that could not be sent.
+        query: String,
+        /// The underlying HTTP failure.
+        #[source]
+        source: reqwest::Error,
+    },
 }
 
 /// The result of a successful claim mutation.
@@ -114,13 +107,16 @@ impl Faucet {
             }))
             .send()
             .await
-            .with_context(|| format!("executing query {query:?}"))?
+            .map_err(|source| Error::Query {
+                query: query.to_string(),
+                source,
+            })?
             .error_for_status()?
             .json()
             .await?;
 
         if let Some(errors) = response.errors {
-            Err(ErrorInner::GraphQl(errors).into())
+            Err(Error::GraphQl(errors))
         } else {
             Ok(response
                 .data

--- a/linera-persistent/Cargo.toml
+++ b/linera-persistent/Cargo.toml
@@ -30,6 +30,5 @@ derive_more = { workspace = true, features = ["deref", "deref_mut"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-thiserror-context.workspace = true
 tracing.workspace = true
 trait-variant.workspace = true

--- a/linera-persistent/src/file.rs
+++ b/linera-persistent/src/file.rs
@@ -9,66 +9,68 @@ use std::{
 };
 
 use fs4::FileExt;
-use thiserror_context::Context;
 
 use super::Persist;
 
 /// A guard that keeps an exclusive lock on a file.
 struct Lock(fs_err::File);
 
+/// The kinds of error that persisting a value to a file can produce.
 #[derive(Debug, thiserror::Error)]
-enum ErrorInner {
+#[non_exhaustive]
+pub enum Error {
+    /// An I/O operation on the file failed.
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
+    /// The value could not be serialized to, or deserialized from, JSON.
     #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
+    /// The file could not be locked for exclusive access.
+    #[error("failed to lock {}: {source}", path.display())]
+    Lock {
+        /// The path that could not be locked.
+        path: std::path::PathBuf,
+        /// The underlying I/O failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// An operation failed, and so did the cleanup that followed it.
+    #[error("failed to clean up after an error: {cleanup}; the original error was: {original}")]
+    Cleanup {
+        /// The failure of the cleanup step itself.
+        #[source]
+        cleanup: Box<Error>,
+        /// The failure that prompted the cleanup.
+        original: Box<Error>,
+    },
 }
 
-pub use error::Error;
-
-mod error {
-    // `impl_context!` generates a public `Error` newtype (with accessors) that cannot carry
-    // doc comments, so this wrapper module is exempted from the crate's `missing_docs` policy.
-    // `expect` (rather than `allow`) flags this if the macro ever stops generating such items.
-    #![expect(missing_docs)]
-
-    use thiserror_context::Context;
-
-    use super::ErrorInner;
-
-    thiserror_context::impl_context!(Error(ErrorInner));
-}
-
-/// Utility: run a fallible cleanup function if an operation failed, attaching the
-/// original operation as context to its error.
+/// Utility: run a fallible cleanup function if an operation failed, reporting both
+/// failures if the cleanup fails too.
 trait CleanupExt {
+    /// The success type of the operation.
     type Ok;
-    type Error;
 
-    fn or_cleanup<E>(self, f: impl FnOnce() -> Result<(), E>) -> Result<Self::Ok, Self::Error>
-    where
-        E: Into<Self::Error>,
-        Result<(), E>: Context<Self::Error, Self::Ok, E>;
+    /// Runs `cleanup` if the operation failed.
+    fn or_cleanup<E: Into<Error>>(
+        self,
+        cleanup: impl FnOnce() -> Result<(), E>,
+    ) -> Result<Self::Ok, Error>;
 }
 
-impl<T, W> CleanupExt for Result<T, W>
-where
-    W: std::fmt::Display + Send + Sync + 'static,
-{
+impl<T> CleanupExt for Result<T, Error> {
     type Ok = T;
-    type Error = W;
 
-    fn or_cleanup<E>(self, cleanup: impl FnOnce() -> Result<(), E>) -> Self
-    where
-        E: Into<W>,
-        Result<(), E>: Context<W, T, E>,
-    {
-        self.or_else(|error| {
-            if let Err(cleanup_error) = cleanup() {
-                Err(cleanup_error).context(error)
-            } else {
-                Err(error)
-            }
+    fn or_cleanup<E: Into<Error>>(
+        self,
+        cleanup: impl FnOnce() -> Result<(), E>,
+    ) -> Result<T, Error> {
+        self.map_err(|original| match cleanup() {
+            Ok(()) => original,
+            Err(cleanup) => Error::Cleanup {
+                cleanup: Box::new(cleanup.into()),
+                original: Box::new(original),
+            },
         })
     }
 }
@@ -136,7 +138,10 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned> File<T> {
                     .create(true)
                     .open(path)?,
             )
-            .with_context(|| format!("locking path {}", path.display()))?,
+            .map_err(|source| Error::Lock {
+                path: path.into(),
+                source,
+            })?,
             path: path.into(),
             value,
         };


### PR DESCRIPTION
## Motivation

Backport of #6747 to `testnet_conway`. Closes #6735 on this branch.

`thiserror_context::impl_context!` generates an error newtype with three defects, reproduced against 0.1.2 in a standalone crate:

```
Display  : client error: chain client error: the signer threw: User rejected
Debug    : Mid(Chain(Thrown("User rejected")))

Caused by:
    0: assigning new chain

source() : None
```

- `source()` is `None`, because the macro emits a bare `impl std::error::Error for $out {}`. Every chain is truncated to one node.
- `Display` silently drops the context string: it routes through `AsRef`, which recurses straight past every `Context` node to the `Base`.
- `Debug` prints the root's *derived* `Debug` rather than its message, and files the context under `Caused by:`, inverting the relationship — context is the outer annotation, not the cause.

So neither formatter gives both the messages and the context, and every `.context()` call was invisible on the two paths that matter: the CLI (`main` returns `anyhow::Result`; anyhow prints `Display` plus a `source()` walk, and neither carries context) and the wasm boundary (`to_string()`).

Upstream is dormant — no commit since 2024-09-29, two PRs open and unmerged since 2025 — and the crate has 6 reverse dependencies on crates.io, three of which are ours.

## Proposal

Drop `thiserror-context`. At each of the three sites the private inner enum becomes the public `Error`, and every context annotation becomes an error variant that says the same thing in `Display`:

```
failed to assign the new chain to the wallet: chain client error: the signer threw: User rejected
```

**`linera-client`** — `Inner` becomes `Error`; eight annotations become `AssignChain`, `ChangeOwnership`, `PublishModule`, `PublishDataBlob`, `VerifyDataBlob`, `PublishFormatsBlob`, `PublishModuleAndRegisterFormats`, `DeliverNewChainMessages`.

**`linera-faucet-client`** — `ErrorInner` becomes `Error`; `with_context(|| format!("executing query {query:?}"))` becomes a `Query { query, source }` variant, keeping the query in the message rather than formatting it into a string that was then discarded.

**`linera-persistent`** — `ErrorInner` becomes `Error`; the `locking path` annotation becomes `Lock { path, source }`, and `CleanupExt::or_cleanup` gets a `Cleanup { cleanup, original }` variant instead of attaching the original error as a context string. `or_cleanup` also sheds a layer of generics.

A side benefit: the three enums can now carry doc comments, so the `mod error { #![expect(missing_docs)] … }` wrappers that existed only to placate `#![deny(missing_docs)]` are gone, and every variant is documented.

### How this differs from #6747

Re-applied against this branch rather than cherry-picked: `git cherry-pick` conflicted in `chain_listener.rs` in a way that would have pulled in main-only code this branch does not have (`owners_with_key`, `unique_owner_with_key`, `maybe_auto_assign_preferred_owner`).

Three real divergences:

- This branch has **twelve** context sites, not nine. The three extra are the formats-registry paths, so it needs two variants `main` does not: `PublishFormatsBlob` (two call sites) and `PublishModuleAndRegisterFormats`.
- This branch's faucet-client enum has no `ArithmeticError` variant, so the `Query` variant is placed after `Http` instead.
- This branch has a **third** lockfile referencing the crate — `examples/Cargo.lock` — which `main` does not. All three are refreshed, each diff limited to the removed entries.

`linera-persistent/src/file.rs` was byte-identical to `main`, so it is the same change there.

### Note for reviewers

This is a breaking change to three published crates. `linera_client::Error`, `linera_faucet_client::Error` and `linera_persistent::file::Error` were newtypes wrapping a private inner enum — nominally public, but with a payload nobody outside could name, so effectively opaque. They are now ordinary enums that callers can match on. All three keep `#[non_exhaustive]` (added to `linera-persistent`'s, which lacked it). Nothing in the tree used the newtype's `into_inner()`, `AsRef`, `Base` or `Context` API.

## Test Plan

This branch's own CI lint set, run locally, all clean:

```
cargo clippy --locked --all-targets --all-features --workspace --exclude linera-web
cargo clippy --locked --no-default-features
cargo clippy --locked --target wasm32-unknown-unknown --no-default-features --features web-default \
  -p linera-client -p linera-rpc -p linera-views
cargo fmt -- --check          # on this branch's pinned nightly
```

Plus `cargo check --locked --all-targets` in `linera-bridge/tests/e2e`, the separate workspace whose lockfile also had to be refreshed.

The three `linera-client` test warnings clippy reports (`unused import: Reason` and friends in `unit_tests/chain_listener.rs`) are present on this branch without these changes too — confirmed by re-running against the pristine tree.

## Release Plan

- These changes should be backported to the latest `testnet` branch — this is that backport.

Breaking API change for `linera-client`, `linera-faucet-client` and `linera-persistent`.

## Links

- #6747 — the same change on `main`.
- Closes #6735.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
