### PR TITLE
Export the four label-less server metrics that never emitted a series

### DIFF
--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -52,10 +52,10 @@ type NotificationSender = tokio::sync::broadcast::Sender<Notification>;
 #[cfg(with_metrics)]
 pub(crate) mod metrics {
     use linera_base::prometheus_util::{
-        exponential_bucket_interval, linear_bucket_interval, register_histogram_vec,
-        register_int_counter_vec,
+        exponential_bucket_interval, linear_bucket_interval, register_histogram,
+        register_histogram_vec, register_int_counter, register_int_counter_vec,
     };
-    use prometheus::{HistogramVec, IntCounterVec};
+    use prometheus::{Histogram, HistogramVec, IntCounter, IntCounterVec};
 
     use super::super::{ERROR_TYPE_LABEL, METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL};
 
@@ -96,32 +96,28 @@ pub(crate) mod metrics {
                 &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
             );
 
-        pub static CROSS_CHAIN_MESSAGE_CHANNEL_FULL: IntCounterVec =
-            register_int_counter_vec(
+        pub static CROSS_CHAIN_MESSAGE_CHANNEL_FULL: IntCounter =
+            register_int_counter(
                 "cross_chain_message_channel_full",
                 "Cross-chain message channel full",
-                &[],
             );
 
-        pub static NOTIFICATIONS_SKIPPED_RECEIVER_LAG: IntCounterVec =
-            register_int_counter_vec(
+        pub static NOTIFICATIONS_SKIPPED_RECEIVER_LAG: IntCounter =
+            register_int_counter(
                 "notifications_skipped_receiver_lag",
                 "Number of notifications skipped because receiver lagged behind sender",
-                &[],
             );
 
-        pub static NOTIFICATIONS_DROPPED_NO_RECEIVER: IntCounterVec =
-            register_int_counter_vec(
+        pub static NOTIFICATIONS_DROPPED_NO_RECEIVER: IntCounter =
+            register_int_counter(
                 "notifications_dropped_no_receiver",
                 "Number of notifications dropped because no receiver was available",
-                &[],
             );
 
-        pub static NOTIFICATION_BATCH_SIZE: HistogramVec =
-            register_histogram_vec(
+        pub static NOTIFICATION_BATCH_SIZE: Histogram =
+            register_histogram(
                 "notification_batch_size",
                 "Number of notifications per batch sent to proxy",
-                &[],
                 exponential_bucket_interval(1.0, 250.0),
             );
 
@@ -153,9 +149,7 @@ impl BatchForwarder {
             let batch: Vec<Notification> = self.pending_notifications.drain(..chunk_size).collect();
 
             #[cfg(with_metrics)]
-            metrics::NOTIFICATION_BATCH_SIZE
-                .with_label_values(&[])
-                .observe(batch.len() as f64);
+            metrics::NOTIFICATION_BATCH_SIZE.observe(batch.len() as f64);
 
             let client = self.client.clone();
             let exporter_clients = self.exporter_clients.clone();
@@ -574,7 +568,6 @@ where
                             );
                             #[cfg(with_metrics)]
                             metrics::NOTIFICATIONS_SKIPPED_RECEIVER_LAG
-                                .with_label_values(&[])
                                 .inc_by(skipped_count);
                         }
                         Err(RecvError::Closed) => {
@@ -618,9 +611,7 @@ where
                 error!(%error, "dropping cross-chain request");
                 #[cfg(with_metrics)]
                 if error.is_full() {
-                    metrics::CROSS_CHAIN_MESSAGE_CHANNEL_FULL
-                        .with_label_values(&[])
-                        .inc();
+                    metrics::CROSS_CHAIN_MESSAGE_CHANNEL_FULL.inc();
                 }
             }
         }
@@ -630,9 +621,7 @@ where
             if let Err(error) = notification_sender.send(notification) {
                 error!(%error, "dropping notification");
                 #[cfg(with_metrics)]
-                metrics::NOTIFICATIONS_DROPPED_NO_RECEIVER
-                    .with_label_values(&[])
-                    .inc();
+                metrics::NOTIFICATIONS_DROPPED_NO_RECEIVER.inc();
             }
         }
     }


### PR DESCRIPTION
## Motivation

Four metrics on the shard/proxy server have **never produced a single sample**, on any network,
since they were added. Confirmed against Mimir: `count by (validator) ({__name__=~"cross_chain_message_channel_full.*"})`
returns nothing — not zero, *nothing* — for testnet-conway and for every benchmark network.

They are declared as `*Vec` types with an empty label set:

```rust
pub static CROSS_CHAIN_MESSAGE_CHANNEL_FULL: IntCounterVec =
    register_int_counter_vec("cross_chain_message_channel_full", "...", &[]);
```

`init_metrics()` forces the `LazyLock`, which registers the metric *family*, but a Prometheus
`MetricVec` only exports children created via `with_label_values`. With no labels there is exactly
one possible child and it is not created until the first `.inc()`. So the series appears only
**after the event fires** — and until then, absence is indistinguishable from zero.

That is the worst possible failure mode for these four, because all of them count things that are
supposed to be rare:

| metric | counts |
|---|---|
| `cross_chain_message_channel_full` | a cross-chain request **dropped** because the queue was full |
| `notifications_skipped_receiver_lag` | notifications skipped when a receiver lagged |
| `notifications_dropped_no_receiver` | notifications dropped with no receiver |
| `notification_batch_size` | batch size histogram |

An alert or dashboard on any of them silently never fires, and a reader seeing no series
reasonably concludes "not instrumented" rather than "healthy".

This bit us concretely. Investigating the `bench-2026-08-19` throughput ceiling, cross-chain
traffic turned out to be **98.7% of all in-flight work at the shards** (29,118 of 29,492 requests,
by `method_name`) and the slowest method by mean latency (809 ms vs ~320 ms for client-facing
methods). The obvious next question — did the cross-chain queue overflow and drop messages? —
could not be answered from metrics at all. It had to be answered from Loki, by counting the
`dropping cross-chain request` log line: **0 matches in 4,553,886 lines** over the peak hour.
That is a good answer, but it should not have required a log search.

## Proposal

Use the non-`Vec` types for metrics that have no labels — `IntCounter` and `Histogram`, via the
existing `register_int_counter` / `register_histogram` helpers in `linera-base::prometheus_util`.
These are their own child, so `init_metrics()` alone is enough to export them, and they read `0`
from process start.

The four `.with_label_values(&[])` hops at the call sites go away with them, which is the whole
rest of the diff: 14 insertions, 25 deletions.

No behaviour change beyond the metrics becoming visible.

## Test Plan

`cargo clippy -p linera-rpc --all-targets --features metrics` and `cargo fmt --check` clean.

The change is type-level: `IntCounterVec` → `IntCounter` and `HistogramVec` → `Histogram` will not
compile if any call site still passes labels, and all four were updated. Grep confirms zero
remaining `with_label_values(&[])` in the file.

The observable effect — a `0` sample present from startup rather than no series — needs a running
validator to confirm, and I have deliberately not claimed it verified. It is checkable on the next
deployed network with the same query that found the gap:

```
count by (validator) ({__name__=~"cross_chain_message_channel_full.*"})
```

Expect one series per shard reading 0, where today it returns nothing.

## Release Plan

- Nothing to do / These changes follow the usual deployment cycle.

Worth having in the image used for the next benchmark round: cross-chain is currently the prime
suspect for the throughput ceiling, and this is the queue that path runs through.

## Links

Arose from the `bench-2026-08-19` benchmark analysis. Same file as #6745.
