### PR TITLE
Give every block-export test a ScyllaDB case so scylladb alone compiles

### DIFF
--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -165,6 +165,7 @@ async fn test_block_export_through_the_proxy(database: Database, network: Networ
 /// is replayed. Catch-up is bounded per round, so this asserts convergence, not one-shot.
 #[ignore]
 #[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(Database::ScyllaDb, Network::Grpc ; "scylladb_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_export_catches_up_a_newly_added_validator(
     database: Database,
@@ -279,6 +280,7 @@ async fn test_export_catches_up_a_newly_added_validator(
 /// proxy strands every destination assigned to it — silently, since the chain still looks healthy.
 #[ignore]
 #[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(Database::ScyllaDb, Network::Grpc ; "scylladb_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_export_survives_a_dead_proxy(database: Database, network: Network) -> Result<()> {
     let _guard: tokio::sync::MutexGuard<'_, ()> = INTEGRATION_TEST_GUARD.lock().await;
@@ -362,6 +364,7 @@ async fn test_export_survives_a_dead_proxy(database: Database, network: Network)
 /// the refusal directly rather than inferring it from export working.
 #[ignore]
 #[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(Database::ScyllaDb, Network::Grpc ; "scylladb_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_relay_refuses_a_non_committee_destination(
     database: Database,
@@ -418,6 +421,7 @@ async fn test_relay_refuses_a_non_committee_destination(
 /// trade-off: shards hold the validator secret key, so direct means giving them outbound access.
 #[ignore]
 #[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(Database::ScyllaDb, Network::Grpc ; "scylladb_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_block_export_direct_bypasses_the_proxy(
     database: Database,


### PR DESCRIPTION
## Motivation

`main` is red. Since 2a0952d26e8 (#6726) the `Lint check all features` workflow fails in partition
5, and it has stayed red through #6745 and #6750:

```
error: functions used as tests can not have any arguments
  --> linera-service/tests/block_export_tests.rs:168:1
  = note: this error originates in the attribute macro `test_log::test`
... 4 errors, then:
process didn't exit successfully: cargo check --all-targets \
  --manifest-path linera-service/Cargo.toml --no-default-features --features scylladb
```

`block_export_tests.rs` is gated `#![cfg(any(feature = "scylladb", feature = "storage-service"))]`,
so the file is compiled when only `scylladb` is on — but four of its five tests carried a
`storage-service` `test_case` and no `scylladb` one. With `scylladb` alone nothing expands, and
`test_log::test` is left applied to a bare `async fn f(database: Database, network: Network)`.
`test_block_export_through_the_proxy` already had both cases, which is why it is the one test that
does not error.

Only `cargo hack --each-feature` reaches that combination. `linera-service` has
`default = ["wasmer", "rocksdb", "storage-service"]`, so `storage-service` is only absent under
`--no-default-features`; the `ScyllaDB tests` workflow runs `cargo test --features scylladb` with
defaults on and passed on 2a0952d26e8.

## Proposal

Give the four tests the `scylladb` case their siblings have. `local_net_tests.rs` and
`exporter_tests.rs` sit behind the same file-level gate and pair both `cfg_attr` variants on every
test; that pairing is what keeps those files compiling under either feature alone.

No CI time is added: all five tests are `#[ignore]`, and the `ScyllaDB tests` workflow does not pass
`--ignored`.

## Test Plan

The exact command from the failing job, on the same toolchain CI uses
(`nightly-2026-05-11`, `rustc 1.97.0-nightly (4b0c9d76a 2026-05-10)`):

```
$ ln -sf toolchains/nightly/rust-toolchain.toml
$ cargo check --all-targets --manifest-path linera-service/Cargo.toml \
    --no-default-features --features scylladb
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9m 37s
```

Zero errors, and no warnings from workspace crates (the only warning is the pre-existing
`proc-macro-error2` future-incompatibility note, which the passing partitions emit too).
`cargo fmt -- --check` is clean.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6726 — added the tests
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

Worth a separate issue: `check-all-features-partition` is declared
`if: github.event_name != 'pull_request'`, and its aggregator passes on `skipped`, so on #6726 the
matrix was skipped while `lint-check-all-features` reported success. With no merge queue in use,
this check only ever runs after a merge — every `cargo hack` regression lands on `main` first.
