### PR TITLE
Leave the generated Solidity untouched when forge fmt cannot run

### DIFF
--- a/linera-bridge/build.rs
+++ b/linera-bridge/build.rs
@@ -8,38 +8,66 @@ fn main() {
 
 #[cfg(feature = "codegen")]
 mod codegen {
-    use std::{collections::BTreeMap, path::PathBuf, process::Command};
+    use std::{collections::BTreeMap, fs, path::PathBuf, process::Command};
 
     use serde_generate::{solidity, CodeGeneratorConfig, SourceInstaller};
     use serde_reflection::Registry;
 
     pub fn generate() {
+        let generated = [
+            PathBuf::from("src/solidity/BridgeTypes.sol"),
+            PathBuf::from("src/solidity/WrappedFungibleTypesV1.sol"),
+        ];
+        // The generators overwrite the checked-in sources, and only `forge fmt` turns their
+        // output into the committed form, so without it every build leaves the tree dirty
+        // with equivalent-but-unformatted code that is easy to commit by accident.
+        let committed: Vec<Option<String>> = generated
+            .iter()
+            .map(|path| fs::read_to_string(path).ok())
+            .collect();
+
         generate_bridge_types();
         generate_fungible_types();
-        forge_fmt(&PathBuf::from("src/solidity/BridgeTypes.sol"));
-        forge_fmt(&PathBuf::from("src/solidity/WrappedFungibleTypesV1.sol"));
+
+        for (path, committed) in generated.iter().zip(committed) {
+            if forge_fmt(path) {
+                continue;
+            }
+            if let Some(committed) = committed {
+                if let Err(e) = fs::write(path, committed) {
+                    println!("cargo:warning=could not restore {}: {e}", path.display());
+                }
+            }
+        }
     }
 
-    /// Reformats a freshly generated Solidity file with `forge fmt` so the
-    /// generator's output matches the rest of the codebase. Falls back to
-    /// a warning (non-fatal) if `forge` is not on PATH — codegen is a
-    /// best-effort developer convenience and shouldn't break a build that
-    /// otherwise wouldn't have run forge.
-    fn forge_fmt(path: &PathBuf) {
+    /// Reformats a freshly generated Solidity file with `forge fmt` so the generator's
+    /// output matches the rest of the codebase, reporting whether it succeeded. Failure is
+    /// non-fatal (codegen is a developer convenience and should not break a build that
+    /// would not otherwise have run forge), but the caller restores the committed file,
+    /// because unformatted output differs from it and would dirty the tree.
+    fn forge_fmt(path: &PathBuf) -> bool {
         if !path.exists() {
-            return;
+            return false;
         }
         let status = Command::new("forge").arg("fmt").arg(path).status();
         match status {
-            Ok(s) if s.success() => {}
+            Ok(s) if s.success() => true,
             Ok(s) => {
-                println!("cargo:warning=forge fmt {} exited with {s}", path.display());
+                println!(
+                    "cargo:warning=forge fmt {} exited with {s}; leaving the committed file \
+                     in place",
+                    path.display()
+                );
+                false
             }
             Err(e) => {
                 println!(
-                    "cargo:warning=forge fmt {} could not be invoked: {e}",
+                    "cargo:warning=forge fmt {} could not be invoked: {e}; leaving the \
+                     committed file in place",
                     path.display()
                 );
+                false
             }
         }
     }


### PR DESCRIPTION
## Motivation

`linera-bridge/build.rs` regenerates two checked-in Solidity files **into the source tree** and
then reformats them with `forge fmt`. When `forge` is not on PATH the format step warns and
continues — leaving the raw generator output in place, which differs from what is committed.

The result is that anyone who builds with the `codegen` feature and without `forge` gets:

```
 M linera-bridge/src/solidity/BridgeTypes.sol
 M linera-bridge/src/solidity/WrappedFungibleTypesV1.sol
```

736 lines of diff that nobody asked for, in files nobody edited, appearing in `git status`
indefinitely. It is easy to sweep them into an unrelated commit with `git add -A` — which has
already happened once on this repo.

The diff looks like pure reformatting, and it very nearly is: the only semantic difference is that
the generator emits `uint i` in for-loops where `forge fmt` normalises it to `uint256 i`. Those are
the same type in Solidity. But "nearly" is doing real work there — the point is that the committed
form is the *formatted* one, so committing the unformatted variant would be wrong, and would flip
straight back the next time someone with `forge` installed runs a build.

## Proposal

Make a build a no-op on these files unless it can produce the canonical content.

`generate()` snapshots both files before generating. `forge_fmt` now reports success. If
formatting did not happen — `forge` missing, or it exited non-zero — the snapshot is written back,
so the tree is exactly as it was. If formatting succeeded, the freshly generated and formatted
content stays.

The warning now also says what was done about it, so a developer who sees it is not left guessing:

```
warning: forge fmt src/solidity/BridgeTypes.sol could not be invoked:
         No such file or directory (os error 2); leaving the committed file in place
```

The guarantee is deliberately "the build does not change these files", not "the build restores
them to HEAD" — a build script has no business consulting git, and restoring pre-build state is
both sufficient and idempotent.

## Test Plan

Both branches were exercised directly, since the whole point is a behaviour that only shows up
when an optional external tool is absent.

**`forge` missing (the reported failure).** With `forge` not on PATH, from a clean tree:

```
$ touch linera-bridge/build.rs
$ cargo check -p linera-bridge --features codegen
warning: linera-bridge@0.16.0: forge fmt src/solidity/BridgeTypes.sol could not be invoked:
         No such file or directory (os error 2); leaving the committed file in place
warning: linera-bridge@0.16.0: forge fmt src/solidity/WrappedFungibleTypesV1.sol could not be
         invoked: ...; leaving the committed file in place
$ git status --short -- linera-bridge/src/solidity/
(empty)
```

The warnings confirm the build script actually ran and took the restore path, rather than the
check passing vacuously because nothing was rebuilt.

**`forge` succeeding.** With a stub `forge` on PATH that exits 0 without formatting, the restore is
correctly skipped and the generated output is left in place (visible as a modified tree, because
the stub does not format). That is the intended behaviour: when `forge` reports success we keep
what it produced. With a real `forge` that output equals the committed content, so the tree stays
clean.

**Idempotent.** Re-running the build leaves the file hash unchanged.

Not verified: the real-`forge` path, because `forge` is not installed in my environment. The stub
covers the control flow; it cannot confirm that a real `forge fmt` reproduces the committed bytes.
That property already held before this PR and is unchanged by it.

`cargo clippy -p linera-bridge --features codegen` and `cargo fmt --check` clean.

## Release Plan

- Nothing to do / These changes follow the usual deployment cycle.

## Links

Found while porting the lite benchmark generator (#6752), where these two files kept reappearing
as unrelated modifications.
