### PR TITLE
Describe the storage layout and register the types it names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5932,6 +5932,7 @@ dependencies = [
  "papaya",
  "prometheus",
  "serde",
+ "serde-reflection",
  "test-case",
  "test-log",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5921,6 +5921,7 @@ dependencies = [
  "clap",
  "futures",
  "hex",
+ "insta",
  "itertools 0.14.0",
  "linera-base",
  "linera-cache",

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -56,6 +56,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 insta = { workspace = true, features = ["yaml"] }
+serde-reflection.workspace = true
 linera-chain = { workspace = true, features = ["test"] }
 linera-storage = { path = ".", default-features = false, features = ["test"] }
 test-case.workspace = true

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -55,6 +55,7 @@ serde.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+insta = { workspace = true, features = ["yaml"] }
 linera-chain = { workspace = true, features = ["test"] }
 linera-storage = { path = ".", default-features = false, features = ["test"] }
 test-case.workspace = true

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -584,9 +584,13 @@ impl RootKey {
     }
 }
 
+/// An event identifier with the chain removed, because the chain is carried by the
+/// [`RootKey`] of the partition the event is stored in.
 #[derive(Debug, Serialize, Deserialize)]
-struct RestrictedEventId {
+pub struct RestrictedEventId {
+    /// The stream the event belongs to.
     pub stream_id: StreamId,
+    /// The index of the event within that stream.
     pub index: u32,
 }
 

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -270,19 +270,19 @@ pub mod metrics {
 }
 
 /// The key used for blobs. The Blob ID itself is contained in the root key.
-const BLOB_KEY: &[u8] = &[0];
+pub(crate) const BLOB_KEY: &[u8] = &[0];
 
 /// The key used for blob states. The Blob ID itself is contained in the root key.
-const BLOB_STATE_KEY: &[u8] = &[1];
+pub(crate) const BLOB_STATE_KEY: &[u8] = &[1];
 
 /// The key used for lite certificates. The cryptohash itself is contained in the root key.
-const LITE_CERTIFICATE_KEY: &[u8] = &[2];
+pub(crate) const LITE_CERTIFICATE_KEY: &[u8] = &[2];
 
 /// The key used for confirmed blocks. The cryptohash itself is contained in the root key.
-const BLOCK_KEY: &[u8] = &[3];
+pub(crate) const BLOCK_KEY: &[u8] = &[3];
 
 /// The key used for the network description.
-const NETWORK_DESCRIPTION_KEY: &[u8] = &[4];
+pub(crate) const NETWORK_DESCRIPTION_KEY: &[u8] = &[4];
 
 fn get_block_keys() -> Vec<Vec<u8>> {
     vec![LITE_CERTIFICATE_KEY.to_vec(), BLOCK_KEY.to_vec()]

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -269,23 +269,55 @@ pub mod metrics {
     }
 }
 
-/// The key used for blobs. The Blob ID itself is contained in the root key.
-pub(crate) const BLOB_KEY: &[u8] = &[0];
+/// The key of a fixed entry inside a partition, addressed relative to its [`RootKey`].
+///
+/// The identifier a partition is keyed by — a blob ID, a block hash — lives in the root key
+/// and is not repeated here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EntryKey {
+    /// The contents of a blob.
+    Blob,
+    /// The state of a blob.
+    BlobState,
+    /// A lite certificate.
+    LiteCertificate,
+    /// A confirmed block.
+    Block,
+    /// The network description.
+    NetworkDescription,
+}
 
-/// The key used for blob states. The Blob ID itself is contained in the root key.
-pub(crate) const BLOB_STATE_KEY: &[u8] = &[1];
+impl EntryKey {
+    /// Every entry key, for exhaustive descriptions of the layout.
+    pub const ALL: &'static [EntryKey] = &[
+        EntryKey::Blob,
+        EntryKey::BlobState,
+        EntryKey::LiteCertificate,
+        EntryKey::Block,
+        EntryKey::NetworkDescription,
+    ];
 
-/// The key used for lite certificates. The cryptohash itself is contained in the root key.
-pub(crate) const LITE_CERTIFICATE_KEY: &[u8] = &[2];
-
-/// The key used for confirmed blocks. The cryptohash itself is contained in the root key.
-pub(crate) const BLOCK_KEY: &[u8] = &[3];
-
-/// The key used for the network description.
-pub(crate) const NETWORK_DESCRIPTION_KEY: &[u8] = &[4];
+    /// The stored bytes of this key.
+    ///
+    /// This is the BCS encoding, which for a fieldless enum is just its variant index; it is
+    /// spelled out so that reads need no allocation. `tests::entry_keys_match_bcs` checks the
+    /// two against each other.
+    pub const fn as_bytes(self) -> &'static [u8] {
+        match self {
+            EntryKey::Blob => &[0],
+            EntryKey::BlobState => &[1],
+            EntryKey::LiteCertificate => &[2],
+            EntryKey::Block => &[3],
+            EntryKey::NetworkDescription => &[4],
+        }
+    }
+}
 
 fn get_block_keys() -> Vec<Vec<u8>> {
-    vec![LITE_CERTIFICATE_KEY.to_vec(), BLOCK_KEY.to_vec()]
+    vec![
+        EntryKey::LiteCertificate.as_bytes().to_vec(),
+        EntryKey::Block.as_bytes().to_vec(),
+    ]
 }
 
 #[derive(Default)]
@@ -312,13 +344,13 @@ impl MultiPartitionBatch {
         #[cfg(with_metrics)]
         metrics::WRITE_BLOB_COUNTER.inc();
         let root_key = RootKey::BlobId(blob.id()).bytes();
-        let key = BLOB_KEY.to_vec();
+        let key = EntryKey::Blob.as_bytes().to_vec();
         self.put_key_value(root_key, key, blob.bytes().to_vec());
     }
 
     fn add_blob_state(&mut self, blob_id: BlobId, blob_state: &BlobState) -> Result<(), ViewError> {
         let root_key = RootKey::BlobId(blob_id).bytes();
-        let key = BLOB_STATE_KEY.to_vec();
+        let key = EntryKey::BlobState.as_bytes().to_vec();
         let value = bcs::to_bytes(blob_state)?;
         self.put_key_value(root_key, key, value);
         Ok(())
@@ -346,12 +378,12 @@ impl MultiPartitionBatch {
         // Write certificate data by hash
         let root_key = RootKey::BlockHash(hash).bytes();
         let mut key_values = Vec::new();
-        let key = LITE_CERTIFICATE_KEY.to_vec();
+        let key = EntryKey::LiteCertificate.as_bytes().to_vec();
         let value = bcs::to_bytes(&certificate.lite_certificate())?;
         #[cfg(with_metrics)]
         metrics::CERTIFICATE_LITE_BYTES.observe(value.len() as f64);
         key_values.push((key, value));
-        let key = BLOCK_KEY.to_vec();
+        let key = EntryKey::Block.as_bytes().to_vec();
         let value = bcs::to_bytes(&certificate.value())?;
         #[cfg(with_metrics)]
         metrics::CERTIFICATE_VALUE_BYTES.observe(value.len() as f64);
@@ -400,7 +432,7 @@ impl MultiPartitionBatch {
         #[cfg(with_metrics)]
         metrics::WRITE_NETWORK_DESCRIPTION.inc();
         let root_key = RootKey::NetworkDescription.bytes();
-        let key = NETWORK_DESCRIPTION_KEY.to_vec();
+        let key = EntryKey::NetworkDescription.as_bytes().to_vec();
         let value = bcs::to_bytes(information)?;
         self.put_key_value(root_key, key, value);
         Ok(())
@@ -782,7 +814,7 @@ where
         }
         let root_key = RootKey::BlobId(blob_id).bytes();
         let store = self.database.open_shared(&root_key)?;
-        let test = store.contains_key(BLOB_KEY).await?;
+        let test = store.contains_key(EntryKey::Blob.as_bytes()).await?;
         #[cfg(with_metrics)]
         metrics::CONTAINS_BLOB_COUNTER
             .with_label_values(&[metrics::DB])
@@ -811,7 +843,7 @@ where
             }
             let root_key = RootKey::BlobId(*blob_id).bytes();
             let store = self.database.open_shared(&root_key)?;
-            if !store.contains_key(BLOB_KEY).await? {
+            if !store.contains_key(EntryKey::Blob.as_bytes()).await? {
                 missing_blobs.push(*blob_id);
             }
         }
@@ -835,7 +867,7 @@ where
     async fn contains_blob_state(&self, blob_id: BlobId) -> Result<bool, ViewError> {
         let root_key = RootKey::BlobId(blob_id).bytes();
         let store = self.database.open_shared(&root_key)?;
-        let test = store.contains_key(BLOB_STATE_KEY).await?;
+        let test = store.contains_key(EntryKey::BlobState.as_bytes()).await?;
         #[cfg(with_metrics)]
         metrics::CONTAINS_BLOB_STATE_COUNTER
             .with_label_values(&[metrics::DB])
@@ -857,7 +889,9 @@ where
         }
         let root_key = RootKey::BlockHash(hash).bytes();
         let store = self.database.open_shared(&root_key)?;
-        let value = store.read_value::<ConfirmedBlock>(BLOCK_KEY).await?;
+        let value = store
+            .read_value::<ConfirmedBlock>(EntryKey::Block.as_bytes())
+            .await?;
         #[cfg(with_metrics)]
         metrics::READ_CONFIRMED_BLOCK_COUNTER
             .with_label_values(&[metrics::DB])
@@ -891,7 +925,10 @@ where
             let root_keys = Self::get_root_keys_for_certificates(&miss_hashes);
             for (miss_idx, root_key) in misses.iter().zip(root_keys) {
                 let store = self.database.open_shared(&root_key)?;
-                if let Some(block) = store.read_value::<ConfirmedBlock>(BLOCK_KEY).await? {
+                if let Some(block) = store
+                    .read_value::<ConfirmedBlock>(EntryKey::Block.as_bytes())
+                    .await?
+                {
                     results[*miss_idx] = Some(
                         self.caches
                             .confirmed_block
@@ -929,7 +966,7 @@ where
         }
         let root_key = RootKey::BlobId(blob_id).bytes();
         let store = self.database.open_shared(&root_key)?;
-        let maybe_blob_bytes = store.read_value_bytes(BLOB_KEY).await?;
+        let maybe_blob_bytes = store.read_value_bytes(EntryKey::Blob.as_bytes()).await?;
         #[cfg(with_metrics)]
         metrics::READ_BLOB_COUNTER
             .with_label_values(&[metrics::DB])
@@ -963,7 +1000,9 @@ where
     async fn read_blob_state(&self, blob_id: BlobId) -> Result<Option<BlobState>, ViewError> {
         let root_key = RootKey::BlobId(blob_id).bytes();
         let store = self.database.open_shared(&root_key)?;
-        let blob_state = store.read_value::<BlobState>(BLOB_STATE_KEY).await?;
+        let blob_state = store
+            .read_value::<BlobState>(EntryKey::BlobState.as_bytes())
+            .await?;
         #[cfg(with_metrics)]
         metrics::READ_BLOB_STATE_COUNTER
             .with_label_values(&[metrics::DB])
@@ -1008,7 +1047,9 @@ where
         for blob_id in blob_ids {
             let root_key = RootKey::BlobId(*blob_id).bytes();
             let store = self.database.open_shared(&root_key)?;
-            let maybe_blob_state = store.read_value::<BlobState>(BLOB_STATE_KEY).await?;
+            let maybe_blob_state = store
+                .read_value::<BlobState>(EntryKey::BlobState.as_bytes())
+                .await?;
             maybe_blob_states.push(maybe_blob_state);
         }
         let mut batch = MultiPartitionBatch::new();
@@ -1041,7 +1082,7 @@ where
         for blob in blobs {
             let root_key = RootKey::BlobId(blob.id()).bytes();
             let store = self.database.open_shared(&root_key)?;
-            let has_state = store.contains_key(BLOB_STATE_KEY).await?;
+            let has_state = store.contains_key(EntryKey::BlobState.as_bytes()).await?;
             blob_states.push(has_state);
             if has_state {
                 batch.add_blob(blob);
@@ -1545,8 +1586,9 @@ where
         }
         let root_key = RootKey::NetworkDescription.bytes();
         let store = self.database.open_shared(&root_key)?;
-        let maybe_value: Option<NetworkDescription> =
-            store.read_value(NETWORK_DESCRIPTION_KEY).await?;
+        let maybe_value: Option<NetworkDescription> = store
+            .read_value(EntryKey::NetworkDescription.as_bytes())
+            .await?;
         #[cfg(with_metrics)]
         metrics::READ_NETWORK_DESCRIPTION
             .with_label_values(&[metrics::DB])

--- a/linera-storage/src/format.rs
+++ b/linera-storage/src/format.rs
@@ -1,0 +1,279 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A machine-readable description of how storage lays out its keys and values.
+//!
+//! Storage is divided into partitions, each addressed by the BCS encoding of a [`RootKey`](crate::RootKey).
+//! Within a partition, keys either form the key space of a root view or a fixed table of
+//! entries. This module describes that layout so that raw key-value pairs can be interpreted
+//! without reference to the code that wrote them.
+//!
+//! The description is only as good as its agreement with the writers, so it names the same
+//! constants they use, and `tests::root_key_variants_match_declaration` checks the declared
+//! partition tags against the encoding of real [`RootKey`](crate::RootKey) values.
+//!
+//! The description starts at the root key. Backends wrap it further: ScyllaDB prepends a zero
+//! byte because it requires non-empty partition keys (`get_big_root_key`), and RocksDB prefixes
+//! the data domain with `ROOT_KEY_DOMAIN` to separate it from its root-key registry. Those
+//! belong to `linera-views` and are not described here.
+
+use serde::Serialize;
+
+use crate::db_storage::{
+    BLOB_KEY, BLOB_STATE_KEY, BLOCK_KEY, LITE_CERTIFICATE_KEY, NETWORK_DESCRIPTION_KEY,
+};
+
+/// How the bytes of a key are produced.
+#[derive(Debug, Serialize)]
+pub enum KeyFormat {
+    /// A fixed byte string.
+    Literal(Vec<u8>),
+    /// The BCS encoding of a value of the named type.
+    Bcs {
+        /// The name of the encoded type.
+        type_name: &'static str,
+    },
+}
+
+/// How the bytes of a value are produced.
+#[derive(Debug, Serialize)]
+pub enum ValueFormat {
+    /// The BCS encoding of a value of the named type.
+    Bcs {
+        /// The name of the encoded type.
+        type_name: &'static str,
+    },
+    /// Bytes whose interpretation this schema does not determine.
+    Opaque {
+        /// What the bytes are, for a human reader.
+        description: &'static str,
+    },
+}
+
+/// A single entry of a partition holding a fixed table.
+#[derive(Debug, Serialize)]
+pub struct FlatEntry {
+    /// The key, relative to the root key.
+    pub key: KeyFormat,
+    /// The value stored under it.
+    pub value: ValueFormat,
+}
+
+/// What a partition holds.
+#[derive(Debug, Serialize)]
+pub enum PartitionBody {
+    /// The key space of a root view of the named type, as laid out by `linera-views`.
+    RootView {
+        /// The name of the view type.
+        type_name: &'static str,
+    },
+    /// A fixed table of entries.
+    Flat {
+        /// The entries, in no particular order.
+        entries: Vec<FlatEntry>,
+    },
+}
+
+/// One partition of the key space.
+#[derive(Debug, Serialize)]
+pub struct Partition {
+    /// The name of the [`RootKey`](crate::RootKey) variant addressing this partition.
+    pub name: &'static str,
+    /// The BCS variant index of that root key, which is the first byte of every key's
+    /// partition address.
+    pub variant: u32,
+    /// The payload the root key carries, which is context for the keys inside: the chain a
+    /// partition belongs to is not repeated in its keys.
+    pub payload: Option<&'static str>,
+    /// What the partition holds.
+    pub body: PartitionBody,
+}
+
+/// The layout of storage.
+#[derive(Debug, Serialize)]
+pub struct StorageFormat {
+    /// The type whose BCS encoding addresses a partition.
+    pub root_key_type: &'static str,
+    /// The partitions, in the declaration order of [`RootKey`](crate::RootKey).
+    pub partitions: Vec<Partition>,
+}
+
+impl StorageFormat {
+    /// Describes the layout this build of `linera-storage` reads and writes.
+    pub fn current() -> Self {
+        StorageFormat {
+            root_key_type: "RootKey",
+            partitions: vec![
+                Partition {
+                    name: "NetworkDescription",
+                    variant: 0,
+                    payload: None,
+                    body: PartitionBody::Flat {
+                        entries: vec![FlatEntry {
+                            key: KeyFormat::Literal(NETWORK_DESCRIPTION_KEY.to_vec()),
+                            value: ValueFormat::Bcs {
+                                type_name: "NetworkDescription",
+                            },
+                        }],
+                    },
+                },
+                Partition {
+                    name: "BlockExporterState",
+                    variant: 1,
+                    payload: Some("u32"),
+                    body: PartitionBody::RootView {
+                        type_name: "BlockExporterStateView",
+                    },
+                },
+                Partition {
+                    name: "ChainState",
+                    variant: 2,
+                    payload: Some("ChainId"),
+                    body: PartitionBody::RootView {
+                        type_name: "ChainStateView",
+                    },
+                },
+                Partition {
+                    name: "BlockHash",
+                    variant: 3,
+                    payload: Some("CryptoHash"),
+                    body: PartitionBody::Flat {
+                        entries: vec![
+                            FlatEntry {
+                                key: KeyFormat::Literal(LITE_CERTIFICATE_KEY.to_vec()),
+                                value: ValueFormat::Bcs {
+                                    type_name: "LiteCertificate",
+                                },
+                            },
+                            FlatEntry {
+                                key: KeyFormat::Literal(BLOCK_KEY.to_vec()),
+                                value: ValueFormat::Bcs {
+                                    type_name: "ConfirmedBlock",
+                                },
+                            },
+                        ],
+                    },
+                },
+                Partition {
+                    name: "BlobId",
+                    variant: 4,
+                    payload: Some("BlobId"),
+                    body: PartitionBody::Flat {
+                        entries: vec![
+                            FlatEntry {
+                                key: KeyFormat::Literal(BLOB_KEY.to_vec()),
+                                value: ValueFormat::Opaque {
+                                    description: "the contents of the blob",
+                                },
+                            },
+                            FlatEntry {
+                                key: KeyFormat::Literal(BLOB_STATE_KEY.to_vec()),
+                                value: ValueFormat::Bcs {
+                                    type_name: "BlobState",
+                                },
+                            },
+                        ],
+                    },
+                },
+                Partition {
+                    name: "Event",
+                    variant: 5,
+                    payload: Some("ChainId"),
+                    body: PartitionBody::Flat {
+                        entries: vec![FlatEntry {
+                            // The chain is carried by the root key, so only the stream and
+                            // index remain: together they reconstitute an `EventId`.
+                            key: KeyFormat::Bcs {
+                                type_name: "RestrictedEventId",
+                            },
+                            value: ValueFormat::Opaque {
+                                description: "the contents of the event",
+                            },
+                        }],
+                    },
+                },
+                Partition {
+                    name: "BlockByHeight",
+                    variant: 6,
+                    payload: Some("ChainId"),
+                    body: PartitionBody::Flat {
+                        entries: vec![FlatEntry {
+                            key: KeyFormat::Bcs {
+                                type_name: "BlockHeight",
+                            },
+                            value: ValueFormat::Bcs {
+                                type_name: "CryptoHash",
+                            },
+                        }],
+                    },
+                },
+                Partition {
+                    name: "EventBlockHeight",
+                    variant: 7,
+                    payload: Some("ChainId"),
+                    body: PartitionBody::Flat {
+                        entries: vec![FlatEntry {
+                            key: KeyFormat::Bcs {
+                                type_name: "RestrictedEventId",
+                            },
+                            value: ValueFormat::Bcs {
+                                type_name: "BlockHeight",
+                            },
+                        }],
+                    },
+                },
+            ],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use linera_base::{
+        crypto::CryptoHash,
+        identifiers::{BlobId, BlobType, ChainId},
+    };
+
+    use super::*;
+    use crate::RootKey;
+
+    /// The declared partition tags must be the ones `RootKey` actually encodes to. This is what
+    /// makes the description trustworthy: reordering the enum fails here rather than silently
+    /// invalidating the schema.
+    #[test]
+    fn root_key_variants_match_declaration() {
+        let hash = CryptoHash::default();
+        let chain_id = ChainId(hash);
+        let blob_id = BlobId {
+            blob_type: BlobType::Data,
+            hash,
+        };
+        let samples = [
+            RootKey::NetworkDescription,
+            RootKey::BlockExporterState(0),
+            RootKey::ChainState(chain_id),
+            RootKey::BlockHash(hash),
+            RootKey::BlobId(blob_id),
+            RootKey::Event(chain_id),
+            RootKey::BlockByHeight(chain_id),
+            RootKey::EventBlockHeight(chain_id),
+        ];
+        let format = StorageFormat::current();
+        assert_eq!(format.partitions.len(), samples.len());
+        for (partition, sample) in format.partitions.iter().zip(samples) {
+            let bytes = sample.bytes();
+            // Every variant index so far fits in one ULEB128 byte.
+            assert_eq!(
+                u32::from(bytes[0]),
+                partition.variant,
+                "declared tag for {} does not match its encoding",
+                partition.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_format() {
+        insta::assert_yaml_snapshot!("storage_format.yaml", StorageFormat::current());
+    }
+}

--- a/linera-storage/src/format.rs
+++ b/linera-storage/src/format.rs
@@ -19,15 +19,18 @@
 
 use serde::Serialize;
 
-use crate::db_storage::{
-    BLOB_KEY, BLOB_STATE_KEY, BLOCK_KEY, LITE_CERTIFICATE_KEY, NETWORK_DESCRIPTION_KEY,
-};
+use crate::db_storage::EntryKey;
 
 /// How the bytes of a key are produced.
 #[derive(Debug, Serialize)]
 pub enum KeyFormat {
-    /// A fixed byte string.
-    Literal(Vec<u8>),
+    /// A fixed entry, named by its [`EntryKey`](crate::EntryKey) variant.
+    Fixed {
+        /// The name of the variant.
+        variant: String,
+        /// Its stored bytes.
+        bytes: Vec<u8>,
+    },
     /// The BCS encoding of a value of the named type.
     Bcs {
         /// The name of the encoded type.
@@ -98,6 +101,16 @@ pub struct StorageFormat {
     pub partitions: Vec<Partition>,
 }
 
+/// Describes a fixed entry key by asking it for its own bytes.
+fn fixed(key: EntryKey) -> KeyFormat {
+    KeyFormat::Fixed {
+        // The derived `Debug` of a fieldless variant is its name, so there is no second
+        // name-to-variant mapping to keep in step.
+        variant: format!("{key:?}"),
+        bytes: key.as_bytes().to_vec(),
+    }
+}
+
 impl StorageFormat {
     /// Describes the layout this build of `linera-storage` reads and writes.
     pub fn current() -> Self {
@@ -110,7 +123,7 @@ impl StorageFormat {
                     payload: None,
                     body: PartitionBody::Flat {
                         entries: vec![FlatEntry {
-                            key: KeyFormat::Literal(NETWORK_DESCRIPTION_KEY.to_vec()),
+                            key: fixed(EntryKey::NetworkDescription),
                             value: ValueFormat::Bcs {
                                 type_name: "NetworkDescription",
                             },
@@ -140,13 +153,13 @@ impl StorageFormat {
                     body: PartitionBody::Flat {
                         entries: vec![
                             FlatEntry {
-                                key: KeyFormat::Literal(LITE_CERTIFICATE_KEY.to_vec()),
+                                key: fixed(EntryKey::LiteCertificate),
                                 value: ValueFormat::Bcs {
                                     type_name: "LiteCertificate",
                                 },
                             },
                             FlatEntry {
-                                key: KeyFormat::Literal(BLOCK_KEY.to_vec()),
+                                key: fixed(EntryKey::Block),
                                 value: ValueFormat::Bcs {
                                     type_name: "ConfirmedBlock",
                                 },
@@ -161,13 +174,13 @@ impl StorageFormat {
                     body: PartitionBody::Flat {
                         entries: vec![
                             FlatEntry {
-                                key: KeyFormat::Literal(BLOB_KEY.to_vec()),
+                                key: fixed(EntryKey::Blob),
                                 value: ValueFormat::Opaque {
                                     description: "the contents of the blob",
                                 },
                             },
                             FlatEntry {
-                                key: KeyFormat::Literal(BLOB_STATE_KEY.to_vec()),
+                                key: fixed(EntryKey::BlobState),
                                 value: ValueFormat::Bcs {
                                     type_name: "BlobState",
                                 },
@@ -268,6 +281,19 @@ mod tests {
                 partition.variant,
                 "declared tag for {} does not match its encoding",
                 partition.name
+            );
+        }
+    }
+
+    /// The spelled-out bytes must be the BCS encoding, or reads and the description disagree
+    /// with what a decoder would compute.
+    #[test]
+    fn entry_keys_match_bcs() {
+        for key in EntryKey::ALL {
+            assert_eq!(
+                key.as_bytes(),
+                bcs::to_bytes(key).unwrap(),
+                "{key:?} does not encode to its stated bytes"
             );
         }
     }

--- a/linera-storage/src/format.rs
+++ b/linera-storage/src/format.rs
@@ -17,6 +17,8 @@
 //! the data domain with `ROOT_KEY_DOMAIN` to separate it from its root-key registry. Those
 //! belong to `linera-views` and are not described here.
 
+use std::collections::BTreeSet;
+
 use serde::Serialize;
 
 use crate::db_storage::EntryKey;
@@ -112,6 +114,28 @@ fn fixed(key: EntryKey) -> KeyFormat {
 }
 
 impl StorageFormat {
+    /// The names of the types whose BCS encodings appear in keys and values.
+    ///
+    /// Every one of these must resolve in the storage type registry, or a decoder handed this
+    /// description has no way to interpret the bytes. `tests/format.rs` checks it.
+    pub fn serialized_type_names(&self) -> BTreeSet<&'static str> {
+        let mut names = BTreeSet::new();
+        for partition in &self.partitions {
+            let PartitionBody::Flat { entries } = &partition.body else {
+                continue;
+            };
+            for entry in entries {
+                if let KeyFormat::Bcs { type_name } = &entry.key {
+                    names.insert(*type_name);
+                }
+                if let ValueFormat::Bcs { type_name } = &entry.value {
+                    names.insert(*type_name);
+                }
+            }
+        }
+        names
+    }
+
     /// Describes the layout this build of `linera-storage` reads and writes.
     pub fn current() -> Self {
         StorageFormat {
@@ -160,9 +184,10 @@ impl StorageFormat {
                             },
                             FlatEntry {
                                 key: fixed(EntryKey::Block),
-                                value: ValueFormat::Bcs {
-                                    type_name: "ConfirmedBlock",
-                                },
+                                // Written as a `ConfirmedBlock`, but that wrapper serializes
+                                // transparently as the `Block` it holds: its hash is recomputed
+                                // on deserialization rather than stored.
+                                value: ValueFormat::Bcs { type_name: "Block" },
                             },
                         ],
                     },

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -45,8 +45,8 @@ use linera_views::{context::Context, views::RootView, ViewError};
 #[cfg(with_metrics)]
 pub use crate::db_storage::metrics;
 pub use crate::db_storage::{
-    ChainStatesFirstAssignment, DbStorage, EntryKey, RootKey, StorageCacheConfig, StorageCaches,
-    WallClock,
+    ChainStatesFirstAssignment, DbStorage, EntryKey, RestrictedEventId, RootKey,
+    StorageCacheConfig, StorageCaches, WallClock,
 };
 #[cfg(with_testing)]
 pub use crate::db_storage::{TestClock, DEFAULT_STORAGE_CACHE_CONFIG};

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -6,6 +6,8 @@
 #![deny(missing_docs)]
 
 mod db_storage;
+/// A machine-readable description of the storage layout.
+pub mod format;
 
 use std::sync::Arc as StdArc;
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -45,7 +45,8 @@ use linera_views::{context::Context, views::RootView, ViewError};
 #[cfg(with_metrics)]
 pub use crate::db_storage::metrics;
 pub use crate::db_storage::{
-    ChainStatesFirstAssignment, DbStorage, RootKey, StorageCacheConfig, StorageCaches, WallClock,
+    ChainStatesFirstAssignment, DbStorage, EntryKey, RootKey, StorageCacheConfig, StorageCaches,
+    WallClock,
 };
 #[cfg(with_testing)]
 pub use crate::db_storage::{TestClock, DEFAULT_STORAGE_CACHE_CONFIG};

--- a/linera-storage/src/snapshots/linera_storage__format__tests__storage_format.yaml.snap
+++ b/linera-storage/src/snapshots/linera_storage__format__tests__storage_format.yaml.snap
@@ -11,8 +11,10 @@ partitions:
       Flat:
         entries:
           - key:
-              Literal:
-                - 4
+              Fixed:
+                variant: NetworkDescription
+                bytes:
+                  - 4
             value:
               Bcs:
                 type_name: NetworkDescription
@@ -35,14 +37,18 @@ partitions:
       Flat:
         entries:
           - key:
-              Literal:
-                - 2
+              Fixed:
+                variant: LiteCertificate
+                bytes:
+                  - 2
             value:
               Bcs:
                 type_name: LiteCertificate
           - key:
-              Literal:
-                - 3
+              Fixed:
+                variant: Block
+                bytes:
+                  - 3
             value:
               Bcs:
                 type_name: ConfirmedBlock
@@ -53,14 +59,18 @@ partitions:
       Flat:
         entries:
           - key:
-              Literal:
-                - 0
+              Fixed:
+                variant: Blob
+                bytes:
+                  - 0
             value:
               Opaque:
                 description: the contents of the blob
           - key:
-              Literal:
-                - 1
+              Fixed:
+                variant: BlobState
+                bytes:
+                  - 1
             value:
               Bcs:
                 type_name: BlobState

--- a/linera-storage/src/snapshots/linera_storage__format__tests__storage_format.yaml.snap
+++ b/linera-storage/src/snapshots/linera_storage__format__tests__storage_format.yaml.snap
@@ -51,7 +51,7 @@ partitions:
                   - 3
             value:
               Bcs:
-                type_name: ConfirmedBlock
+                type_name: Block
   - name: BlobId
     variant: 4
     payload: BlobId

--- a/linera-storage/src/snapshots/linera_storage__format__tests__storage_format.yaml.snap
+++ b/linera-storage/src/snapshots/linera_storage__format__tests__storage_format.yaml.snap
@@ -1,0 +1,102 @@
+---
+source: linera-storage/src/format.rs
+expression: "StorageFormat::current()"
+---
+root_key_type: RootKey
+partitions:
+  - name: NetworkDescription
+    variant: 0
+    payload: ~
+    body:
+      Flat:
+        entries:
+          - key:
+              Literal:
+                - 4
+            value:
+              Bcs:
+                type_name: NetworkDescription
+  - name: BlockExporterState
+    variant: 1
+    payload: u32
+    body:
+      RootView:
+        type_name: BlockExporterStateView
+  - name: ChainState
+    variant: 2
+    payload: ChainId
+    body:
+      RootView:
+        type_name: ChainStateView
+  - name: BlockHash
+    variant: 3
+    payload: CryptoHash
+    body:
+      Flat:
+        entries:
+          - key:
+              Literal:
+                - 2
+            value:
+              Bcs:
+                type_name: LiteCertificate
+          - key:
+              Literal:
+                - 3
+            value:
+              Bcs:
+                type_name: ConfirmedBlock
+  - name: BlobId
+    variant: 4
+    payload: BlobId
+    body:
+      Flat:
+        entries:
+          - key:
+              Literal:
+                - 0
+            value:
+              Opaque:
+                description: the contents of the blob
+          - key:
+              Literal:
+                - 1
+            value:
+              Bcs:
+                type_name: BlobState
+  - name: Event
+    variant: 5
+    payload: ChainId
+    body:
+      Flat:
+        entries:
+          - key:
+              Bcs:
+                type_name: RestrictedEventId
+            value:
+              Opaque:
+                description: the contents of the event
+  - name: BlockByHeight
+    variant: 6
+    payload: ChainId
+    body:
+      Flat:
+        entries:
+          - key:
+              Bcs:
+                type_name: BlockHeight
+            value:
+              Bcs:
+                type_name: CryptoHash
+  - name: EventBlockHeight
+    variant: 7
+    payload: ChainId
+    body:
+      Flat:
+        entries:
+          - key:
+              Bcs:
+                type_name: RestrictedEventId
+            value:
+              Bcs:
+                type_name: BlockHeight

--- a/linera-storage/tests/format.rs
+++ b/linera-storage/tests/format.rs
@@ -1,0 +1,106 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The BCS formats of the types that storage keys and values are encoded with.
+//!
+//! `linera-rpc` does the same for the wire surface. Together with
+//! [`linera_storage::format::StorageFormat`], which says *where* each type appears, this registry
+//! is what a decoder needs to turn a raw key-value pair into JSON.
+
+use linera_base::{
+    crypto::{CryptoHash, TestString},
+    data_types::{BlockHeight, NetworkDescription, OracleResponse, Round},
+    identifiers::{AccountOwner, BlobType, GenericApplicationId},
+    vm::VmRuntime,
+};
+use linera_chain::{
+    data_types::{MessageAction, Transaction},
+    types::{CertificateKind, ConfirmedBlock, LiteCertificate},
+};
+use linera_execution::{
+    system::{AdminOperation, SystemMessage, SystemOperation},
+    BlobOrigin, BlobState, Message, MessageKind, Operation,
+};
+use linera_storage::{format::StorageFormat, EntryKey, RestrictedEventId, RootKey};
+use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
+
+fn get_registry() -> Result<Registry> {
+    let mut tracer = Tracer::new(
+        TracerConfig::default()
+            .record_samples_for_newtype_structs(true)
+            .record_samples_for_tuple_structs(true),
+    );
+    let mut samples = Samples::new();
+
+    // Signature types have custom deserializers that reject the values serde-reflection would
+    // invent, so record real ones first. Same treatment as in `linera-rpc/tests/format.rs`.
+    let validator_keypair = linera_base::crypto::ValidatorKeypair::generate();
+    let validator_signature = linera_base::crypto::ValidatorSignature::new(
+        &TestString::new("signature".to_string()),
+        &validator_keypair.secret_key,
+    );
+    tracer.trace_value(&mut samples, &validator_keypair.public_key)?;
+    tracer.trace_value(&mut samples, &validator_signature)?;
+
+    let evm_secret_key = linera_base::crypto::EvmSecretKey::generate();
+    let evm_public_key = evm_secret_key.public();
+    tracer.trace_value(&mut samples, &evm_public_key)?;
+    let evm_signature = linera_base::crypto::EvmSignature::new(
+        CryptoHash::new(&TestString::new("signature".to_string())),
+        &evm_secret_key,
+    );
+    tracer.trace_value(&mut samples, &evm_signature)?;
+
+    // The keys.
+    tracer.trace_type::<RootKey>(&samples)?;
+    tracer.trace_type::<EntryKey>(&samples)?;
+    tracer.trace_type::<RestrictedEventId>(&samples)?;
+    tracer.trace_type::<BlockHeight>(&samples)?;
+    tracer.trace_type::<CryptoHash>(&samples)?;
+
+    // Enums must be traced individually, or serde-reflection only discovers the variants that
+    // happen to be reachable from the values above.
+    tracer.trace_type::<AccountOwner>(&samples)?;
+    tracer.trace_type::<AdminOperation>(&samples)?;
+    tracer.trace_type::<BlobOrigin>(&samples)?;
+    tracer.trace_type::<BlobType>(&samples)?;
+    tracer.trace_type::<CertificateKind>(&samples)?;
+    tracer.trace_type::<GenericApplicationId>(&samples)?;
+    tracer.trace_type::<Message>(&samples)?;
+    tracer.trace_type::<MessageAction>(&samples)?;
+    tracer.trace_type::<MessageKind>(&samples)?;
+    tracer.trace_type::<Operation>(&samples)?;
+    tracer.trace_type::<OracleResponse>(&samples)?;
+    tracer.trace_type::<Round>(&samples)?;
+    tracer.trace_type::<SystemMessage>(&samples)?;
+    tracer.trace_type::<SystemOperation>(&samples)?;
+    tracer.trace_type::<Transaction>(&samples)?;
+    tracer.trace_type::<VmRuntime>(&samples)?;
+
+    // The values.
+    tracer.trace_type::<NetworkDescription>(&samples)?;
+    tracer.trace_type::<LiteCertificate>(&samples)?;
+    tracer.trace_type::<ConfirmedBlock>(&samples)?;
+    tracer.trace_type::<BlobState>(&samples)?;
+
+    tracer.registry()
+}
+
+#[test]
+fn test_format() {
+    insta::assert_yaml_snapshot!("storage_types.yaml", get_registry().unwrap());
+}
+
+/// Every type the layout description names must be one this registry defines. Without this the
+/// names in `StorageFormat` are just strings, and nothing catches a rename or a stale entry.
+#[test]
+fn schema_type_names_resolve() {
+    let registry = get_registry().unwrap();
+    for name in StorageFormat::current().serialized_type_names() {
+        assert!(
+            registry.contains_key(name),
+            "the layout description names `{name}`, which the storage type registry does not \
+             define; either the name is wrong or the type needs tracing in this file"
+        );
+    }
+}

--- a/linera-storage/tests/snapshots/format__storage_types.yaml.snap
+++ b/linera-storage/tests/snapshots/format__storage_types.yaml.snap
@@ -1,0 +1,712 @@
+---
+source: linera-storage/tests/format.rs
+expression: get_registry().unwrap()
+---
+Account:
+  STRUCT:
+    - chain_id:
+        TYPENAME: ChainId
+    - owner:
+        TYPENAME: AccountOwner
+AccountOwner:
+  ENUM:
+    0:
+      Reserved:
+        NEWTYPE: U8
+    1:
+      Address32:
+        NEWTYPE:
+          TYPENAME: CryptoHash
+    2:
+      Address20:
+        NEWTYPE:
+          TUPLEARRAY:
+            CONTENT: U8
+            SIZE: 20
+AdminOperation:
+  ENUM:
+    0:
+      PublishCommitteeBlob:
+        STRUCT:
+          - blob_hash:
+              TYPENAME: CryptoHash
+    1:
+      CreateCommittee:
+        STRUCT:
+          - epoch:
+              TYPENAME: Epoch
+          - blob_hash:
+              TYPENAME: CryptoHash
+    2:
+      RemoveCommittee:
+        STRUCT:
+          - epoch:
+              TYPENAME: Epoch
+Amount:
+  NEWTYPESTRUCT: U128
+ApplicationId:
+  STRUCT:
+    - application_description_hash:
+        TYPENAME: CryptoHash
+ApplicationPermissions:
+  STRUCT:
+    - execute_operations:
+        OPTION:
+          SEQ:
+            TYPENAME: ApplicationId
+    - mandatory_applications:
+        SEQ:
+          TYPENAME: ApplicationId
+    - manage_chain:
+        SEQ:
+          TYPENAME: ApplicationId
+    - call_service_as_oracle:
+        OPTION:
+          SEQ:
+            TYPENAME: ApplicationId
+    - make_http_requests:
+        OPTION:
+          SEQ:
+            TYPENAME: ApplicationId
+BlobContent:
+  STRUCT:
+    - blob_type:
+        TYPENAME: BlobType
+    - bytes: BYTES
+BlobId:
+  STRUCT:
+    - hash:
+        TYPENAME: CryptoHash
+    - blob_type:
+        TYPENAME: BlobType
+BlobOrigin:
+  ENUM:
+    0:
+      Genesis: UNIT
+    1:
+      Published:
+        STRUCT:
+          - chain_id:
+              TYPENAME: ChainId
+          - block_height:
+              TYPENAME: BlockHeight
+BlobState:
+  STRUCT:
+    - origin:
+        TYPENAME: BlobOrigin
+    - last_used_by:
+        OPTION:
+          TYPENAME: CryptoHash
+    - epoch:
+        OPTION:
+          TYPENAME: Epoch
+BlobType:
+  ENUM:
+    0:
+      Data: UNIT
+    1:
+      ContractBytecode: UNIT
+    2:
+      ServiceBytecode: UNIT
+    3:
+      EvmBytecode: UNIT
+    4:
+      ApplicationDescription: UNIT
+    5:
+      Committee: UNIT
+    6:
+      ChainDescription: UNIT
+    7:
+      ApplicationFormats: UNIT
+    8:
+      CheckpointExecutionState: UNIT
+Block:
+  STRUCT:
+    - header:
+        TYPENAME: BlockHeader
+    - body:
+        TYPENAME: BlockBody
+BlockBody:
+  STRUCT:
+    - transactions:
+        SEQ:
+          TYPENAME: Transaction
+    - messages:
+        SEQ:
+          SEQ:
+            TYPENAME: OutgoingMessage
+    - previous_message_blocks:
+        MAP:
+          KEY:
+            TYPENAME: ChainId
+          VALUE:
+            TUPLE:
+              - TYPENAME: CryptoHash
+              - TYPENAME: BlockHeight
+    - previous_event_blocks:
+        MAP:
+          KEY:
+            TYPENAME: StreamId
+          VALUE:
+            TUPLE:
+              - TYPENAME: CryptoHash
+              - TYPENAME: BlockHeight
+    - oracle_responses:
+        SEQ:
+          SEQ:
+            TYPENAME: OracleResponse
+    - events:
+        SEQ:
+          SEQ:
+            TYPENAME: Event
+    - blobs:
+        SEQ:
+          SEQ:
+            TYPENAME: BlobContent
+    - operation_results:
+        SEQ:
+          TYPENAME: OperationResult
+BlockHeader:
+  STRUCT:
+    - chain_id:
+        TYPENAME: ChainId
+    - epoch:
+        TYPENAME: Epoch
+    - height:
+        TYPENAME: BlockHeight
+    - timestamp:
+        TYPENAME: Timestamp
+    - state_hash:
+        TYPENAME: CryptoHash
+    - previous_block_hash:
+        OPTION:
+          TYPENAME: CryptoHash
+    - authenticated_owner:
+        OPTION:
+          TYPENAME: AccountOwner
+BlockHeight:
+  NEWTYPESTRUCT: U64
+CertificateKind:
+  ENUM:
+    0:
+      Timeout: UNIT
+    1:
+      Validated: UNIT
+    2:
+      Confirmed: UNIT
+ChainId:
+  NEWTYPESTRUCT:
+    TYPENAME: CryptoHash
+ChainOwnership:
+  STRUCT:
+    - super_owners:
+        SEQ:
+          TYPENAME: AccountOwner
+    - owners:
+        MAP:
+          KEY:
+            TYPENAME: AccountOwner
+          VALUE: U64
+    - first_leader:
+        OPTION:
+          TYPENAME: AccountOwner
+    - multi_leader_rounds: U32
+    - open_multi_leader_rounds: BOOL
+    - timeout_config:
+        TYPENAME: TimeoutConfig
+CryptoHash:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 32
+Cursor:
+  STRUCT:
+    - height:
+        TYPENAME: BlockHeight
+    - index: U32
+EntryKey:
+  ENUM:
+    0:
+      Blob: UNIT
+    1:
+      BlobState: UNIT
+    2:
+      LiteCertificate: UNIT
+    3:
+      Block: UNIT
+    4:
+      NetworkDescription: UNIT
+Epoch:
+  NEWTYPESTRUCT: U32
+Event:
+  STRUCT:
+    - stream_id:
+        TYPENAME: StreamId
+    - index: U32
+    - value: BYTES
+EventId:
+  STRUCT:
+    - chain_id:
+        TYPENAME: ChainId
+    - stream_id:
+        TYPENAME: StreamId
+    - index: U32
+EvmPublicKey:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 33
+EvmSignature:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 65
+GenericApplicationId:
+  ENUM:
+    0:
+      System: UNIT
+    1:
+      User:
+        NEWTYPE:
+          TYPENAME: ApplicationId
+Header:
+  STRUCT:
+    - name: STR
+    - value: BYTES
+IncomingBundle:
+  STRUCT:
+    - origin:
+        TYPENAME: ChainId
+    - bundle:
+        TYPENAME: MessageBundle
+    - action:
+        TYPENAME: MessageAction
+JustificationChain:
+  STRUCT:
+    - links:
+        SEQ:
+          TYPENAME: JustificationLink
+JustificationLink:
+  STRUCT:
+    - round:
+        TYPENAME: Round
+    - signatures:
+        SEQ:
+          TUPLE:
+            - TYPENAME: Secp256k1PublicKey
+            - TYPENAME: Secp256k1Signature
+LiteCertificate:
+  STRUCT:
+    - value:
+        TYPENAME: LiteValue
+    - round:
+        TYPENAME: Round
+    - unlocking_round:
+        OPTION:
+          TYPENAME: Round
+    - first_round: BOOL
+    - justification_commitment:
+        OPTION:
+          TYPENAME: CryptoHash
+    - justification:
+        TYPENAME: JustificationChain
+    - signatures:
+        SEQ:
+          TUPLE:
+            - TYPENAME: Secp256k1PublicKey
+            - TYPENAME: Secp256k1Signature
+LiteValue:
+  STRUCT:
+    - value_hash:
+        TYPENAME: CryptoHash
+    - chain_id:
+        TYPENAME: ChainId
+    - kind:
+        TYPENAME: CertificateKind
+Message:
+  ENUM:
+    0:
+      System:
+        NEWTYPE:
+          TYPENAME: SystemMessage
+    1:
+      User:
+        STRUCT:
+          - application_id:
+              TYPENAME: ApplicationId
+          - bytes: BYTES
+MessageAction:
+  ENUM:
+    0:
+      Accept: UNIT
+    1:
+      Reject: UNIT
+MessageBundle:
+  STRUCT:
+    - height:
+        TYPENAME: BlockHeight
+    - timestamp:
+        TYPENAME: Timestamp
+    - certificate_hash:
+        TYPENAME: CryptoHash
+    - transaction_index: U32
+    - messages:
+        SEQ:
+          TYPENAME: PostedMessage
+MessageKind:
+  ENUM:
+    0:
+      Simple: UNIT
+    1:
+      Protected: UNIT
+    2:
+      Tracked: UNIT
+    3:
+      Bouncing: UNIT
+ModuleId:
+  STRUCT:
+    - contract_blob_hash:
+        TYPENAME: CryptoHash
+    - service_blob_hash:
+        TYPENAME: CryptoHash
+    - vm_runtime:
+        TYPENAME: VmRuntime
+    - formats_blob_hash:
+        OPTION:
+          TYPENAME: CryptoHash
+NetworkDescription:
+  STRUCT:
+    - name: STR
+    - genesis_config_hash:
+        TYPENAME: CryptoHash
+    - genesis_timestamp:
+        TYPENAME: Timestamp
+    - genesis_committee_blob_hash:
+        TYPENAME: CryptoHash
+    - admin_chain_id:
+        TYPENAME: ChainId
+OpenChainConfig:
+  STRUCT:
+    - ownership:
+        TYPENAME: ChainOwnership
+    - account:
+        TYPENAME: AccountOwner
+    - balance:
+        TYPENAME: Amount
+    - application_permissions:
+        TYPENAME: ApplicationPermissions
+Operation:
+  ENUM:
+    0:
+      System:
+        NEWTYPE:
+          TYPENAME: SystemOperation
+    1:
+      User:
+        STRUCT:
+          - application_id:
+              TYPENAME: ApplicationId
+          - bytes: BYTES
+OperationResult:
+  NEWTYPESTRUCT: BYTES
+OracleResponse:
+  ENUM:
+    0:
+      Service:
+        NEWTYPE: BYTES
+    1:
+      Http:
+        NEWTYPE:
+          TYPENAME: Response
+    2:
+      Blob:
+        NEWTYPE:
+          TYPENAME: BlobId
+    3:
+      Assert: UNIT
+    4:
+      Round:
+        NEWTYPE:
+          OPTION: U32
+    5:
+      Event:
+        TUPLE:
+          - TYPENAME: EventId
+          - BYTES
+    6:
+      EventExists:
+        NEWTYPE:
+          TYPENAME: EventId
+    7:
+      Checkpoint:
+        STRUCT:
+          - execution_state_blobs:
+              SEQ:
+                TYPENAME: CryptoHash
+          - used_blobs:
+              SEQ:
+                TYPENAME: BlobId
+          - outbox_block_hashes:
+              SEQ:
+                TYPENAME: CryptoHash
+          - inbox_cursors:
+              SEQ:
+                TUPLE:
+                  - TYPENAME: ChainId
+                  - TYPENAME: Cursor
+OutgoingMessage:
+  STRUCT:
+    - destination:
+        TYPENAME: ChainId
+    - authenticated_owner:
+        OPTION:
+          TYPENAME: AccountOwner
+    - grant:
+        TYPENAME: Amount
+    - refund_grant_to:
+        OPTION:
+          TYPENAME: Account
+    - kind:
+        TYPENAME: MessageKind
+    - message:
+        TYPENAME: Message
+PostedMessage:
+  STRUCT:
+    - authenticated_owner:
+        OPTION:
+          TYPENAME: AccountOwner
+    - grant:
+        TYPENAME: Amount
+    - refund_grant_to:
+        OPTION:
+          TYPENAME: Account
+    - kind:
+        TYPENAME: MessageKind
+    - message:
+        TYPENAME: Message
+Response:
+  STRUCT:
+    - status: U16
+    - headers:
+        SEQ:
+          TYPENAME: Header
+    - body: BYTES
+RestrictedEventId:
+  STRUCT:
+    - stream_id:
+        TYPENAME: StreamId
+    - index: U32
+RootKey:
+  ENUM:
+    0:
+      NetworkDescription: UNIT
+    1:
+      BlockExporterState:
+        NEWTYPE: U32
+    2:
+      ChainState:
+        NEWTYPE:
+          TYPENAME: ChainId
+    3:
+      BlockHash:
+        NEWTYPE:
+          TYPENAME: CryptoHash
+    4:
+      BlobId:
+        NEWTYPE:
+          TYPENAME: BlobId
+    5:
+      Event:
+        NEWTYPE:
+          TYPENAME: ChainId
+    6:
+      BlockByHeight:
+        NEWTYPE:
+          TYPENAME: ChainId
+    7:
+      EventBlockHeight:
+        NEWTYPE:
+          TYPENAME: ChainId
+Round:
+  ENUM:
+    0:
+      Fast: UNIT
+    1:
+      MultiLeader:
+        NEWTYPE: U32
+    2:
+      SingleLeader:
+        NEWTYPE: U32
+    3:
+      Validator:
+        NEWTYPE: U32
+Secp256k1PublicKey:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 65
+Secp256k1Signature:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 64
+StreamId:
+  STRUCT:
+    - application_id:
+        TYPENAME: GenericApplicationId
+    - stream_name:
+        TYPENAME: StreamName
+StreamName:
+  NEWTYPESTRUCT: BYTES
+SystemMessage:
+  ENUM:
+    0:
+      Credit:
+        STRUCT:
+          - target:
+              TYPENAME: AccountOwner
+          - amount:
+              TYPENAME: Amount
+          - source:
+              TYPENAME: AccountOwner
+    1:
+      Withdraw:
+        STRUCT:
+          - owner:
+              TYPENAME: AccountOwner
+          - amount:
+              TYPENAME: Amount
+          - recipient:
+              TYPENAME: Account
+    2:
+      CheckpointAck:
+        STRUCT:
+          - latest_received_cursor:
+              TYPENAME: Cursor
+SystemOperation:
+  ENUM:
+    0:
+      Transfer:
+        STRUCT:
+          - owner:
+              TYPENAME: AccountOwner
+          - recipient:
+              TYPENAME: Account
+          - amount:
+              TYPENAME: Amount
+    1:
+      Claim:
+        STRUCT:
+          - owner:
+              TYPENAME: AccountOwner
+          - target_id:
+              TYPENAME: ChainId
+          - recipient:
+              TYPENAME: Account
+          - amount:
+              TYPENAME: Amount
+    2:
+      OpenChain:
+        NEWTYPE:
+          TYPENAME: OpenChainConfig
+    3:
+      CloseChain: UNIT
+    4:
+      ChangeOwnership:
+        STRUCT:
+          - super_owners:
+              SEQ:
+                TYPENAME: AccountOwner
+          - owners:
+              SEQ:
+                TUPLE:
+                  - TYPENAME: AccountOwner
+                  - U64
+          - first_leader:
+              OPTION:
+                TYPENAME: AccountOwner
+          - multi_leader_rounds: U32
+          - open_multi_leader_rounds: BOOL
+          - timeout_config:
+              TYPENAME: TimeoutConfig
+    5:
+      ChangeApplicationPermissions:
+        NEWTYPE:
+          TYPENAME: ApplicationPermissions
+    6:
+      PublishModule:
+        STRUCT:
+          - module_id:
+              TYPENAME: ModuleId
+    7:
+      PublishDataBlob:
+        STRUCT:
+          - blob_hash:
+              TYPENAME: CryptoHash
+    8:
+      VerifyBlob:
+        STRUCT:
+          - blob_id:
+              TYPENAME: BlobId
+    9:
+      CreateApplication:
+        STRUCT:
+          - module_id:
+              TYPENAME: ModuleId
+          - parameters: BYTES
+          - instantiation_argument: BYTES
+          - required_application_ids:
+              SEQ:
+                TYPENAME: ApplicationId
+    10:
+      Admin:
+        NEWTYPE:
+          TYPENAME: AdminOperation
+    11:
+      ProcessNewEpoch:
+        NEWTYPE:
+          TYPENAME: Epoch
+    12:
+      UpdateStream:
+        STRUCT:
+          - application_id:
+              TYPENAME: ApplicationId
+          - chain_id:
+              TYPENAME: ChainId
+          - stream_id:
+              TYPENAME: StreamId
+          - first_index: U32
+          - next_index: U32
+    13:
+      Checkpoint: UNIT
+TimeDelta:
+  NEWTYPESTRUCT: U64
+TimeoutConfig:
+  STRUCT:
+    - fast_round_duration:
+        OPTION:
+          TYPENAME: TimeDelta
+    - base_timeout:
+        TYPENAME: TimeDelta
+    - timeout_increment:
+        TYPENAME: TimeDelta
+    - fallback_duration:
+        TYPENAME: TimeDelta
+Timestamp:
+  NEWTYPESTRUCT: U64
+Transaction:
+  ENUM:
+    0:
+      ReceiveMessages:
+        NEWTYPE:
+          TYPENAME: IncomingBundle
+    1:
+      ExecuteOperation:
+        NEWTYPE:
+          TYPENAME: Operation
+VmRuntime:
+  ENUM:
+    0:
+      Wasm: UNIT
+    1:
+      Evm: UNIT


### PR DESCRIPTION
## Motivation

Nothing records how storage lays out its keys, nor what the bytes under them decode to. That
knowledge lives implicitly in `RootKey`, a handful of private byte constants, and the
`linera-views` key derivation — so a raw key-value pair pulled out of ScyllaDB or RocksDB cannot
be interpreted without reading the code that wrote it.

That has three costs:

1. **No tooling.** There is no way to render stored data as JSON for an explorer or for
   debugging. `decode_key.rs` decodes a partition key into its `RootKey` variant, but stops
   there — nothing describes what lives *inside* a partition.
2. **Format changes fail silently.** #6723 and #6724 both change the on-disk layout, and their
   failure mode is a store that looks *empty* rather than one that refuses to open. Nothing
   recorded anywhere would catch reading old data with new code.
3. **Convention changes are unreviewable.** The key space has three levels with three different
   encoding conventions; changing any of them today means reasoning about the blast radius
   rather than reading a diff.

This is the first step of a longer plan: a description precise enough to decode with, whose
digest can serve as the format version, and against which a later convention cleanup becomes a
readable snapshot diff.

## Proposal

### `EntryKey`: name the fixed keys

The five private constants become one public enum next to `RootKey`:

```rust
pub enum EntryKey { Blob, BlobState, LiteCertificate, Block, NetworkDescription }
```

`as_bytes` spells the encoding out so reads stay allocation-free, and
`tests::entry_keys_match_bcs` checks it against `bcs::to_bytes` — the fast path cannot drift
from the canonical encoding.

**No stored byte changes.** A fieldless enum's BCS encoding is its variant index, so declaring
them in their existing order reproduces `0..4` exactly. The snapshot's byte values are identical
before and after this refactor (`4 2 3 0 1`).

This also makes an existing smell visible in the type rather than hidden in the constants: the
five keys were numbered in one global sequence although they belong to **three disjoint
partitions** — `Blob`/`BlobState` under `BlobId`, `LiteCertificate`/`Block` under `BlockHash`,
`NetworkDescription` on its own. Splitting them into per-partition enums would be the natural
next step, but it *does* renumber (each enum restarts at 0), so it belongs with the convention
change where it will show up as a snapshot diff rather than being smuggled into a descriptive PR.

### The layout description

`linera_storage::format` describes the partition layout, snapshotted with `insta` following the
pattern `linera-rpc/tests/format.rs` already uses for wire types.

Scope is deliberately the part that is small, fixed and fully enumerable **today**: the
`RootKey` partitions and the flat tables inside them. The two partitions holding root views
(`ChainState`, `BlockExporterState`) are named but their interiors are not described — that
needs generation from the `linera-views` derive macro, which is #6783.

Three things keep it honest rather than decorative:

- It **enumerates `EntryKey` and asks each variant for its own bytes**, so there are no literals
  to retype. Variant names come from the derived `Debug`, so there is no second name-to-variant
  mapping either.
- `root_key_variants_match_declaration` **checks the declared partition tags against the BCS
  encoding of real `RootKey` values**. Reordering the enum fails that test rather than silently
  invalidating the schema — and it subsumes what the existing `CHAIN_ID_TAG` / `BLOB_ID_TAG` /
  `EVENT_ID_TAG` assertions check by hand.
- `entry_keys_match_bcs`, as above.

The schema records the property that a partition's payload is *context for the keys inside it*:
`Event(ChainId)` plus a `bcs(RestrictedEventId)` key reconstitutes a full `EventId`, because the
chain is not repeated in the key. A decoder that ignores this renders half-keys.

### The type registry, and checking the description against it

A layout that names types is only useful if those names resolve to something. `linera-storage/tests/format.rs`
traces the storage value types into a 62-type `serde-reflection` registry, snapshotted the same
way — the same machinery `linera-rpc` uses for the wire surface, which covers the RPC types but
not the storage ones.

`schema_type_names_resolve` then checks that **every type the layout names is one the registry
defines**. That is what turns the names from strings into references, and it earned its keep
immediately: it failed on `ConfirmedBlock`, which has a hand-written transparent `Serialize`
(`block.rs:99-109`) delegating to the `Block` it wraps — its hash is recomputed on
deserialization rather than stored. So the bytes under `BLOCK_KEY` are a plain `Block` encoding,
and the description had been naming a type no decoder could use. Corrected, with the reason
recorded next to the entry.

`RestrictedEventId` is made public for the same reason: the layout named a type consumers could
not resolve.

Getting the registry to build takes an explicit `trace_type` per enum — serde-reflection only
discovers variants reachable from what you trace, so `AdminOperation`, `VmRuntime`, `Operation`,
`SystemOperation` and nine others each need one. Same reason `linera-rpc` traces every enum
individually; noted in the file so the next person does not rediscover it.

### Boundaries, stated in the module

The description starts at the root key. Backends wrap it further — ScyllaDB prepends a zero byte
because it requires non-empty partition keys (`get_big_root_key`), RocksDB prefixes the data
domain with `ROOT_KEY_DOMAIN` — and those belong to `linera-views`, so they are named but not
modelled.

Blob contents and event values are marked `Opaque`: they are user-defined bytes and no schema
can claim otherwise.

## Test Plan

- `cargo test -p linera-storage --lib format` — three tests.
- `cargo test -p linera-storage --test format` — two tests, including the cross-check.
- `cargo clippy --locked --all-targets --all-features --workspace` — clean.
- Nightly `cargo fmt --check`.

The two snapshots are the artifacts under review: `linera-storage/src/snapshots/` for the
layout, `linera-storage/tests/snapshots/` for the registry.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

Purely descriptive — no stored bytes change.

## Links

- #6783 — views describing their own key layout, which is what fills in the two partitions this
  PR can only name.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
