### PR TITLE
State that no committee certifies its own introduction

### DIFF
--- a/linera-chain/src/manager/proof/locking.rs
+++ b/linera-chain/src/manager/proof/locking.rs
@@ -46,7 +46,7 @@ use crate::{
         CorrectValidatorInIntersection,
     },
     manager::proof::{
-        model::{ConsensusInstance, DurablePersistence, EpochAgreement, SerializedChainState},
+        model::{ConsensusInstance, DurablePersistence, EpochAgreement, SequentialChainState},
         rounds::{CurrentRoundMonotone, RoundFloor, VoteRoundBelowCurrentRound},
         voting::{
             ConfirmationNeedsValidatedCertificate, ConfirmationOnlyInCurrentRound,
@@ -200,19 +200,19 @@ pub trait CastValidationRoundFloor:
 ///
 /// The argument needs the two votes to be observed by the *same* manager state, which is
 /// [`DurablePersistence`] — a validator that lost its state across a crash could sign twice —
-/// and [`SerializedChainState`], which rules out two concurrent handlers each seeing the
+/// and [`SequentialChainState`], which rules out two concurrent handlers each seeing the
 /// pre-vote state. ∎
 ///
 /// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
 /// [`validated_vote`]: field@crate::manager::ChainManager::validated_vote
 /// [`Outcome::Skip`]: crate::manager::Outcome::Skip
-/// [`SerializedChainState`]: crate::manager::proof::model::SerializedChainState
+/// [`SequentialChainState`]: crate::manager::proof::model::SequentialChainState
 pub trait OneValidationVotePerRound:
     ProposalGate
     + CastValidationRoundFloor
     + ValidationRoundStrictlyIncreases
     + DurablePersistence
-    + SerializedChainState
+    + SequentialChainState
 {
 }
 
@@ -246,7 +246,7 @@ pub trait OneValidationVotePerRound:
 /// branch instead.)
 ///
 /// As in [`OneValidationVotePerRound`], the argument consumes [`DurablePersistence`] and
-/// [`SerializedChainState`]. ∎
+/// [`SequentialChainState`]. ∎
 ///
 /// **Where this is fragile.** In the non-fast case the guard lives in
 /// [`ChainManager::check_validated_block`], i.e. at the *call site*, not inside
@@ -260,7 +260,7 @@ pub trait OneValidationVotePerRound:
 /// [`ChainManager::check_validated_block`]: crate::manager::ChainManager::check_validated_block
 /// [`ChainManager::current_round`]: method@crate::manager::ChainManager::current_round
 /// [`Outcome::Skip`]: crate::manager::Outcome::Skip
-/// [`SerializedChainState`]: crate::manager::proof::model::SerializedChainState
+/// [`SequentialChainState`]: crate::manager::proof::model::SequentialChainState
 pub trait OneConfirmationVotePerRound:
     ProposalGate
     + FastConfirmationNeedsEmptyLock
@@ -268,7 +268,7 @@ pub trait OneConfirmationVotePerRound:
     + LockRoundMonotone
     + RoundFloor
     + DurablePersistence
-    + SerializedChainState
+    + SequentialChainState
 {
 }
 

--- a/linera-chain/src/manager/proof/model.rs
+++ b/linera-chain/src/manager/proof/model.rs
@@ -114,13 +114,36 @@ pub trait CorrectValidator {}
 /// [`ChainTipState::verify_block_chaining`]: crate::ChainTipState::verify_block_chaining
 pub trait ConflictingBlocks {}
 
-/// **Assumption (Maximum Byzantine weight).** In the committee governing a chain's epoch, the
-/// total [`Committee::weight`] of faulty validators is strictly less than
-/// [`Committee::validity_threshold`], i.e. at most `f⁺ − 1` where `f⁺ = ⌈N/3⌉`.
+/// **Assumption (Maximum Byzantine weight, per epoch).** For **every** epoch whose committee has
+/// not been revoked, the total [`Committee::weight`] of faulty validators *in that committee* is
+/// strictly less than its [`Committee::validity_threshold`] — at most `f⁺ − 1` where
+/// `f⁺ = ⌈N/3⌉`, equivalently strictly below one third of that committee's total weight.
 ///
-/// Equivalently, faulty weight is strictly below one third of the total. This is the only fault
-/// bound assumed anywhere in the specification.
+/// This is the only fault bound assumed anywhere in the specification, and it is assumed once per
+/// live committee rather than once globally. The quantifier carries most of the content.
 ///
+/// *Committees are bounded independently.* Membership and weights differ between epochs, so this
+/// is a separate hypothesis for each: a validator may hold weight in several committees, or in
+/// none, and being faulty is a property of a validator *within* a committee. Every quorum argument
+/// here reasons inside a single committee — two quorums drawn from different committees need not
+/// intersect at all — and [`EpochAgreement`] is what confines each argument to one.
+///
+/// *A revoked committee is assumed nothing.* Revocation is exactly the withdrawal of this
+/// hypothesis. Once the admin chain has written a removal event for an epoch — which is what
+/// `Storage::is_epoch_revoked` tests — that committee may be arbitrarily corrupt and its
+/// signatures establish nothing on their own. This is why material from a revoked epoch is
+/// admitted only when a still-trusted committee vouches for it, as
+/// `ChainWorkerState::select_message_bundles` does for bundles whose epoch has lapsed.
+///
+/// *Not revoking is not free.* Revocations are ordered
+/// ([`AdminOperation::RemoveCommittee`] requires them to be sequential), so the revoked epochs
+/// form a prefix and the assumed-correct ones a suffix. That suffix gains a committee whenever one
+/// is created and loses one only on revocation. A deployment that never revokes is therefore
+/// assuming, permanently, that *every committee it has ever created* still satisfies the bound —
+/// including validator sets long since rotated out. The assumption does not weaken with time; it
+/// accumulates.
+///
+/// [`AdminOperation::RemoveCommittee`]: linera_execution::system::AdminOperation::RemoveCommittee
 /// [`Committee::weight`]: linera_execution::committee::Committee::weight
 /// [`Committee::validity_threshold`]: linera_execution::committee::Committee::validity_threshold
 pub trait MaxByzantineWeight {}

--- a/linera-chain/src/manager/proof/model.rs
+++ b/linera-chain/src/manager/proof/model.rs
@@ -201,7 +201,7 @@ pub trait UnforgeableSignatures {}
 /// [`ChainManagerInfo`]: crate::manager::ChainManagerInfo
 pub trait DurablePersistence {}
 
-/// **Assumption (Serialized instance state).** The transitions of one consensus instance are
+/// **Assumption (Sequential instance state).** The transitions of one consensus instance are
 /// mutually exclusive and each runs to completion: no two of them interleave their reads and
 /// writes of the same [`ChainManager`](crate::manager::ChainManager).
 ///
@@ -246,7 +246,7 @@ pub trait DurablePersistence {}
 /// [`UnlockingJustification`]: crate::manager::proof::safety::UnlockingJustification
 /// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
 /// [`ChainManager::create_vote`]: crate::manager::ChainManager::create_vote
-pub trait SerializedChainState {}
+pub trait SequentialChainState {}
 
 /// **Assumption (Atomic persistence).** A single `WritableKeyValueStore::write_batch` — one batch
 /// against one root key — is applied atomically, within whatever key-count and size limits the
@@ -268,7 +268,7 @@ pub trait SerializedChainState {}
 /// `write_batch`. A crash part-way therefore leaves a resumable journal rather than a torn
 /// state. That slow path requires exclusive access to the keys under the chain's root — it fails
 /// with `JournalingError::JournalRequiresExclusiveAccess` otherwise — which is exactly what
-/// [`SerializedChainState`] supplies.
+/// [`SequentialChainState`] supplies.
 ///
 /// **Two things are called `write_batch`, and only one is atomic.** The store-level one above is.
 /// `DbStorage::write_batch` is not: it takes a `MultiPartitionBatch` keyed by root key, opens a

--- a/linera-chain/src/manager/proof/voting.rs
+++ b/linera-chain/src/manager/proof/voting.rs
@@ -266,7 +266,7 @@ pub trait FastConfirmationNeedsEmptyLock:
 /// **Lemma (A non-fast confirmation requires a validated certificate in the same round).** If a
 /// correct validator casts a confirmation vote for block `A` in a round `r` other than
 /// [`Round::Fast`](linera_base::data_types::Round::Fast), then a [`ValidatedBlockCertificate`]
-/// for `A` in round `r`, valid for the committee, existed at that moment.
+/// for `A` in round `r`, valid for the committee of its epoch, existed at that moment.
 ///
 /// *Code correspondence.*
 ///

--- a/linera-chain/src/manager/proof/voting.rs
+++ b/linera-chain/src/manager/proof/voting.rs
@@ -15,7 +15,7 @@
 //!
 //! [`CertificateCarriesCorrectVote`]: crate::data_types::proof::quorum::CertificateCarriesCorrectVote
 
-use crate::manager::proof::model::{CorrectValidator, SerializedChainState};
+use crate::manager::proof::model::{CorrectValidator, SequentialChainState};
 
 /// **Lemma (Vote construction sites).** A correct validator signs a block-related vote only in
 /// [`ChainManager::create_vote`] and [`ChainManager::create_final_vote`], and a timeout vote only
@@ -90,7 +90,7 @@ pub trait VoteConstructionSites: CorrectValidator {}
 ///   `chain.manager.check_validated_block(&certificate)`. A `Skip` outcome returns early; an
 ///   `Err` propagates via `?`. Only `Ok(Accept)` falls through.
 ///
-/// By [`SerializedChainState`] no other transition on this instance interleaves, so the state
+/// By [`SequentialChainState`] no other transition on this instance interleaves, so the state
 /// the guard inspected is the state `create_vote` / `create_final_vote` then mutates. ∎
 ///
 /// **Where this is fragile.** The guards are at the call sites, not inside the signing methods:
@@ -106,7 +106,7 @@ pub trait VoteConstructionSites: CorrectValidator {}
 /// [`ChainManager::update_signed_proposal`]: crate::manager::ChainManager::update_signed_proposal
 /// [`ChainManager::current_round`]: method@crate::manager::ChainManager::current_round
 /// [`Outcome::Accept`]: crate::manager::Outcome::Accept
-pub trait ProposalGate: SerializedChainState {}
+pub trait ProposalGate: SequentialChainState {}
 
 /// **Lemma (Validation rounds strictly increase).** If a correct validator's
 /// [`validated_vote`] holds a vote in round `s`, it casts no further validation vote in any

--- a/linera-chain/src/proof/checkpoints.rs
+++ b/linera-chain/src/proof/checkpoints.rs
@@ -3,7 +3,7 @@
 
 //! Event streams across a checkpoint boundary.
 
-use crate::manager::proof::model::SerializedChainState;
+use crate::manager::proof::model::SequentialChainState;
 
 /// **Invariant (A stream's readable floor is its first index since the last checkpoint).** For
 /// every event stream of a chain, [`StreamCounts::first_index`] is the index of the first event
@@ -49,7 +49,7 @@ use crate::manager::proof::model::SerializedChainState;
 /// [`previous_event_blocks`]: crate::block::BlockBody::previous_event_blocks
 /// [`previous_event_blocks_hash`]: crate::block::BlockHeader::previous_event_blocks_hash
 /// [`OracleResponse::Event`]: linera_base::data_types::OracleResponse::Event
-pub trait EventFloorTracksCheckpoints: SerializedChainState {}
+pub trait EventFloorTracksCheckpoints: SequentialChainState {}
 
 /// **Lemma (A checkpoint summarizes every user stream that published since the previous one).**
 /// At a checkpoint, each application holding an event stream that has published since the previous
@@ -127,7 +127,7 @@ pub trait CheckpointSummarizesUserStreams: EventFloorTracksCheckpoints {}
 /// to, captured before the checkpoint block runs, and travels in the checkpoint's oracle response.
 /// The checkpoint block's certificate therefore transitively certifies those older blocks, so a
 /// bootstrapping node can rely on them without replaying the chain.
-pub trait CheckpointPreservesConsumptionBoundary: SerializedChainState {}
+pub trait CheckpointPreservesConsumptionBoundary: SequentialChainState {}
 
 /// **Lemma (A checkpoint leaves blob availability unchanged).** Checkpointing neither strands a
 /// blob the chain can still reach nor silently requires one a bootstrapping node cannot obtain.
@@ -153,7 +153,7 @@ pub trait CheckpointPreservesConsumptionBoundary: SerializedChainState {}
 /// node the right to skip replaying history; it does not buy free storage.
 ///
 /// [`OracleResponse::Checkpoint`]: linera_base::data_types::OracleResponse::Checkpoint
-pub trait CheckpointPreservesBlobAvailability: SerializedChainState {}
+pub trait CheckpointPreservesBlobAvailability: SequentialChainState {}
 
 /// **Lemma (A checkpoint restores exactly the execution state it captured).** Applying a
 /// checkpoint's blobs reproduces the chain's execution state as it stood immediately before the
@@ -195,4 +195,4 @@ pub trait CheckpointPreservesBlobAvailability: SerializedChainState {}
 /// convention at the call site rather than by construction.
 ///
 /// [`SafetyStateRecovery`]: crate::manager::proof::locking::SafetyStateRecovery
-pub trait CheckpointRestoresExecutionState: SerializedChainState {}
+pub trait CheckpointRestoresExecutionState: SequentialChainState {}

--- a/linera-chain/src/proof/epochs.rs
+++ b/linera-chain/src/proof/epochs.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Committees, epochs, and how a node comes to trust one.
+//!
+//! A committee is identified by an [`Epoch`], and epochs are managed on the admin chain: created by
+//! [`AdminOperation::CreateCommittee`], retired by [`AdminOperation::RemoveCommittee`]. Every
+//! certificate is judged by the committee for the epoch its block declares, so before anything can
+//! be verified a node must know which committee that is.
+//!
+//! This module is about where that knowledge comes from. The results here are what let the rest of
+//! the specification induct on epochs at all.
+//!
+//! [`Epoch`]: linera_base::data_types::Epoch
+//! [`AdminOperation::CreateCommittee`]: linera_execution::system::AdminOperation::CreateCommittee
+//! [`AdminOperation::RemoveCommittee`]: linera_execution::system::AdminOperation::RemoveCommittee
+
+use crate::manager::proof::model::CorrectValidator;
+
+/// **Theorem (No committee certifies its own introduction).** For every epoch, a node can learn
+/// that epoch's committee only from evidence certified under a *strictly earlier* epoch, or — for
+/// epoch zero alone — from network configuration that is not a certificate at all. The relation
+/// "the committee for `e` was learned from a certificate in epoch `e'`" is therefore well founded,
+/// with `e' < e`.
+///
+/// This is what makes induction on the epoch legitimate, and it is the property a reconfiguration
+/// scheme is easiest to get wrong. Were a committee able to authenticate the evidence that
+/// introduces it — a per-chain genesis configuration naming a committee would do it — an attacker
+/// who could produce such a configuration could mint a committee out of nothing and have it vouch
+/// for itself. Nothing here would detect that, because every signature would check out.
+///
+/// *Code correspondence.*
+///
+/// | | |
+/// |---|---|
+/// | transition | `ExecutionRuntimeContext::get_committee_hashes`, reached from `ChainWorkerState::committee_for_epoch` before `certificate.check` |
+/// | reads | for epoch `0`, `NetworkDescription::genesis_committee_blob_hash`; otherwise the admin chain's [`EPOCH_STREAM_NAME`] event at index `epoch` |
+/// | writes | nothing |
+/// | failure | `ExecutionError::EventsNotFound` when the epoch's event is absent, so the certificate is not verified rather than verified optimistically |
+///
+/// *Proof.* By descent on the epoch.
+///
+/// *The base is not a certificate.* Epoch `0` resolves to
+/// `NetworkDescription::genesis_committee_blob_hash`. A [`NetworkDescription`] is configuration a
+/// node is given, network-wide and identical for every chain. No chain can introduce one, and in
+/// particular creating a chain cannot introduce a committee — the failure mode this theorem exists
+/// to exclude.
+///
+/// *Every step descends.* For `epoch > 0` the committee hash is read from the event at index
+/// `epoch` of the admin chain's epoch stream, written by [`AdminOperation::CreateCommittee`]. To
+/// hold that event a node must have processed the admin-chain block containing it, which by
+/// [`TipAdvancesOnlyOnValidCertificate`] required a valid certificate for that block, judged
+/// against the committee for the epoch that block *declares*. A block declares the epoch its chain
+/// was in before executing, and a block advances the epoch at most once
+/// ([`ChainError::MultipleEpochAdvances`]), so the block introducing epoch `e` declares at most
+/// `e - 1`.
+///
+/// *There is no other route.* `committee_for_epoch` is the sole path from an epoch to a committee
+/// on the verification path, and it consults exactly these two sources. When the event is missing
+/// it fails with `EventsNotFound`; nothing falls back to a committee carried by the certificate
+/// being checked, or by the block, or by the chain being created. ∎
+///
+/// **A missing epoch is recoverable, which is why the strictness costs nothing.** Refusing to
+/// verify a certificate whose epoch a node has not yet learned would be an availability problem if
+/// there were no way to catch up. There is: `EventsNotFound` on the admin chain's stream is a class
+/// in `linera_core::proof::availability::MissingDependenciesAreRecoverable`, and
+/// `send_confirmed_certificate` answers it by pushing the admin chain to that validator before
+/// retrying. So the node learns the epoch and then verifies, in that order — which is the whole
+/// point.
+///
+/// [`EPOCH_STREAM_NAME`]: linera_execution::system::EPOCH_STREAM_NAME
+/// [`NetworkDescription`]: linera_base::data_types::NetworkDescription
+/// [`AdminOperation::CreateCommittee`]: linera_execution::system::AdminOperation::CreateCommittee
+/// [`TipAdvancesOnlyOnValidCertificate`]: crate::manager::proof::commit::TipAdvancesOnlyOnValidCertificate
+/// [`ChainError::MultipleEpochAdvances`]: crate::ChainError::MultipleEpochAdvances
+pub trait CommitteeKnowledgeIsWellFounded: CorrectValidator {}

--- a/linera-chain/src/proof/mod.rs
+++ b/linera-chain/src/proof/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! What a checkpoint preserves.
+//! Reconfiguration and checkpoints.
 //!
 //! A checkpoint lets a node adopt a chain's state at some height without replaying the blocks
 //! below it. Every statement here is a *conservation* claim — "this behaves as it would have
@@ -10,6 +10,8 @@
 //!
 //! | module | covers |
 //! |---|---|
+//! | [`epochs`] | committees, epochs, and how a node comes to trust one |
 //! | [`checkpoints`] | events, messages, blobs and execution state across a checkpoint boundary |
 
 pub mod checkpoints;
+pub mod epochs;

--- a/linera-core/src/proof/assumptions.rs
+++ b/linera-core/src/proof/assumptions.rs
@@ -33,12 +33,12 @@ pub trait EventualSynchrony {}
 /// permanently crashed. It is needed because [`CorrectValidatorsFormQuorum`] only says the
 /// correct validators *hold* enough weight; progress needs them to answer.
 ///
-/// The per-chain serialization of [`SerializedChainState`] means "bounded local time" also
+/// The per-chain serialization of [`SequentialChainState`] means "bounded local time" also
 /// requires that no single chain's queue grows without bound — a chain saturated by requests can
 /// starve its own consensus without any validator being faulty.
 ///
 /// [`CorrectValidator`]: linera_chain::manager::proof::model::CorrectValidator
-/// [`SerializedChainState`]: linera_chain::manager::proof::model::SerializedChainState
+/// [`SequentialChainState`]: linera_chain::manager::proof::model::SequentialChainState
 /// [`CorrectValidatorsFormQuorum`]: linera_chain::data_types::proof::quorum::CorrectValidatorsFormQuorum
 pub trait CorrectValidatorAvailability {}
 

--- a/linera-core/src/proof/availability.rs
+++ b/linera-core/src/proof/availability.rs
@@ -12,7 +12,7 @@
 
 use linera_chain::manager::proof::{
     commit::{CommittedBlock, IncomingBundlesAreSelfDerived},
-    model::{CorrectValidator, SerializedChainState, StorageAtomicity},
+    model::{CorrectValidator, SequentialChainState, StorageAtomicity},
 };
 
 use super::assumptions::{
@@ -62,7 +62,7 @@ use super::assumptions::{
 ///
 /// **What becomes visible early.** Certificates, blobs and events are written to storage shared
 /// across chains — the channel by which chains observe each other at all — while the tip and the
-/// inboxes are per-chain state no other worker reads ([`SerializedChainState`]). Between the two
+/// inboxes are per-chain state no other worker reads ([`SequentialChainState`]). Between the two
 /// writes, then, a block's outputs are globally readable while the producing chain has not yet
 /// recorded the block locally. That is harmless because `certificate.check` precedes every one of
 /// these writes: what becomes visible early is content a quorum has already certified, and by
@@ -288,7 +288,7 @@ pub trait MissingDependenciesAreRecoverable:
 /// [`StorageAtomicity`]: linera_chain::manager::proof::model::StorageAtomicity
 /// [`CorrectValidator`]: linera_chain::manager::proof::model::CorrectValidator
 pub trait EffectsSurviveRestart:
-    StorageAtomicity + SerializedChainState + CorrectValidator
+    StorageAtomicity + SequentialChainState + CorrectValidator
 {
 }
 
@@ -302,7 +302,7 @@ pub trait EffectsSurviveRestart:
 /// `linera_rpc` routes each to the shard owning the target chain, so the request comes from
 /// another worker of the same validator, which built it in `build_network_actions` from its own
 /// persisted outbox for a block it had processed ([`EffectsSurviveRestart`], sender half). No
-/// other validator's word enters, and by [`SerializedChainState`] no other process writes this
+/// other validator's word enters, and by [`SequentialChainState`] no other process writes this
 /// chain's inboxes. `select_message_bundles` additionally drops bundles whose epoch has been
 /// revoked, unless they were already anticipated. ∎
 ///
@@ -311,7 +311,7 @@ pub trait EffectsSurviveRestart:
 /// own provenance.
 ///
 /// [`MessageBundle`]: linera_chain::data_types::MessageBundle
-pub trait InboxHoldsOnlySentBundles: CorrectValidator + SerializedChainState {}
+pub trait InboxHoldsOnlySentBundles: CorrectValidator + SequentialChainState {}
 
 /// **Lemma (A bundle is consumed at most once).** No two blocks of a chain consume the same
 /// [`MessageBundle`] from the same origin, even though delivery is at-least-once.

--- a/linera-core/src/proof/notifications.rs
+++ b/linera-core/src/proof/notifications.rs
@@ -129,7 +129,8 @@ pub trait NoProofDependsOnNotifications: NotificationsAreBestEffort {}
 ///
 /// Serving them is the ordinary node surface: `download_certificate`, `download_certificates` and
 /// `download_certificates_by_heights`. A node that receives one of these notifications can fetch
-/// the certificate, verify it against the committee, and push it onward — `send_confirmed_certificate`
+/// the certificate, verify it against the committee for its epoch, and push it onward —
+/// `send_confirmed_certificate`
 /// is exactly that path. ∎
 ///
 /// This is the precise sense in which a notification is worth acting on despite carrying no

--- a/linera-spec/src/lib.rs
+++ b/linera-spec/src/lib.rs
@@ -106,7 +106,7 @@
 //!
 //! ```text
 //!  MaxByzantineWeight, UnforgeableSignatures,           EventualSynchrony, ClockAccuracy,
-//!  DurablePersistence, SerializedChainState,            CorrectValidatorAvailability,
+//!  DurablePersistence, SequentialChainState,            CorrectValidatorAvailability,
 //!  EpochAgreement, DeterministicExecution               ActiveCorrectDriver, LeaderFairness,
 //!         |                                             RoundTimeoutGrowth, FullReachability
 //!         v                                                     |


### PR DESCRIPTION
## Motivation

Opens the reconfiguration theme with its one unconditionally provable result, and renames an assumption whose name collides with an unrelated concept.

Committee reconfiguration is the largest area the specification does not cover: `EpochAgreement` assumes committees away rather than proving anything about them. Before any of that can be stated, one property has to be settled — that inducting on the epoch is legitimate at all.

## Proposal

### `CommitteeKnowledgeIsWellFounded` (new)

New module `linera_chain::proof::epochs`.

**No committee certifies its own introduction.** A node can learn an epoch's committee only from evidence certified under a *strictly earlier* epoch, or — for epoch zero alone — from network configuration that is not a certificate at all.

- **The base is not a certificate.** Epoch `0` resolves to `NetworkDescription::genesis_committee_blob_hash`. A `NetworkDescription` is configuration, network-wide and identical for every chain. No chain can introduce one, so *creating a chain cannot introduce a committee* — the failure mode this theorem exists to exclude.
- **Every step descends.** For `epoch > 0` the committee hash comes from the admin chain's `EPOCH_STREAM_NAME` event at index `epoch`. Holding that event requires having processed the admin-chain block containing it, which required a valid certificate judged against the epoch *that block declares* — and since a block declares the epoch its chain was in before executing, and advances the epoch at most once (`MultipleEpochAdvances`), the block introducing epoch `e` declares at most `e - 1`.
- **There is no other route.** `committee_for_epoch` is the only path from an epoch to a committee on the verification path, and it consults exactly those two sources. When the event is missing it fails with `EventsNotFound` — nothing falls back to a committee carried by the certificate being checked, by the block, or by the chain being created.

This is what makes induction on the epoch legitimate, and it is the property a reconfiguration scheme is easiest to get wrong. If a committee could authenticate the evidence introducing it — a per-chain genesis configuration naming a committee would do it — a committee could be minted from nothing and vouch for itself, with every signature checking out.

**Strictness costs nothing here**, because a missing epoch is recoverable: `EventsNotFound` on the admin chain's stream is already a class in `MissingDependenciesAreRecoverable`, and `send_confirmed_certificate` answers it by pushing the admin chain before retrying. The node learns the epoch and *then* verifies, in that order.

### `MaxByzantineWeight` is now per epoch

The bound previously read "in the committee governing a chain's epoch", which is implicitly per-committee but says nothing about *which* committees must satisfy it. It now quantifies explicitly: **for every epoch whose committee has not been revoked**, faulty weight in that committee is strictly below its validity threshold.

Three things follow from the quantifier, all previously unstated:

- **Committees are bounded independently.** Membership and weights differ between epochs, so being faulty is a property of a validator *within* a committee — one may hold weight in several, or none. Every quorum argument reasons inside a single committee, since quorums from different committees need not intersect, and `EpochAgreement` is what confines each argument to one.
- **A revoked committee is assumed nothing.** Revocation is exactly the withdrawal of this hypothesis: once the admin chain has written a removal event, that committee may be arbitrarily corrupt and its signatures establish nothing alone. This is why material from a revoked epoch is admitted only when a still-trusted committee vouches for it — `select_message_bundles` is one such site.
- **Not revoking is not free.** Revocations are sequential, so revoked epochs form a prefix and assumed-correct ones a suffix. That suffix gains a committee on every creation and loses one only on revocation, so a deployment that never revokes is assuming — permanently — that *every committee it has ever created* still satisfies the bound, including validator sets long since rotated out. The assumption does not weaken with time; it accumulates.

Two neighbouring statements said "valid for the committee" where the per-epoch framing makes the ambiguity worth removing (`voting.rs`, `notifications.rs`); both now say "the committee of/for its epoch". Neither changes a conclusion.

### `SerializedChainState` → `SequentialChainState`

The assumption is about serializability in the concurrency sense — transitions are mutually exclusive and each runs to completion. In a codebase where `Serialize`, `Deserialize` and `bcs::to_bytes` are everywhere, and where the neighbouring `CheckpointRestoresExecutionState` genuinely does discuss serializing a view, the old name reads as "the chain state, serialized".

25 references across 7 files. The identifiers are compiler-checked; the statement's own label (`**Assumption (Serialized instance state)**`) is not, and needed updating by hand — the same class of unchecked prose reference that survived the earlier `proof::durability` rename.

## Test Plan

CI. Documentation-only apart from the trait rename, which has no runtime footprint: the statements are marker traits with no members, implementors, or call sites. `cargo doc --all-features` under `-D warnings` passes, which is what checks that every cited item resolves; `cargo +nightly fmt --check` and `cargo clippy --all-features` are clean.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6692 — introduced `SerializedChainState` and `MissingDependenciesAreRecoverable`.
- #6738 — checkpoint conservation, including `CheckpointRecertifiesReferencedBlocks`, the other place epochs and trust interact.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)