### PR TITLE
Sparse sender catch-up for block proposals

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -663,6 +663,7 @@ where
         bundle: MessageBundle,
         local_time: Timestamp,
         add_to_received_log: bool,
+        allow_sparse_catchup: bool,
     ) -> Result<(), ChainError> {
         assert!(!bundle.messages.is_empty());
         let chain_id = self.chain_id();
@@ -691,7 +692,7 @@ where
 
         // Process the inbox bundle and update the inbox state.
         let newly_added = inbox
-            .add_bundle(bundle)
+            .add_bundle(bundle, allow_sparse_catchup)
             .await
             .map_err(|error| match error {
                 InboxError::ViewError(error) => ChainError::ViewError(error),
@@ -1333,7 +1334,9 @@ where
             self.block_zero_executed_at.set(local_time);
         }
         self.execution_state_hash.set(Some(block.header.state_hash));
-        let recipients = self.process_outgoing_messages(block, tracked).await?;
+        let recipients = self
+            .process_outgoing_messages(block, tracked, false)
+            .await?;
 
         for recipient in recipients {
             self.previous_message_blocks
@@ -1368,6 +1371,7 @@ where
         &mut self,
         block: &ConfirmedBlock,
         tracked: Option<&ChainIdSet>,
+        allow_sparse_catchup: bool,
     ) -> Result<BTreeSet<StreamId>, ChainError> {
         let hash = block.inner().hash();
         let block = block.inner().inner();
@@ -1375,7 +1379,8 @@ where
         if height < self.tip_state.get().next_block_height {
             return Ok(BTreeSet::new());
         }
-        self.process_outgoing_messages(block, tracked).await?;
+        self.process_outgoing_messages(block, tracked, allow_sparse_catchup)
+            .await?;
         let updated_streams = self.process_emitted_events(block).await?;
         self.preprocessed_blocks.insert(&height, hash)?;
         Ok(updated_streams)
@@ -1496,6 +1501,7 @@ where
         &mut self,
         block: &Block,
         tracked: Option<&ChainIdSet>,
+        allow_sparse_catchup: bool,
     ) -> Result<Vec<ChainId>, ChainError> {
         // Record the messages of the execution. Messages are understood within an
         // application.
@@ -1559,14 +1565,19 @@ where
                         // We have no previously processed block in the outbox, but we are
                         // expecting one - this could be due to an empty outbox having been pruned.
                         // Only process the outbox if the height of the previous message block is
-                        // lower than the tip
-                        if *prev_msg_block_height >= next_height {
+                        // lower than the tip.
+                        //
+                        // Under sparse catch-up we schedule anyway: the recipient may already have
+                        // consumed past this predecessor, and only the recipient can tell. A
+                        // recipient that has *not* answers with `GapDetected`, whose `RevertConfirm`
+                        // repairs this outbox.
+                        if *prev_msg_block_height >= next_height && !allow_sparse_catchup {
                             continue;
                         }
                     }
                     (Some(ref prev_hash), Some((prev_msg_block_hash, _))) => {
-                        // Only process the outbox if the hashes match.
-                        if prev_hash != prev_msg_block_hash {
+                        // Only process the outbox if the hashes match. Same exception as above.
+                        if prev_hash != prev_msg_block_hash && !allow_sparse_catchup {
                             continue;
                         }
                     }

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -267,9 +267,33 @@ where
     /// many validators are faulty.
     ///
     /// Returns `true` if the bundle was new, `false` if it was already in `removed_bundles`.
-    pub(crate) async fn add_bundle(&mut self, bundle: MessageBundle) -> Result<bool, InboxError> {
+    /// `allow_sparse_catchup` permits the sender to skip bundles this chain has *already
+    /// consumed* by anticipation: entries in `removed_bundles` strictly below the incoming
+    /// cursor are dropped rather than treated as a mismatch, because a sparsely catching-up
+    /// sender will never deliver them. Bundles this chain has not consumed are unaffected —
+    /// they still have to arrive in order.
+    pub(crate) async fn add_bundle(
+        &mut self,
+        bundle: MessageBundle,
+        allow_sparse_catchup: bool,
+    ) -> Result<bool, InboxError> {
         // Record the latest cursor.
         let cursor = Cursor::from(&bundle);
+        if allow_sparse_catchup {
+            // Drop anticipated removals the sparse sender is skipping over. Their effects are
+            // already in this chain's execution state; the equality check they would have
+            // performed on arrival is redundant with the one a quorum ran at voting time.
+            while let Some(previous_bundle) = self.removed_bundles.front().await? {
+                if Cursor::from(&previous_bundle) >= cursor {
+                    break;
+                }
+                tracing::debug!(
+                    "Dropping anticipated bundle {:?}: sender is catching up sparsely past it",
+                    previous_bundle
+                );
+                self.removed_bundles.delete_front();
+            }
+        }
         ensure!(
             cursor >= *self.next_cursor_to_add.get(),
             InboxError::IncorrectOrder {

--- a/linera-chain/src/unit_tests/inbox_tests.rs
+++ b/linera-chain/src/unit_tests/inbox_tests.rs
@@ -44,7 +44,10 @@ async fn test_inbox_add_then_remove_skippable() {
     let hash = CryptoHash::test_hash("1");
     let mut view = InboxStateView::new().await;
     // Add one bundle.
-    assert!(view.add_bundle(make_bundle(hash, 0, 0, [0])).await.unwrap());
+    assert!(view
+        .add_bundle(make_bundle(hash, 0, 0, [0]), false)
+        .await
+        .unwrap());
     // Remove the same bundle
     assert!(view
         .remove_bundle(&make_bundle(hash, 0, 0, [0]))
@@ -52,7 +55,7 @@ async fn test_inbox_add_then_remove_skippable() {
         .unwrap());
     // Fail to add an old bundle.
     assert_matches!(
-        view.add_bundle(make_bundle(hash, 0, 0, [0])).await,
+        view.add_bundle(make_bundle(hash, 0, 0, [0]), false).await,
         Err(InboxError::IncorrectOrder { .. })
     );
     // Fail to remove an old bundle.
@@ -61,8 +64,14 @@ async fn test_inbox_add_then_remove_skippable() {
         Err(InboxError::IncorrectOrder { .. })
     );
     // Add two more bundles.
-    assert!(view.add_bundle(make_bundle(hash, 0, 1, [1])).await.unwrap());
-    assert!(view.add_bundle(make_bundle(hash, 1, 0, [2])).await.unwrap());
+    assert!(view
+        .add_bundle(make_bundle(hash, 0, 1, [1]), false)
+        .await
+        .unwrap());
+    assert!(view
+        .add_bundle(make_bundle(hash, 1, 0, [2]), false)
+        .await
+        .unwrap());
     // Fail to remove non-matching bundle.
     assert_matches!(
         view.remove_bundle(&make_bundle(hash, 0, 1, [0])).await,
@@ -94,7 +103,10 @@ async fn test_inbox_remove_then_add_skippable() {
         .await
         .unwrap());
     // Add the same bundle
-    assert!(!view.add_bundle(make_bundle(hash, 0, 0, [0])).await.unwrap());
+    assert!(!view
+        .add_bundle(make_bundle(hash, 0, 0, [0]), false)
+        .await
+        .unwrap());
     // Fail to remove an old bundle.
     assert_matches!(
         view.remove_bundle(&make_bundle(hash, 0, 0, [0])).await,
@@ -102,7 +114,7 @@ async fn test_inbox_remove_then_add_skippable() {
     );
     // Fail to add an old bundle.
     assert_matches!(
-        view.add_bundle(make_bundle(hash, 0, 0, [0])).await,
+        view.add_bundle(make_bundle(hash, 0, 0, [0]), false).await,
         Err(InboxError::IncorrectOrder { .. })
     );
     // Remove two more bundles.
@@ -116,30 +128,39 @@ async fn test_inbox_remove_then_add_skippable() {
         .unwrap());
     // Fail to add non-matching bundle.
     assert_matches!(
-        view.add_bundle(make_bundle(hash, 0, 1, [0])).await,
+        view.add_bundle(make_bundle(hash, 0, 1, [0]), false).await,
         Err(InboxError::UnexpectedBundle { .. })
     );
     // Fail to add non-matching bundle (hash).
     assert_matches!(
-        view.add_bundle(make_bundle(CryptoHash::test_hash("2"), 0, 1, [1]))
+        view.add_bundle(make_bundle(CryptoHash::test_hash("2"), 0, 1, [1]), false)
             .await,
         Err(InboxError::UnexpectedBundle { .. })
     );
     // NOT OK to forget about previous consumed bundles while backfilling.
     assert_matches!(
-        view.add_bundle(make_bundle(hash, 1, 0, [2])).await,
+        view.add_bundle(make_bundle(hash, 1, 0, [2]), false).await,
         Err(InboxError::UnexpectedBundle { .. })
     );
     // OK to backfill the two consumed bundles, with one skippable bundle in the middle.
-    assert!(!view.add_bundle(make_bundle(hash, 0, 1, [1])).await.unwrap());
+    assert!(!view
+        .add_bundle(make_bundle(hash, 0, 1, [1]), false)
+        .await
+        .unwrap());
     // Cannot add an unskippable bundle that was visibly skipped already.
     assert_matches!(
-        view.add_bundle(make_unskippable_bundle(hash, 1, 0, [2]))
+        view.add_bundle(make_unskippable_bundle(hash, 1, 0, [2]), false)
             .await,
         Err(InboxError::UnexpectedBundle { .. })
     );
-    assert!(!view.add_bundle(make_bundle(hash, 1, 0, [2])).await.unwrap());
-    assert!(!view.add_bundle(make_bundle(hash, 1, 1, [3])).await.unwrap());
+    assert!(!view
+        .add_bundle(make_bundle(hash, 1, 0, [2]), false)
+        .await
+        .unwrap());
+    assert!(!view
+        .add_bundle(make_bundle(hash, 1, 1, [3]), false)
+        .await
+        .unwrap());
     // Inbox is empty again.
     assert_eq!(view.added_bundles.count(), 0);
     assert_eq!(view.removed_bundles.count(), 0);
@@ -151,7 +172,7 @@ async fn test_inbox_add_then_remove_unskippable() {
     let mut view = InboxStateView::new().await;
     // Add one bundle.
     assert!(view
-        .add_bundle(make_unskippable_bundle(hash, 0, 0, [0]))
+        .add_bundle(make_unskippable_bundle(hash, 0, 0, [0]), false)
         .await
         .unwrap());
     // Remove the same bundle
@@ -161,7 +182,7 @@ async fn test_inbox_add_then_remove_unskippable() {
         .unwrap());
     // Fail to add an old bundle.
     assert_matches!(
-        view.add_bundle(make_unskippable_bundle(hash, 0, 0, [0]))
+        view.add_bundle(make_unskippable_bundle(hash, 0, 0, [0]), false)
             .await,
         Err(InboxError::IncorrectOrder { .. })
     );
@@ -173,11 +194,11 @@ async fn test_inbox_add_then_remove_unskippable() {
     );
     // Add two more bundles.
     assert!(view
-        .add_bundle(make_unskippable_bundle(hash, 0, 1, [1]))
+        .add_bundle(make_unskippable_bundle(hash, 0, 1, [1]), false)
         .await
         .unwrap());
     assert!(view
-        .add_bundle(make_unskippable_bundle(hash, 1, 0, [2]))
+        .add_bundle(make_unskippable_bundle(hash, 1, 0, [2]), false)
         .await
         .unwrap());
     // Fail to remove non-matching bundle.
@@ -227,7 +248,7 @@ async fn test_inbox_remove_then_add_unskippable() {
         .unwrap());
     // Add the same bundle
     assert!(!view
-        .add_bundle(make_unskippable_bundle(hash, 0, 0, [0]))
+        .add_bundle(make_unskippable_bundle(hash, 0, 0, [0]), false)
         .await
         .unwrap());
     // Fail to remove an old bundle.
@@ -238,7 +259,7 @@ async fn test_inbox_remove_then_add_unskippable() {
     );
     // Fail to add an old bundle.
     assert_matches!(
-        view.add_bundle(make_unskippable_bundle(hash, 0, 0, [0]))
+        view.add_bundle(make_unskippable_bundle(hash, 0, 0, [0]), false)
             .await,
         Err(InboxError::IncorrectOrder { .. })
     );
@@ -253,40 +274,38 @@ async fn test_inbox_remove_then_add_unskippable() {
         .unwrap());
     // Fail to add non-matching bundle.
     assert_matches!(
-        view.add_bundle(make_unskippable_bundle(hash, 0, 1, [0]))
+        view.add_bundle(make_unskippable_bundle(hash, 0, 1, [0]), false)
             .await,
         Err(InboxError::UnexpectedBundle { .. })
     );
     // Fail to add non-matching bundle (hash).
     assert_matches!(
-        view.add_bundle(make_unskippable_bundle(
-            CryptoHash::test_hash("2"),
-            0,
-            1,
-            [1]
-        ))
+        view.add_bundle(
+            make_unskippable_bundle(CryptoHash::test_hash("2"), 0, 1, [1]),
+            false
+        )
         .await,
         Err(InboxError::UnexpectedBundle { .. })
     );
     // NOT OK to forget about previous consumed bundles while backfilling.
     assert_matches!(
-        view.add_bundle(make_unskippable_bundle(hash, 1, 1, [3]))
+        view.add_bundle(make_unskippable_bundle(hash, 1, 1, [3]), false)
             .await,
         Err(InboxError::UnexpectedBundle { .. })
     );
     // OK to add the two bundles.
     assert!(!view
-        .add_bundle(make_unskippable_bundle(hash, 0, 1, [1]))
+        .add_bundle(make_unskippable_bundle(hash, 0, 1, [1]), false)
         .await
         .unwrap());
     // Cannot add an unskippable bundle that was visibly skipped already.
     assert_matches!(
-        view.add_bundle(make_unskippable_bundle(hash, 1, 0, [2]))
+        view.add_bundle(make_unskippable_bundle(hash, 1, 0, [2]), false)
             .await,
         Err(InboxError::UnexpectedBundle { .. })
     );
     assert!(!view
-        .add_bundle(make_unskippable_bundle(hash, 1, 1, [3]))
+        .add_bundle(make_unskippable_bundle(hash, 1, 1, [3]), false)
         .await
         .unwrap());
     // Inbox is empty again.
@@ -300,10 +319,13 @@ async fn test_inbox_add_then_remove_mixed() {
     let mut view = InboxStateView::new().await;
     // Add two bundles.
     assert!(view
-        .add_bundle(make_unskippable_bundle(hash, 0, 1, [1]))
+        .add_bundle(make_unskippable_bundle(hash, 0, 1, [1]), false)
         .await
         .unwrap());
-    assert!(view.add_bundle(make_bundle(hash, 1, 0, [2])).await.unwrap());
+    assert!(view
+        .add_bundle(make_bundle(hash, 1, 0, [2]), false)
+        .await
+        .unwrap());
     // Fail to remove non-matching bundle (skippability).
     assert_matches!(
         view.remove_bundle(&make_bundle(hash, 0, 1, [1])).await,
@@ -337,4 +359,81 @@ async fn test_inbox_add_then_remove_mixed() {
     // Inbox is empty again.
     assert_eq!(view.added_bundles.count(), 0);
     assert_eq!(view.removed_bundles.count(), 0);
+}
+
+/// Sparse catch-up: a chain that consumed bundles by anticipation accepts a later bundle
+/// directly, dropping the anticipated entries the sparse sender will never deliver.
+#[tokio::test]
+async fn test_inbox_sparse_catchup_drops_consumed_anticipations() {
+    let hash = CryptoHash::test_hash("1");
+    let mut view = InboxStateView::new().await;
+    // Consume heights 1 and 2 by anticipation, as a validator current on this chain but
+    // behind on the sender does. `next_cursor_to_add` stays at zero throughout.
+    view.remove_bundle(&make_bundle(hash, 1, 0, [1]))
+        .await
+        .unwrap();
+    view.remove_bundle(&make_bundle(hash, 2, 0, [2]))
+        .await
+        .unwrap();
+    assert_eq!(view.removed_bundles.count(), 2);
+    assert_eq!(
+        view.next_block_height_to_receive().unwrap(),
+        BlockHeight::from(0)
+    );
+    // Without the flag the sparse delivery is rejected as a mismatch.
+    let mut strict = view.clone_unchecked().unwrap();
+    assert_matches!(
+        strict.add_bundle(make_bundle(hash, 3, 0, [3]), false).await,
+        Err(InboxError::UnexpectedBundle { .. })
+    );
+    // With it, the stale anticipations are dropped and the bundle is queued.
+    assert!(view
+        .add_bundle(make_bundle(hash, 3, 0, [3]), true)
+        .await
+        .unwrap());
+    assert_eq!(view.removed_bundles.count(), 0);
+    assert_eq!(view.added_bundles.count(), 1);
+}
+
+/// Sparse catch-up must not disturb an exact anticipation match: a bundle that *does*
+/// correspond to the front of the queue is still reconciled against it, not dropped.
+#[tokio::test]
+async fn test_inbox_sparse_catchup_still_matches_exact_anticipation() {
+    let hash = CryptoHash::test_hash("1");
+    let mut view = InboxStateView::new().await;
+    view.remove_bundle(&make_bundle(hash, 1, 0, [1]))
+        .await
+        .unwrap();
+    // Delivered bundle matches the anticipated one: consumed from the queue, not added.
+    assert!(!view
+        .add_bundle(make_bundle(hash, 1, 0, [1]), true)
+        .await
+        .unwrap());
+    assert_eq!(view.removed_bundles.count(), 0);
+    assert_eq!(view.added_bundles.count(), 0);
+    // A mismatching bundle at the same cursor is still rejected under the flag.
+    let mut view = InboxStateView::new().await;
+    view.remove_bundle(&make_bundle(hash, 1, 0, [1]))
+        .await
+        .unwrap();
+    assert_matches!(
+        view.add_bundle(make_bundle(hash, 1, 0, [9]), true).await,
+        Err(InboxError::UnexpectedBundle { .. })
+    );
+}
+
+/// Sparse catch-up does not relax the ordering rule itself: a bundle below
+/// `next_cursor_to_add` is still out of order, flag or not.
+#[tokio::test]
+async fn test_inbox_sparse_catchup_still_rejects_out_of_order() {
+    let hash = CryptoHash::test_hash("1");
+    let mut view = InboxStateView::new().await;
+    assert!(view
+        .add_bundle(make_bundle(hash, 5, 0, [5]), true)
+        .await
+        .unwrap());
+    assert_matches!(
+        view.add_bundle(make_bundle(hash, 4, 0, [4]), true).await,
+        Err(InboxError::IncorrectOrder { .. })
+    );
 }

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -52,6 +52,24 @@ pub struct ChainWorkerConfig {
     pub cross_chain_batch_size_limit: usize,
     /// Whether to attempt recovery via `RevertConfirm` when an inbox gap is detected.
     pub allow_revert_confirm: bool,
+    /// Whether to accept "super-sparse" sender catch-up: a proposer may push only the sender
+    /// blocks its current proposal consumes, omitting message-bearing ancestors the recipient
+    /// has *already consumed* by anticipation.
+    ///
+    /// Two relaxations are enabled together, and only together:
+    ///
+    /// * the sender's outbox will schedule a preprocessed block for a recipient even when the
+    ///   recipient's outbox is not caught up to that block's declared predecessor, deferring the
+    ///   decision to the recipient (which is where the consumption frontier lives);
+    /// * the recipient accepts such an update when it has already consumed past the declared
+    ///   predecessor, and drops the matching stale entries from its anticipation queue.
+    ///
+    /// Bundles the recipient has *not* consumed are still delivered contiguously, so ordering
+    /// guarantees for unskippable bundles are unchanged.
+    ///
+    /// Requires [`Self::allow_revert_confirm`] to be sound: when the recipient reports a genuine
+    /// gap, the resulting `RevertConfirm` is what repairs the sender's outbox high-water mark.
+    pub allow_sparse_sender_catchup: bool,
     /// If set, reset the chain state and re-execute all blocks when the chain
     /// state is detected to be corrupted — but only if the given duration has
     /// elapsed since block 0 was last executed (to prevent reset loops).
@@ -103,6 +121,7 @@ impl Default for ChainWorkerConfig {
             exported_heights_fold_interval: linera_base::time::Duration::from_secs(5),
             cross_chain_batch_size_limit: 1000,
             allow_revert_confirm: false,
+            allow_sparse_sender_catchup: false,
             reset_on_corrupted_chain_state: None,
             recovery_whitelist: None,
         }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -864,7 +864,11 @@ where
             let block =
                 maybe_block.ok_or_else(|| WorkerError::LocalBlockNotFound { height, chain_id })?;
             self.chain
-                .preprocess_block(&block, tracked.as_deref().map(|h| h.inner()))
+                .preprocess_block(
+                    &block,
+                    tracked.as_deref().map(|h| h.inner()),
+                    self.config.allow_sparse_sender_catchup,
+                )
                 .await?;
         }
         Ok(())
@@ -995,7 +999,11 @@ where
         let tracked = self.reconcile_tracked_outboxes().await?;
         let updated_event_streams = self
             .chain
-            .preprocess_block(certificate.value(), tracked.as_deref().map(|h| h.inner()))
+            .preprocess_block(
+                certificate.value(),
+                tracked.as_deref().map(|h| h.inner()),
+                self.config.allow_sparse_sender_catchup,
+            )
             .await?;
         self.save().await?;
         let mut actions = self.create_network_actions(None).await?;
@@ -1284,8 +1292,20 @@ where
 
         // Proactive gap detection: if the sender declares a predecessor height that
         // we haven't received yet, the inbox has a gap.
+        //
+        // Under sparse catch-up there is one exception. `next_height_to_receive` is derived from
+        // `next_cursor_to_add`, which only advances on delivery — so a chain that consumed the
+        // sender's earlier bundles *by anticipation* (the ordinary case for a validator that is
+        // current on this chain but behind on the sender) still reports 0 here while its real
+        // progress sits in `removed_bundles`. When the anticipation queue already reaches the
+        // declared predecessor, the "missing" bundles are ones this chain has consumed and will
+        // never consume again, so this is not a gap.
+        let already_consumed_past_predecessor = |prev: BlockHeight| {
+            self.config.allow_sparse_sender_catchup
+                && last_anticipated_block_height.is_some_and(|last| last >= prev)
+        };
         if let Some(prev) = previous_height {
-            if prev >= next_height_to_receive {
+            if prev >= next_height_to_receive && !already_consumed_past_predecessor(prev) {
                 let chain_id = self.chain_id();
                 if self.config.allow_revert_confirm && self.config.recovery_allowed_for(&chain_id) {
                     warn!(
@@ -1338,6 +1358,7 @@ where
                     bundle,
                     local_time,
                     add_to_received_log,
+                    self.config.allow_sparse_sender_catchup,
                 )
                 .await?;
         }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -179,6 +179,11 @@ where
         self
     }
 
+    fn with_sparse_sender_catchup(mut self) -> Self {
+        self.worker.set_allow_sparse_sender_catchup(true);
+        self
+    }
+
     fn admin_public_key(&self) -> AccountPublicKey {
         self.admin_keypair.public()
     }
@@ -5357,5 +5362,62 @@ where
     );
     assert!(!chain.nonempty_outboxes.get().contains(&chain_2));
     assert!(chain.outbox_counters.get().is_empty());
+    Ok(())
+}
+
+/// Sparse sender catch-up must not admit a *genuine* gap (case B): a recipient that has
+/// neither received nor consumed the sender's earlier bundles still refuses an update whose
+/// declared predecessor it has never seen, flag or no flag. This is the property that keeps
+/// ordering guarantees for unskippable bundles intact.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_sparse_catchup_still_rejects_genuine_gap<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let sender_key_pair = AccountSecretKey::generate();
+    let mut env = TestEnvironment::new(storage_builder.build().await?, false, false)
+        .await
+        .with_sparse_sender_catchup();
+    let chain_2_desc = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ONE)
+        .await;
+    let chain_2 = chain_2_desc.id();
+    let chain_1_desc = dummy_chain_description(1);
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_1_desc,
+            sender_key_pair.public(),
+            chain_2,
+            Amount::from_tokens(10),
+            Vec::new(),
+            Amount::ZERO,
+            vec![],
+        )
+        .await;
+    // Claim a predecessor the recipient has never received and never consumed.
+    let CrossChainRequest::UpdateRecipient {
+        sender,
+        recipient,
+        bundles,
+        ..
+    } = update_recipient_direct(chain_2, &certificate)
+    else {
+        panic!("expected an UpdateRecipient request");
+    };
+    let request = CrossChainRequest::UpdateRecipient {
+        sender,
+        recipient,
+        bundles,
+        previous_height: Some(BlockHeight::from(7)),
+    };
+    assert_matches!(
+        env.worker().handle_cross_chain_request(request).await,
+        Err(WorkerError::ChainError(error))
+            if matches!(*error, ChainError::InboxGapDetected { .. }),
+        "a genuine gap must still be refused under sparse catch-up"
+    );
     Ok(())
 }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -574,11 +574,11 @@ where
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let chain_id = proposal.content.block.chain_id;
         // `sent_cross_chain_updates` tracks per-origin progress for the legacy per-sender
-        // `MissingCrossChainUpdate` path (a non-upgraded validator); `synced_cross_chain_updates`
-        // is the one-shot guard for the aggregated `MissingCrossChainUpdates` path;
+        // `MissingCrossChainUpdate` path (a non-upgraded validator); `cross_chain_update_attempts`
+        // is the two-shot guard for the aggregated `MissingCrossChainUpdates` path;
         // `synced_round_and_height` is the one-shot guard for the round/height mismatch path.
         let mut sent_cross_chain_updates = BTreeMap::new();
-        let mut synced_cross_chain_updates = false;
+        let mut cross_chain_update_attempts = 0u8;
         let mut synced_round_and_height = false;
         let mut publisher_chain_ids_sent = BTreeSet::new();
         let storage = self.local_node.storage_client();
@@ -651,7 +651,7 @@ where
                     bundles,
                 }) if dependencies_chain_id == proposal.content.block.chain_id => {
                     ensure!(
-                        !synced_cross_chain_updates,
+                        cross_chain_update_attempts < 2,
                         NodeError::ResponseHandlingError {
                             error: format!(
                                 "validator still reports missing cross-chain updates for chain \
@@ -659,26 +659,51 @@ where
                             ),
                         }
                     );
-                    synced_cross_chain_updates = true;
-                    tracing::debug!(
-                        remote_node = %self.remote_node.address(),
-                        %chain_id,
-                        bundles = bundles.len(),
-                        "validator reported missing cross-chain updates; syncing them in one batch",
-                    );
-                    // Sync each reported origin chain up to the needed height, collapsing any
-                    // duplicate origins to the highest height.
-                    let mut origin_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
-                    for (origin, height) in bundles {
-                        let target = height.try_add_one()?;
-                        let entry = origin_heights.entry(origin).or_insert(target);
-                        *entry = (*entry).max(target);
+                    cross_chain_update_attempts += 1;
+                    // First attempt: push *only* the sender blocks this proposal consumes
+                    // ("super-sparse"), which is all a validator with
+                    // `allow_sparse_sender_catchup` needs. If the validator does not support it,
+                    // or the gap is a genuine one rather than already-consumed ancestors, it
+                    // reports the same error again and the second attempt falls back to pushing
+                    // each origin's locally-held prefix, exactly as before.
+                    if cross_chain_update_attempts == 1 {
+                        let mut origin_heights: BTreeMap<ChainId, BTreeSet<BlockHeight>> =
+                            BTreeMap::new();
+                        for (origin, height) in &bundles {
+                            origin_heights.entry(*origin).or_default().insert(*height);
+                        }
+                        tracing::debug!(
+                            remote_node = %self.remote_node.address(),
+                            %chain_id,
+                            bundles = bundles.len(),
+                            "validator reported missing cross-chain updates; trying a sparse push",
+                        );
+                        self.send_chain_info_at_heights(
+                            origin_heights,
+                            CrossChainMessageDelivery::Blocking,
+                        )
+                        .await?;
+                    } else {
+                        tracing::debug!(
+                            remote_node = %self.remote_node.address(),
+                            %chain_id,
+                            bundles = bundles.len(),
+                            "sparse push was not enough; syncing full prefixes in one batch",
+                        );
+                        // Sync each reported origin chain up to the needed height, collapsing any
+                        // duplicate origins to the highest height.
+                        let mut origin_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
+                        for (origin, height) in bundles {
+                            let target = height.try_add_one()?;
+                            let entry = origin_heights.entry(origin).or_insert(target);
+                            *entry = (*entry).max(target);
+                        }
+                        self.send_chain_info_up_to_heights(
+                            origin_heights,
+                            CrossChainMessageDelivery::Blocking,
+                        )
+                        .await?;
                     }
-                    self.send_chain_info_up_to_heights(
-                        origin_heights,
-                        CrossChainMessageDelivery::Blocking,
-                    )
-                    .await?;
                 }
                 Err(NodeError::MissingCrossChainUpdate {
                     chain_id,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -751,6 +751,12 @@ where
         self.chain_worker_config.cross_chain_message_chunk_limit = limit;
     }
 
+    /// Enables or disables sparse sender catch-up.
+    #[cfg(with_testing)]
+    pub fn set_allow_sparse_sender_catchup(&mut self, allow: bool) {
+        self.chain_worker_config.allow_sparse_sender_catchup = allow;
+    }
+
     /// Returns the worker's nickname.
     #[instrument(level = "trace", skip(self))]
     pub fn nickname(&self) -> &str {


### PR DESCRIPTION
## Motivation

To accept a block proposal, a validator must already hold the incoming bundles it consumes. When it
does not, it answers `MissingCrossChainUpdates` and the proposer pushes sender blocks — today, every
message-bearing block of that `(sender, recipient)` pair from the validator's height up to the target
(`send_chain_info_up_to_heights`). For a long-lived pair that is the pair's entire message history,
replayed to establish facts about one or two blocks.

Almost all of that history is already *consumed*. A validator that is current on the recipient but
behind on the sender has consumed the sender's earlier bundles **by anticipation**: `remove_bundle`
took its `None` branch each time, pushing onto `removed_bundles` and advancing only
`next_cursor_to_remove`. `next_cursor_to_add` never moved, so `next_block_height_to_receive()` still
reports 0 while the real progress sits in the anticipation queue. The history is replayed purely to
drain that queue in order.

This enables pushing only the sender blocks the current proposal actually consumes.

## Proposal

A new `ChainWorkerConfig::allow_sparse_sender_catchup`, **default `false`** — conway behaviour is
unchanged until it is switched on. The scoping rule is:

> **Sparse *below* the recipient's consumption frontier; contiguous *above* it.**

Only bundles the recipient has already consumed may be skipped. They can never be consumed again, so
dropping them loses nothing. Everything not yet consumed is still delivered contiguously, so ordering
guarantees for unskippable bundles (today, bundles carrying a non-zero grant) are untouched.

Four changes, in dependency order:

1. **`ChainStateView::process_outgoing_messages`** — the binding constraint turned out to be here,
   not on the receiver. When preprocessing a block above the tip, the sender's outbox only schedules
   it for a recipient whose outbox is caught up to that block's `previous_message_blocks` entry;
   otherwise it skips, and the bundle never leaves the outbox, so no cross-chain request is built and
   no notification is emitted. Under the flag we schedule anyway and defer the decision to the
   recipient, which is where the consumption frontier lives.
2. **`ChainWorkerState::process_cross_chain_update`** — accept a declared predecessor at or above
   `next_block_height_to_receive` when the anticipation queue already reaches it. A recipient that has
   *not* consumed past it still reports a gap exactly as before.
3. **`Inbox::add_bundle`** — drop `removed_bundles` entries strictly below an incoming cursor, since a
   sparsely catching-up sender will never deliver them. Exact matches are still reconciled against the
   queue, and the ordering rule itself is unchanged.
4. **`ValidatorUpdater::send_block_proposal`** — the aggregated `MissingCrossChainUpdates` arm becomes
   a two-stage retry: first push only the exact heights reported (`send_chain_info_at_heights`), then
   on a second report fall back to today's full-prefix push. This needs no client-side configuration
   and degrades gracefully against validators that do not have the flag on.

Recovery is the existing one: a recipient that reports a genuine gap produces `GapDetected` →
`RevertConfirm` → `Outbox::revert`, which clears and re-schedules from a sorted set and so repairs the
outbox high-water mark. The flag is only sound alongside `allow_revert_confirm`, and the doc comment
says so.

## Test Plan

`cargo clippy -p linera-chain -p linera-core --all-targets -- -D warnings` clean;
`cargo +nightly-2025-04-03 fmt --all` applied; `cargo test -p linera-chain --lib` (55 passed) and
`cargo test -p linera-core --lib` (188 passed) green.

New tests:

- `test_inbox_sparse_catchup_drops_consumed_anticipations` — a chain that consumed heights 1 and 2 by
  anticipation accepts a bundle at height 3 directly under the flag and drops the stale entries; the
  same delivery is still `UnexpectedBundle` without it.
- `test_inbox_sparse_catchup_still_matches_exact_anticipation` — an exactly matching bundle is still
  reconciled against the queue rather than dropped, and a mismatch at the same cursor is still refused.
- `test_inbox_sparse_catchup_still_rejects_out_of_order` — the flag does not relax `IncorrectOrder`.
- `test_sparse_catchup_still_rejects_genuine_gap` — worker level: with the flag **on**, a recipient
  that has neither received nor consumed the earlier bundles still refuses an update declaring an
  unseen predecessor. This is the assertion that keeps unskippable-bundle ordering intact.

Not yet covered, and the main thing I would like review to weigh in on: an end-to-end test that a
proposer against a flag-enabled validator pushes exactly one sender certificate where it currently
pushes the whole prefix. The pieces are here but the fixture is a chunk of scaffolding, and it is the
measurement that actually justifies the change.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Draft for discussion. The trade-off worth arguing about is in `Inbox::add_bundle`: it converts a
  late, destructive check (`UnexpectedBundle` leading to `CorruptedChainState` on the delivery path)
  into a silent drop. The equality check it removes is redundant with the one a quorum ran at voting
  time under `must_be_present = true`, and its failure mode today is a chain wedge — but it does move
  us further along the axis `manager/proof/commit.rs` already names, where cross-chain integrity
  "degrades with how much of the chain graph each validator executes".
- Follow-on, not included: forbidding implicit skipping entirely (every bundle accepted or rejected in
  sequence) would make the scoping rule sound *by construction* rather than under honest-majority,
  because `next_cursor_to_remove` would then mean "consumed" rather than "consumed or jumped over".
  It needs a compressible bulk-reject to stay DoS-resistant, and an answer to the revoked-epoch
  deadlock that implicit skipping currently escapes.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
