### PR TITLE
State what repairs a lost notification

### DIFF
--- a/linera-core/src/proof/notifications.rs
+++ b/linera-core/src/proof/notifications.rs
@@ -3,11 +3,16 @@
 
 //! What a notification tells a client, and what it does not.
 //!
-//! A [`Notification`] is a hint that shortens the wait between a change and a client noticing it.
-//! From a correct validator it is sound — what it reports really happened — and from any validator
-//! it is best effort, since it may never arrive and carries nothing that could be checked if it
-//! did. The results here fix each half, and together they are the reason for the third: nothing in
-//! this specification may depend on a notification.
+//! A [`Notification`] tells a client that a chain has changed. From a correct validator it is sound
+//! — what it reports really happened — and from any validator it is best effort, since it may never
+//! arrive and carries nothing that could be checked if it did.
+//!
+//! That combination would be alarming if clients merely used notifications to go faster. They do
+//! not: a `ChainListener` acts on them, processing inboxes and following new chains, so an
+//! application's own liveness can rest on one arriving. What makes best-effort delivery tolerable
+//! is not that nobody depends on it, but that the dependence is *self-repairing* — handlers bring a
+//! chain up to date rather than applying the change they were told about, so any later notification
+//! does the work of every lost one. The exception is the last.
 //!
 //! [`Notification`]: crate::worker::Notification
 
@@ -78,34 +83,67 @@ pub trait NotificationImpliesPersistedChange: CorrectValidator + StorageAtomicit
 /// * *The process crashed in between.* [`NotificationImpliesPersistedChange`] orders the save
 ///   before the dispatch, which leaves exactly this window: saved, not yet notified, gone.
 ///
-/// Delivery is therefore neither retried nor acknowledged, and no notification is durable.
+/// Delivery is therefore neither retried nor acknowledged, and no notification is durable. What
+/// bounds the damage is [`LostNotificationsCoalesce`], not any property of delivery itself.
 pub trait NotificationsAreBestEffort {}
 
-/// **Invariant (No proof depends on a notification arriving).** No statement in this specification
-/// has the delivery of a [`Notification`] among its premises.
+/// **Lemma (A lost notification is repaired by the next one).** If a client misses a notification
+/// for a chain but receives any later one for that same chain, it ends in the state it would have
+/// reached had none been lost. Only a loss with no successor has lasting effect.
 ///
-/// *Proof.* By inspection of the whole specification: no statement names a notification in its
-/// dependencies, and the progress argument reaches its conclusions without one. What drives a
-/// chain forward is [`ActiveCorrectDriver`] — a client that polls and retries — together with the
-/// `linera_core::updater` loops, which learn what a validator is missing from the *error it
-/// returns*, never from a notification. [`MissingDependenciesAreRecoverable`] is that argument, and
-/// nothing in it consults a notification. ∎
+/// *Proof.* No handler applies the change it was told about; each brings the chain up to date.
+/// In `linera_client::chain_listener`, `Reason::NewIncomingBundle` and `Reason::NewEvents` both
+/// reduce to `maybe_notify_inbox_processing`, which pokes a per-chain [`Notify`]; the waiting loop
+/// then runs `ChainClient::process_inbox_without_prepare`, which drains *everything* pending rather
+/// than the one bundle named. `Reason::NewBlock` calls `update_wallet` for the chain and re-derives
+/// its event subscriptions. `Reason::NewRound` calls `update_validators`.
 ///
-/// This is what makes both ways a notification can fail harmless. A lost one costs latency, never
-/// correctness and never progress. A *fabricated* one — which a faulty validator can send freely,
-/// notifications being unauthenticated — costs at most a wasted query, since the client acts on
-/// what it then reads and not on what it was told. It also fixes their role: notifications are an
-/// optimization over polling, and a client that ignores them entirely is slower but no less
-/// correct.
+/// Each handler is therefore idempotent and its effect depends only on the chain's current state,
+/// not on which notification triggered it. Running it once after `k` notifications achieves what
+/// running it `k` times would. Two mechanisms make the coalescing safe rather than lossy:
+/// `Notify::notify_one` stores a permit when no task is waiting, so a notification arriving *during*
+/// processing is not dropped but starts another pass; and the pass itself reads the inbox, so work
+/// that arrived while it ran is picked up regardless. ∎
 ///
-/// **Re-established, not preserved.** Like any exhaustive-search argument this one holds only for
-/// the statements that exist. A future statement that assumed a client learns of a change promptly
-/// would break it, and would have to introduce a delivery assumption to say so.
+/// **The last notification is the one that matters.** `ChainListener::next_action` selects over the
+/// notification streams, the cancellation token and its command channel — and nothing else. There
+/// is no timer and no periodic poll. So if the final notification for a chain is lost, no later one
+/// repairs it and the listener waits indefinitely, with pending bundles unprocessed and subscribed
+/// events unread. The window this lemma closes is bounded by the *next* notification; when there is
+/// no next one, it does not close.
 ///
-/// [`Notification`]: crate::worker::Notification
+/// This is a real exposure for applications rather than a theoretical one, and it is the reason
+/// [`NotificationsAreBestEffort`] must not be read as "notifications do not matter". They do; what
+/// is true is narrower — losing one in the middle of a stream is free.
+///
+/// [`Notify`]: https://docs.rs/tokio/latest/tokio/sync/struct.Notify.html
+pub trait LostNotificationsCoalesce: NotificationsAreBestEffort {}
+
+/// **Lemma (Chain progress does not depend on notifications).** A chain's block height grows without
+/// bound under the liveness assumptions whether or not any notification is delivered.
+///
+/// This is the boundary worth drawing, because it is *not* true of everything a client does. What
+/// is independent of notifications is the protocol: a validator never waits for one — it has none to
+/// wait for, since notifications travel only outward to clients — and the progress argument reaches
+/// its conclusions from [`ActiveCorrectDriver`], a client that polls and retries, together with the
+/// `linera_core::updater` loops, which learn what a validator is missing from the *error it returns*
+/// rather than from any notification ([`MissingDependenciesAreRecoverable`]).
+///
+/// *Proof.* By inspection of the closure of `UnboundedProgress`: no statement in it names a
+/// notification, and none of the transitions it depends on reads one. `Notifier::notify_chain` has
+/// no caller inside the consensus path; its only effect is to write to client subscriptions. ∎
+///
+/// **What does depend on them is application liveness.** A `ChainListener` processes an inbox
+/// because it was told to, so a chain whose owner is a `ChainListener` advances only when
+/// notifications arrive — the client is the driver [`ActiveCorrectDriver`] assumes, and
+/// notifications are what wakes it. So the split is: consensus cannot be stalled by losing
+/// notifications, an application can. [`LostNotificationsCoalesce`] bounds that to the case where no
+/// further notification arrives.
+///
 /// [`ActiveCorrectDriver`]: super::assumptions::ActiveCorrectDriver
 /// [`MissingDependenciesAreRecoverable`]: super::availability::MissingDependenciesAreRecoverable
-pub trait NoProofDependsOnNotifications: NotificationsAreBestEffort {}
+/// [`UnboundedProgress`]: super::liveness::UnboundedProgress
+pub trait ChainProgressIsIndependentOfNotifications: LostNotificationsCoalesce {}
 
 /// **Lemma (A notification is backed by a certificate the validator can serve — except for a new
 /// round).** For every notification a correct validator emits other than `Reason::NewRound`, that

--- a/linera-core/src/proof/notifications.rs
+++ b/linera-core/src/proof/notifications.rs
@@ -7,12 +7,14 @@
 //! — what it reports really happened — and from any validator it is best effort, since it may never
 //! arrive and carries nothing that could be checked if it did.
 //!
-//! That combination would be alarming if clients merely used notifications to go faster. They do
-//! not: a `ChainListener` acts on them, processing inboxes and following new chains, so an
-//! application's own liveness can rest on one arriving. What makes best-effort delivery tolerable
-//! is not that nobody depends on it, but that the dependence is *self-repairing* — handlers bring a
-//! chain up to date rather than applying the change they were told about, so any later notification
-//! does the work of every lost one. The exception is the last.
+//! The channel is **lossy by model**, not merely unreliable in practice, so nothing here may assume
+//! a notification arrives. That would be alarming if clients used notifications merely to go
+//! faster. They do not: a `ChainListener` acts on them, processing inboxes and following new
+//! chains, so an application's own liveness can rest on one arriving.
+//!
+//! What makes a lossy channel tolerable is that the dependence is *self-repairing* — handlers bring
+//! a chain up to date rather than applying the change they were told about, so any later
+//! notification does the work of every lost one. The exception is the last.
 //!
 //! [`Notification`]: crate::worker::Notification
 
@@ -73,18 +75,35 @@ use super::availability::{BlockOutputsArePersisted, InboxHoldsOnlySentBundles};
 /// [`CommitAgreement`]: linera_chain::manager::proof::safety::CommitAgreement
 pub trait NotificationImpliesPersistedChange: CorrectValidator + StorageAtomicity {}
 
-/// **Caveat (Notifications are best effort).** A change can be persisted and its notification
-/// never reach any client. Three ways, none of them an error:
+/// **Definition (The notification channel is lossy).** In this specification's model, the channel
+/// carrying [`Notification`]s from a validator to a client may drop any message, without notice to
+/// either side. Delivery is never retried, never acknowledged, and never durable.
 ///
-/// * *Nobody is listening.* `Notifier::notify_chain` looks the chain up in its sender map and
-///   returns immediately when there is no entry.
-/// * *The receiver went away.* A failed `sender.send` is ignored and the dead sender reaped; for
-///   the delivery notifiers, `notifier.send(())` failing is logged at debug and dropped.
-/// * *The process crashed in between.* [`NotificationImpliesPersistedChange`] orders the save
-///   before the dispatch, which leaves exactly this window: saved, not yet notified, gone.
+/// This is a modelling decision, so no result may assume otherwise — a proof that needed a
+/// notification to arrive would simply not be a proof in this model. The reason to state it as a
+/// definition rather than to prove something about it is that the alternative statement, "no result
+/// depends on notification delivery", is about the specification rather than about the system: in a
+/// model where the channel is lossy, it cannot fail to hold.
 ///
-/// Delivery is therefore neither retried nor acknowledged, and no notification is durable. What
-/// bounds the damage is [`LostNotificationsCoalesce`], not any property of delivery itself.
+/// *Faithfulness to the code.* Three ways a notification is dropped, none of them an error:
+/// `Notifier::notify_chain` returns immediately when the chain has no entry in its sender map;
+/// a failed `sender.send` is ignored and the dead sender reaped; and
+/// [`NotificationImpliesPersistedChange`] orders the save before the dispatch, which leaves a window
+/// where a change is persisted and the process dies before anything is sent.
+///
+/// **Verified once: nothing on the progress path waits on this channel.** The only place a client
+/// blocks on cross-chain delivery is `CrossChainMessageDelivery::Blocking`, at the
+/// `MissingCrossChainUpdate` arm of `send_block_proposal`. That is a flag on an ordinary
+/// `send_chain_information` request: the *validator* holds its response until the messages are
+/// delivered, so the client is waiting on an RPC bounded by its own timeout, not on a subscription.
+/// The `oneshot` behind it — `DeliveryNotifier`, whose `notifier.send(())` failure is logged at
+/// debug — is an internal signal between a worker and a request handler in the same process, and is
+/// not this channel. The two are easy to conflate and an earlier version of this statement did,
+/// citing that debug log as evidence of lossiness here.
+///
+/// What bounds the damage from a genuine loss is [`LostNotificationsCoalesce`].
+///
+/// [`Notification`]: crate::worker::Notification
 pub trait NotificationsAreBestEffort {}
 
 /// **Lemma (A lost notification is repaired by the next one).** If a client misses a notification
@@ -118,32 +137,6 @@ pub trait NotificationsAreBestEffort {}
 ///
 /// [`Notify`]: https://docs.rs/tokio/latest/tokio/sync/struct.Notify.html
 pub trait LostNotificationsCoalesce: NotificationsAreBestEffort {}
-
-/// **Lemma (Chain progress does not depend on notifications).** A chain's block height grows without
-/// bound under the liveness assumptions whether or not any notification is delivered.
-///
-/// This is the boundary worth drawing, because it is *not* true of everything a client does. What
-/// is independent of notifications is the protocol: a validator never waits for one — it has none to
-/// wait for, since notifications travel only outward to clients — and the progress argument reaches
-/// its conclusions from [`ActiveCorrectDriver`], a client that polls and retries, together with the
-/// `linera_core::updater` loops, which learn what a validator is missing from the *error it returns*
-/// rather than from any notification ([`MissingDependenciesAreRecoverable`]).
-///
-/// *Proof.* By inspection of the closure of `UnboundedProgress`: no statement in it names a
-/// notification, and none of the transitions it depends on reads one. `Notifier::notify_chain` has
-/// no caller inside the consensus path; its only effect is to write to client subscriptions. ∎
-///
-/// **What does depend on them is application liveness.** A `ChainListener` processes an inbox
-/// because it was told to, so a chain whose owner is a `ChainListener` advances only when
-/// notifications arrive — the client is the driver [`ActiveCorrectDriver`] assumes, and
-/// notifications are what wakes it. So the split is: consensus cannot be stalled by losing
-/// notifications, an application can. [`LostNotificationsCoalesce`] bounds that to the case where no
-/// further notification arrives.
-///
-/// [`ActiveCorrectDriver`]: super::assumptions::ActiveCorrectDriver
-/// [`MissingDependenciesAreRecoverable`]: super::availability::MissingDependenciesAreRecoverable
-/// [`UnboundedProgress`]: super::liveness::UnboundedProgress
-pub trait ChainProgressIsIndependentOfNotifications: LostNotificationsCoalesce {}
 
 /// **Lemma (A notification is backed by a certificate the validator can serve — except for a new
 /// round).** For every notification a correct validator emits other than `Reason::NewRound`, that

--- a/linera-core/src/proof/notifications.rs
+++ b/linera-core/src/proof/notifications.rs
@@ -90,11 +90,20 @@ pub trait NotificationImpliesPersistedChange: CorrectValidator + StorageAtomicit
 /// reaped; and [`NotificationImpliesPersistedChange`] orders the save before the dispatch, leaving a
 /// window in which a change is persisted and the process dies before anything is sent.
 ///
-/// All three behave like a crash rather than like corruption, and are modelled the same way
-/// [`CorrectValidator`] models one: permitted freely before GST, and after GST not persisting long
-/// enough to prevent progress. So no result may assume a *particular* notification arrives, and a
-/// result may assume that a client which stays connected to a reachable correct validator
-/// eventually learns.
+/// The third behaves like a crash and is modelled as one: [`CorrectValidator`] permits a crash at
+/// any time, freely before GST and with bounded recovery after. So no result may assume a
+/// *particular* notification arrives, and a result may assume that a client which stays connected
+/// to a reachable correct validator eventually learns.
+///
+/// **The model has no notion of a partial crash, and this is where one would be needed.** A
+/// validator whose notification dispatch stops while its consensus path keeps running is not
+/// described by anything here: it is not faulty, since it signs nothing wrong; it is not crashed,
+/// since the process is alive and answering; and it is not merely "slow or unreachable", the escape
+/// [`CorrectValidator`] does allow, because it responds normally to everything except this. The
+/// crash model is whole-process — a validator stops and restarts, losing unpersisted state — with
+/// nothing between up and down. Component-level failure inside a live validator is outside the
+/// model, and [`LostNotificationsAreRepaired`] shows it is not a harmless omission: it defeats two
+/// of the three mechanisms that would otherwise repair a loss.
 ///
 /// This is why the alternative statement — "no result depends on notification delivery" — is not
 /// worth making. In a model where the channel is lossy it cannot fail to hold; it is a property of
@@ -133,14 +142,20 @@ pub trait NotificationChannelIsLossy {}
 /// achieves what `k` runs would. `Notify::notify_one` stores a permit when no task is waiting, so a
 /// notification arriving *during* a pass starts another rather than being swallowed. ∎
 ///
-/// **What is not repaired.** The mechanisms are conditional on the client having a live subscription
-/// to a validator that holds the change. A client subscribed to nobody, or whose validators are all
-/// unreachable, learns nothing and is not told that it is learning nothing — there is no timer in
-/// `ChainListener::next_action`, which selects over the notification streams, the cancellation token
-/// and its command channel and nothing else. By [`NotificationChannelIsLossy`] that condition is a
-/// pre-GST one, so the model does not admit it persisting; a deployment can still sit in it
-/// indefinitely, with pending bundles unprocessed and subscribed events unread, and nothing in the
-/// implementation escalates.
+/// **What is not repaired.** Every mechanism above assumes a failure that is either whole-process or
+/// network-level, because those are the failures the model has. A validator that is up, answering
+/// RPCs and voting normally, but silently delivering no notifications — the partial crash
+/// [`NotificationChannelIsLossy`] describes — defeats two of the three. Redundancy survives only if
+/// such a failure is independent across validators, which a systematic one is not. Resynchronization
+/// never runs, because it is triggered by establishing a stream and no stream ever drops: the client
+/// holds a healthy connection to a validator that has stopped talking.
+///
+/// Coalescing is then irrelevant, since nothing arrives to coalesce. The client is not told it is
+/// learning nothing, and nothing escalates: `ChainListener::next_action` selects over the
+/// notification streams, the cancellation token and its command channel, and there is no timer among
+/// them. Pending bundles stay unprocessed and subscribed events unread for as long as the condition
+/// lasts, which — being outside the fault model — is not bounded by GST or by anything else the
+/// specification states.
 pub trait LostNotificationsAreRepaired: NotificationChannelIsLossy {}
 
 /// **Lemma (A notification is backed by a certificate the validator can serve — except for a new

--- a/linera-core/src/proof/notifications.rs
+++ b/linera-core/src/proof/notifications.rs
@@ -12,9 +12,12 @@
 //! faster. They do not: a `ChainListener` acts on them, processing inboxes and following new
 //! chains, so an application's own liveness can rest on one arriving.
 //!
-//! What makes a lossy channel tolerable is that the dependence is *self-repairing* — handlers bring
-//! a chain up to date rather than applying the change they were told about, so any later
-//! notification does the work of every lost one. The exception is the last.
+//! What makes a lossy channel tolerable is that the dependence is *self-repairing*, in three ways
+//! that are independent of each other: a client subscribes to every validator, so one silence is
+//! covered by the rest; establishing a stream resynchronizes chain state, so a gap is closed rather
+//! than replayed; and handlers bring a chain up to date rather than applying the change they were
+//! told about, so any later notification does the work of every lost one. All three need the client
+//! to be connected to somebody.
 //!
 //! [`Notification`]: crate::worker::Notification
 
@@ -75,68 +78,70 @@ use super::availability::{BlockOutputsArePersisted, InboxHoldsOnlySentBundles};
 /// [`CommitAgreement`]: linera_chain::manager::proof::safety::CommitAgreement
 pub trait NotificationImpliesPersistedChange: CorrectValidator + StorageAtomicity {}
 
-/// **Definition (The notification channel is lossy).** In this specification's model, the channel
-/// carrying [`Notification`]s from a validator to a client may drop any message, without notice to
-/// either side. Delivery is never retried, never acknowledged, and never durable.
+/// **Definition (The notification channel is lossy).** The channel carrying [`Notification`]s from
+/// a validator to a client may drop any message, without notice to either side. Delivery is never
+/// retried, never acknowledged, and never durable.
 ///
-/// This is a modelling decision, so no result may assume otherwise — a proof that needed a
-/// notification to arrive would simply not be a proof in this model. The reason to state it as a
-/// definition rather than to prove something about it is that the alternative statement, "no result
-/// depends on notification delivery", is about the specification rather than about the system: in a
-/// model where the channel is lossy, it cannot fail to hold.
+/// *Where this sits in the fault model.* Network loss needs no separate treatment — a notification
+/// is a message between participants, so [`EventualSynchrony`] already permits it to be dropped
+/// before GST and forbids that after. What this definition adds are three *local* ways to lose one,
+/// which the network model does not describe: `Notifier::notify_chain` returns immediately when the
+/// chain has no entry in its sender map; a failed `sender.send` is ignored and the dead sender
+/// reaped; and [`NotificationImpliesPersistedChange`] orders the save before the dispatch, leaving a
+/// window in which a change is persisted and the process dies before anything is sent.
 ///
-/// *Faithfulness to the code.* Three ways a notification is dropped, none of them an error:
-/// `Notifier::notify_chain` returns immediately when the chain has no entry in its sender map;
-/// a failed `sender.send` is ignored and the dead sender reaped; and
-/// [`NotificationImpliesPersistedChange`] orders the save before the dispatch, which leaves a window
-/// where a change is persisted and the process dies before anything is sent.
+/// All three behave like a crash rather than like corruption, and are modelled the same way
+/// [`CorrectValidator`] models one: permitted freely before GST, and after GST not persisting long
+/// enough to prevent progress. So no result may assume a *particular* notification arrives, and a
+/// result may assume that a client which stays connected to a reachable correct validator
+/// eventually learns.
 ///
-/// **Verified once: nothing on the progress path waits on this channel.** The only place a client
-/// blocks on cross-chain delivery is `CrossChainMessageDelivery::Blocking`, at the
-/// `MissingCrossChainUpdate` arm of `send_block_proposal`. That is a flag on an ordinary
-/// `send_chain_information` request: the *validator* holds its response until the messages are
-/// delivered, so the client is waiting on an RPC bounded by its own timeout, not on a subscription.
-/// The `oneshot` behind it — `DeliveryNotifier`, whose `notifier.send(())` failure is logged at
-/// debug — is an internal signal between a worker and a request handler in the same process, and is
-/// not this channel. The two are easy to conflate and an earlier version of this statement did,
-/// citing that debug log as evidence of lossiness here.
+/// This is why the alternative statement — "no result depends on notification delivery" — is not
+/// worth making. In a model where the channel is lossy it cannot fail to hold; it is a property of
+/// the specification rather than of the system.
 ///
-/// What bounds the damage from a genuine loss is [`LostNotificationsCoalesce`].
+/// What repairs an individual loss is [`LostNotificationsAreRepaired`].
 ///
 /// [`Notification`]: crate::worker::Notification
+/// [`EventualSynchrony`]: super::assumptions::EventualSynchrony
 pub trait NotificationChannelIsLossy {}
 
-/// **Lemma (A lost notification is repaired by the next one).** If a client misses a notification
-/// for a chain but receives any later one for that same chain, it ends in the state it would have
-/// reached had none been lost. Only a loss with no successor has lasting effect.
+/// **Lemma (A lost notification is repaired).** A client that misses a notification still reaches
+/// the state it would have reached, provided it remains connected to at least one correct validator
+/// that has the change. Three independent mechanisms do this, and none of them replays the lost
+/// message.
 ///
-/// *Proof.* No handler applies the change it was told about; each brings the chain up to date.
+/// *Redundancy.* `ChainClient::listen` opens one subscription per validator in the committee, via
+/// `update_notification_streams`, and processes them concurrently. Every validator that processes a
+/// change notifies about it, so a client loses a notification only when *every* validator it is
+/// subscribed to fails to deliver that one — not when any single one does.
+///
+/// *Resynchronization on (re)subscribe.* Establishing a stream is not just an attachment point: the
+/// same future calls `Client::synchronize_chain_state_from` against that validator before yielding
+/// the stream, precisely because, in the code's own words, "we may have missed notifications since
+/// the last time we synchronized". Since `update_notification_streams` is re-run on every
+/// `Reason::NewBlock`, and a dropped connection is re-established through the same path, a gap in
+/// the stream is closed by *state synchronization* rather than by recovering the messages that fell
+/// in it.
+///
+/// *Coalescing.* No handler applies the change it was told about; each brings the chain up to date.
 /// In `linera_client::chain_listener`, `Reason::NewIncomingBundle` and `Reason::NewEvents` both
-/// reduce to `maybe_notify_inbox_processing`, which pokes a per-chain [`Notify`]; the waiting loop
-/// then runs `ChainClient::process_inbox_without_prepare`, which drains *everything* pending rather
-/// than the one bundle named. `Reason::NewBlock` calls `update_wallet` for the chain and re-derives
-/// its event subscriptions. `Reason::NewRound` calls `update_validators`.
+/// reduce to `maybe_notify_inbox_processing`, whose waiting loop runs
+/// `ChainClient::process_inbox_without_prepare` — draining *everything* pending, not the one bundle
+/// named. `Reason::NewBlock` calls `update_wallet` and re-derives event subscriptions. Handlers are
+/// therefore idempotent and depend only on current state, so one run after `k` notifications
+/// achieves what `k` runs would. `Notify::notify_one` stores a permit when no task is waiting, so a
+/// notification arriving *during* a pass starts another rather than being swallowed. ∎
 ///
-/// Each handler is therefore idempotent and its effect depends only on the chain's current state,
-/// not on which notification triggered it. Running it once after `k` notifications achieves what
-/// running it `k` times would. Two mechanisms make the coalescing safe rather than lossy:
-/// `Notify::notify_one` stores a permit when no task is waiting, so a notification arriving *during*
-/// processing is not dropped but starts another pass; and the pass itself reads the inbox, so work
-/// that arrived while it ran is picked up regardless. ∎
-///
-/// **The last notification is the one that matters.** `ChainListener::next_action` selects over the
-/// notification streams, the cancellation token and its command channel — and nothing else. There
-/// is no timer and no periodic poll. So if the final notification for a chain is lost, no later one
-/// repairs it and the listener waits indefinitely, with pending bundles unprocessed and subscribed
-/// events unread. The window this lemma closes is bounded by the *next* notification; when there is
-/// no next one, it does not close.
-///
-/// This is a real exposure for applications rather than a theoretical one, and it is the reason
-/// [`NotificationChannelIsLossy`] must not be read as "notifications do not matter". They do; what
-/// is true is narrower — losing one in the middle of a stream is free.
-///
-/// [`Notify`]: https://docs.rs/tokio/latest/tokio/sync/struct.Notify.html
-pub trait LostNotificationsCoalesce: NotificationChannelIsLossy {}
+/// **What is not repaired.** The mechanisms are conditional on the client having a live subscription
+/// to a validator that holds the change. A client subscribed to nobody, or whose validators are all
+/// unreachable, learns nothing and is not told that it is learning nothing — there is no timer in
+/// `ChainListener::next_action`, which selects over the notification streams, the cancellation token
+/// and its command channel and nothing else. By [`NotificationChannelIsLossy`] that condition is a
+/// pre-GST one, so the model does not admit it persisting; a deployment can still sit in it
+/// indefinitely, with pending bundles unprocessed and subscribed events unread, and nothing in the
+/// implementation escalates.
+pub trait LostNotificationsAreRepaired: NotificationChannelIsLossy {}
 
 /// **Lemma (A notification is backed by a certificate the validator can serve — except for a new
 /// round).** For every notification a correct validator emits other than `Reason::NewRound`, that

--- a/linera-core/src/proof/notifications.rs
+++ b/linera-core/src/proof/notifications.rs
@@ -4,8 +4,8 @@
 //! What a notification tells a client, and what it does not.
 //!
 //! A [`Notification`] tells a client that a chain has changed. From a correct validator it is sound
-//! — what it reports really happened — and from any validator it is best effort, since it may never
-//! arrive and carries nothing that could be checked if it did.
+//! — what it reports really happened — but from any validator it may simply never arrive, and it
+//! carries nothing that could be checked if it did.
 //!
 //! The channel is **lossy by model**, not merely unreliable in practice, so nothing here may assume
 //! a notification arrives. That would be alarming if clients used notifications merely to go
@@ -104,7 +104,7 @@ pub trait NotificationImpliesPersistedChange: CorrectValidator + StorageAtomicit
 /// What bounds the damage from a genuine loss is [`LostNotificationsCoalesce`].
 ///
 /// [`Notification`]: crate::worker::Notification
-pub trait NotificationsAreBestEffort {}
+pub trait NotificationChannelIsLossy {}
 
 /// **Lemma (A lost notification is repaired by the next one).** If a client misses a notification
 /// for a chain but receives any later one for that same chain, it ends in the state it would have
@@ -132,11 +132,11 @@ pub trait NotificationsAreBestEffort {}
 /// no next one, it does not close.
 ///
 /// This is a real exposure for applications rather than a theoretical one, and it is the reason
-/// [`NotificationsAreBestEffort`] must not be read as "notifications do not matter". They do; what
+/// [`NotificationChannelIsLossy`] must not be read as "notifications do not matter". They do; what
 /// is true is narrower — losing one in the middle of a stream is free.
 ///
 /// [`Notify`]: https://docs.rs/tokio/latest/tokio/sync/struct.Notify.html
-pub trait LostNotificationsCoalesce: NotificationsAreBestEffort {}
+pub trait LostNotificationsCoalesce: NotificationChannelIsLossy {}
 
 /// **Lemma (A notification is backed by a certificate the validator can serve — except for a new
 /// round).** For every notification a correct validator emits other than `Reason::NewRound`, that


### PR DESCRIPTION
## Motivation

Two problems with how #6692 and #6694 left notifications.

**`NoProofDependsOnNotifications` was a claim about the specification, not about the system.** "No statement names a notification in its dependencies" is bookkeeping — it cannot be wrong in an interesting way. Restating it as a lemma about the protocol would be no better: if the *model* says the channel is lossy, no valid progress proof could have assumed otherwise, so such a lemma is vacuous by construction. The fix is to put lossiness in the model and check the code once.

**`NotificationsAreBestEffort` was too weak**, and its claim that a client ignoring notifications is "slower but no less correct" is false. `ChainListener` *acts* on notifications: `NewIncomingBundle` and `NewEvents` drive inbox processing, `NewBlock` updates the wallet and follows newly discovered chains. An application's liveness can rest on one arriving.

## Proposal

### `NotificationChannelIsLossy` — a Definition, part of the model

Relabelled from **Caveat**, renamed to say what it states, and positioned against the existing fault model rather than standing free.

Network loss needs no separate treatment: a notification is a message between participants, so `EventualSynchrony` already permits drops before GST and forbids them after. What the definition adds are three *local* loss modes the network model does not describe — `notify_chain` returning early when no one is subscribed, a failed `sender.send` reaping a dead sender, and the window `NotificationImpliesPersistedChange` creates by ordering the save before the dispatch.

**The model has no notion of a partial crash, and this is where one would be needed.** A validator whose notification dispatch stops while its consensus path keeps running is described by nothing in the model: not faulty, since it signs nothing wrong; not crashed, since the process is alive and answering; not "slow or unreachable", the escape `CorrectValidator` does allow, because it responds normally to everything except this. The crash model is whole-process — stop and restart, losing unpersisted state — with nothing between up and down.

### `LostNotificationsAreRepaired` (new)

The property that makes a lossy channel tolerable. A client that misses a notification still reaches the state it would have reached, provided it stays connected to a correct validator that has the change. **Three independent mechanisms, none of which replays the lost message:**

- **Redundancy.** `ChainClient::listen` opens one subscription *per validator in the committee* and processes them concurrently, so a client loses a notification only when every validator it is subscribed to drops that one.
- **Resynchronization on (re)subscribe.** Establishing a stream is not merely an attachment point: the same future calls `synchronize_chain_state_from` before yielding the stream, in the code's own words because "we may have missed notifications since the last time we synchronized". A gap is closed by state synchronization rather than by recovering the messages that fell in it.
- **Coalescing.** Handlers are level-triggered: `NewIncomingBundle` and `NewEvents` reduce to a per-chain `Notify` whose loop runs `process_inbox_without_prepare`, draining *everything* pending rather than the bundle named. One run after `k` notifications achieves what `k` runs would.

**What is not repaired.** Every mechanism assumes a failure that is whole-process or network-level, because those are the failures the model has. A partial crash — a validator up, voting, answering RPCs, and silently not notifying — defeats two of the three. Redundancy survives only if such a failure is independent across validators, which a systematic one is not; and resynchronization never runs, because it is triggered by establishing a stream and no stream ever drops. The client holds a healthy connection to a validator that has stopped talking, is not told so, and nothing escalates — `ChainListener::next_action` has no timer. Being outside the fault model, that condition is bounded by neither GST nor anything else the specification states.

## Test Plan

CI. Documentation-only: marker traits with no members, implementors or call sites. `cargo doc --all-features` under `-D warnings`, `cargo +nightly fmt --check`, and `cargo clippy --all-features` are clean.

Two things worth flagging for reviewers, both found by tooling rather than by reading:

- Clippy caught that truncating the file to remove the old invariant also removed `NotificationIsCertificateBacked`, which followed it — the unused-import warnings were the only signal. Restored unchanged.
- The earlier version of the lossiness statement cited `DeliveryNotifier`'s debug-logged send failure as one of its loss modes. That is an internal `oneshot` between a worker and a request handler **in the same process**, not the client notification channel; the two look identical at the call site and are unrelated. Removed, and the distinction recorded so the next reader does not repeat it.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6692 — added the statement replaced here and the invariant removed.
- #6694 — scoped notification soundness to correct validators.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
