### PR TITLE
linera-core: push a checkpoint when the catch-up window cannot reach it

### DIFF
--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -49,7 +49,7 @@ use futures::{stream::FuturesUnordered, FutureExt as _, StreamExt as _};
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
-    crypto::ValidatorPublicKey,
+    crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{Blob, BlockHeight, Epoch, TimeDelta, Timestamp},
     identifiers::{BlobId, ChainId, StreamId},
     time::{timer::timeout, Duration},
@@ -405,10 +405,20 @@ impl ProgressMap {
 
 type SharedProgress = Arc<Mutex<ProgressMap>>;
 
-/// The height after each chain's newest announced block. Written on every `export` call before
-/// the queue is tried, so a block the full queue drops still raises the repair target the tick
-/// measures destinations against.
-type SharedTips = Arc<Mutex<HashMap<ChainId, BlockHeight>>>;
+/// What the worker announces about a chain on every `export` call, before the queue is tried, so
+/// a block the full queue drops still raises the repair target the tick measures destinations
+/// against.
+#[derive(Clone, Copy)]
+struct ChainAnnouncement {
+    /// The height after the chain's newest announced block.
+    tip: BlockHeight,
+    /// The chain's latest checkpoint, read from the view the *worker* owns. Export must never
+    /// load the chain itself: `Storage::load_chain` opens the chain partition exclusively, and a
+    /// second live `ChainStateView` racing the worker's is documented as corrupting.
+    checkpoint: Option<BlockHeight>,
+}
+
+type SharedTips = Arc<Mutex<HashMap<ChainId, ChainAnnouncement>>>;
 
 impl BlockExportHandle {
     /// Queues a block for export and returns immediately. A full queue drops the block — never
@@ -420,6 +430,7 @@ impl BlockExportHandle {
         blobs: Vec<CacheArc<Blob>>,
         epoch: Epoch,
         exported_heights: BTreeMap<ValidatorPublicKey, BlockHeight>,
+        latest_checkpoint: Option<BlockHeight>,
     ) {
         // Announced before the queue is tried: a dropped block must still raise the repair
         // target, or a chain whose *last* block was dropped would never be repaired at all.
@@ -427,8 +438,14 @@ impl BlockExportHandle {
             let header = &certificate.block().header;
             let tip = header.height.try_add_one().unwrap_or(BlockHeight::MAX);
             let mut tips = self.tips.lock().expect("tips mutex is never poisoned");
-            let entry = tips.entry(header.chain_id).or_insert(tip);
-            *entry = (*entry).max(tip);
+            let entry = tips.entry(header.chain_id).or_insert(ChainAnnouncement {
+                tip,
+                checkpoint: None,
+            });
+            entry.tip = entry.tip.max(tip);
+            // Only ever rises, like the tip: a later announcement carrying `None` is a worker
+            // that has not loaded the register, not a checkpoint that was withdrawn.
+            entry.checkpoint = entry.checkpoint.max(latest_checkpoint);
         }
         let blob_bytes = blobs.iter().map(|blob| blob.bytes().len()).sum::<usize>();
         // The byte budget is enforced, not merely measured: a block count alone would let a few
@@ -586,6 +603,9 @@ struct ChainRecord {
     /// The height after the chain's last known block: what a destination must reach to be
     /// caught up.
     tip: BlockHeight,
+    /// The chain's latest checkpoint, as announced by its worker. Carried here so a catch-up
+    /// round can reach for it without export ever loading the chain itself.
+    checkpoint: Option<BlockHeight>,
     /// When this chain last saw a block or a completed send, for the convergence sweep.
     last_activity: Timestamp,
     /// Sorted by index, so lookups binary-search integers. A flat vector rather than a map
@@ -608,6 +628,7 @@ impl ChainRecord {
     ) -> Self {
         ChainRecord {
             tip: BlockHeight::ZERO,
+            checkpoint: None,
             last_activity: now,
             // Already in index order, which is the order `dests` must keep.
             dests: destinations
@@ -1079,6 +1100,7 @@ where
             let budget = self.budget_remaining();
             let record = self.chains.get_mut(&chain_id).expect("inserted above");
             let record_tip = record.tip;
+            let record_checkpoint = record.checkpoint;
             let chain_dest = record.dest_entry(index);
             let dest = self
                 .destinations
@@ -1101,6 +1123,7 @@ where
                     dest,
                     chain_dest,
                     record_tip,
+                    record_checkpoint,
                     Some((block.certificate.clone(), block.blobs.clone())),
                 );
             } else if chain_dest.next_height.is_none_or(|next| next < record_tip) {
@@ -1326,13 +1349,15 @@ where
         // cloned — the workers contend on this mutex every block, and once folded the records
         // carry the truth.
         let tips = std::mem::take(&mut *self.tips.lock().expect("tips mutex is never poisoned"));
-        for (chain_id, tip) in tips {
+        for (chain_id, announcement) in tips {
+            let ChainAnnouncement { tip, checkpoint } = announcement;
             let record = self
                 .chains
                 .entry(chain_id)
                 .or_insert_with(|| ChainRecord::new(now, &self.destinations, &BTreeMap::new()));
             let advanced = record.tip < tip;
             record.tip = record.tip.max(tip);
+            record.checkpoint = record.checkpoint.max(checkpoint);
             if advanced {
                 // The scan that used to notice this is gone, so a tip moving forward records
                 // the chains it just put behind, here and now.
@@ -1762,6 +1787,7 @@ where
         dest: &mut DestState<P::Node>,
         chain_dest: &mut ChainDest,
         target: BlockHeight,
+        checkpoint: Option<BlockHeight>,
         live: Option<(CacheArc<ConfirmedBlockCertificate>, Vec<CacheArc<Blob>>)>,
     ) {
         let generation = dest.generation;
@@ -1794,12 +1820,12 @@ where
             let result = match live {
                 Some((certificate, blobs)) => {
                     sender
-                        .send_block(&certificate, &blobs, cursor, max_catch_up)
+                        .send_block(&certificate, &blobs, cursor, max_catch_up, checkpoint)
                         .await
                 }
                 None => {
                     sender
-                        .send_missing_blocks(chain_id, target, cursor, max_catch_up)
+                        .send_missing_blocks(chain_id, target, cursor, max_catch_up, checkpoint)
                         .await
                 }
             };
@@ -1876,11 +1902,12 @@ where
                 continue;
             };
             let tip = record.tip;
+            let checkpoint = record.checkpoint;
             let Some(chain_dest) = record.dest_mut(index) else {
                 continue;
             };
             Self::spawn_job(
-                jobs, storage, config, chain_id, index, dest, chain_dest, tip, None,
+                jobs, storage, config, chain_id, index, dest, chain_dest, tip, checkpoint, None,
             );
         }
         spawned
@@ -1906,6 +1933,15 @@ fn is_chain_scoped(error: &chain_client::Error) -> bool {
 /// Halving the destination's window for it would punish the wrong side, but backing off only the
 /// one pair leaves every other pair reading at full rate — so the control loop cannot see the
 /// bottleneck it is creating. These shrink the queue's *global* budget instead.
+/// How a block the *destination* asked for but we cannot supply is reported.
+///
+/// Deliberately not a read error: `is_local_scoped` would halve the queue's shared budget, so one
+/// peer's reply would throttle export to every other destination and blame our own storage. The
+/// client can map this to a read error safely because it has no shared window; export cannot.
+fn missing_block_error(hash: CryptoHash) -> chain_client::Error {
+    chain_client::Error::RemoteNodeError(NodeError::BlocksNotFound(vec![hash]))
+}
+
 fn is_local_scoped(error: &chain_client::Error) -> bool {
     matches!(
         error,
@@ -1963,6 +1999,7 @@ where
         blobs: &[CacheArc<Blob>],
         destination_next_height: Option<BlockHeight>,
         max_catch_up: u64,
+        checkpoint: Option<BlockHeight>,
     ) -> Result<BlockHeight, chain_client::Error> {
         let block = certificate.block();
         let (chain_id, height) = (block.header.chain_id, block.header.height);
@@ -1970,8 +2007,14 @@ where
         let next_height = if destination_next_height == Some(height) {
             height
         } else {
-            self.send_missing_blocks(chain_id, height, destination_next_height, max_catch_up)
-                .await?
+            self.send_missing_blocks(
+                chain_id,
+                height,
+                destination_next_height,
+                max_catch_up,
+                checkpoint,
+            )
+            .await?
         };
         // Not exactly at this block: either the gap was larger than one chunk, or the validator
         // is already past it — a re-executed chain re-offers its whole history — and in both
@@ -1990,12 +2033,16 @@ where
     /// caller once. Heights whose certificates are not in storage are skipped — a chain we merely
     /// receive from is stored only at its message-bearing blocks, and the destination
     /// preprocesses above such gaps.
+    ///
+    /// A gap too large to close in one round first tries a checkpoint, which is what keeps that
+    /// skipping safe: see [`Self::push_checkpoint_if_useful`].
     pub(crate) async fn send_missing_blocks(
         &mut self,
         chain_id: ChainId,
         target_next_height: BlockHeight,
         destination_next_height: Option<BlockHeight>,
         max_blocks: u64,
+        checkpoint: Option<BlockHeight>,
     ) -> Result<BlockHeight, chain_client::Error> {
         let mut next_height = match destination_next_height {
             Some(height) => height,
@@ -2007,6 +2054,11 @@ where
                     .next_block_height
             }
         };
+        if next_height.0.saturating_add(max_blocks) < target_next_height.0 {
+            next_height = self
+                .push_checkpoint_if_useful(chain_id, next_height, checkpoint)
+                .await?;
+        }
         let last = target_next_height
             .0
             .min(next_height.0.saturating_add(max_blocks));
@@ -2028,6 +2080,52 @@ where
             }
         }
         Ok(next_height)
+    }
+
+    /// Pushes our latest checkpoint certificate if the destination has not reached it, so it
+    /// installs the chain's execution state instead of replaying every block below it, and
+    /// returns the height it reports afterwards.
+    ///
+    /// This is what makes a bounded catch-up window safe on a checkpointed chain: pre-checkpoint
+    /// certificates may be pruned, [`Self::send_missing_blocks`] skips heights it cannot read, and
+    /// a window sitting entirely below the checkpoint therefore sends *nothing* and retries the
+    /// same empty round forever. Reaching the checkpoint is the whole fix — the destination
+    /// already restores rather than preprocesses a block that starts with one.
+    ///
+    /// Mirrors the client's `RemoteNodeUpdater::push_checkpoint_if_useful`. A missing checkpoint
+    /// and an absent certificate are both *not useful*, never errors: the caller's replay path is
+    /// still correct wherever a checkpoint cannot be had.
+    ///
+    /// `checkpoint_height` is announced by the chain's own worker rather than read here. Export
+    /// must not call `Storage::load_chain`: it opens the chain partition exclusively, and a
+    /// second live `ChainStateView` racing the worker's is documented as causing "invalid states
+    /// and data corruption".
+    async fn push_checkpoint_if_useful(
+        &mut self,
+        chain_id: ChainId,
+        next_height: BlockHeight,
+        checkpoint_height: Option<BlockHeight>,
+    ) -> Result<BlockHeight, chain_client::Error> {
+        let Some(checkpoint_height) = checkpoint_height else {
+            return Ok(next_height);
+        };
+        // Strictly below means the destination is already past it; `send_missing_blocks` then
+        // has certificates it can actually read, so replaying is both correct and cheaper.
+        if checkpoint_height < next_height {
+            return Ok(next_height);
+        }
+        let Some(certificate) = self
+            .storage
+            .read_certificates_by_heights(chain_id, &[checkpoint_height])
+            .await?
+            .into_iter()
+            .flatten()
+            .next()
+        else {
+            return Ok(next_height);
+        };
+        let info = self.send_confirmed_certificate(&certificate, &[]).await?;
+        Ok(info.next_block_height)
     }
 
     /// Sends one confirmed certificate, uploading blobs the validator reports missing.
@@ -2056,6 +2154,7 @@ where
         // The same once-per-cause loop as the client's `RemoteNodeUpdater`: a second
         // `BlobsNotFound` naming new blobs is still recoverable, only repeating a cause is not.
         let mut sent_blobs = false;
+        let mut sent_blocks = false;
         loop {
             match result {
                 Err(NodeError::BlobsNotFound(blob_ids)) if !sent_blobs => {
@@ -2067,6 +2166,21 @@ where
                         .upload_blobs(blobs.into_iter().map(CacheArc::into_std).collect())
                         .await?;
                     sent_blobs = true;
+                }
+                // Only a checkpoint certificate provokes this: the destination trusts these
+                // hashes through the checkpoint but lacks the block bytes. Its trust-mark accept
+                // path takes them whatever epoch they carry, so uploading them unblocks the
+                // restore.
+                Err(NodeError::BlocksNotFound(hashes)) if !sent_blocks => {
+                    let certificates = self.storage.read_certificates(&hashes).await?;
+                    for (hash, maybe_certificate) in hashes.iter().zip(certificates) {
+                        let missing =
+                            maybe_certificate.ok_or_else(|| missing_block_error(*hash))?;
+                        self.remote_node
+                            .handle_confirmed_certificate(missing, delivery)
+                            .await?;
+                    }
+                    sent_blocks = true;
                 }
                 result => return Ok(result?),
             }
@@ -2107,9 +2221,33 @@ where
 
 #[cfg(test)]
 mod tests {
-    use linera_base::crypto::CryptoHash;
 
     use super::*;
+
+    /// A block the *destination* named must never be scoped to our own storage.
+    ///
+    /// `LocalScoped` halves the queue's shared budget, so misfiling this would let one peer's
+    /// reply throttle export to every other destination — and blame our storage while doing it.
+    /// The two controls below are what make that assertion mean anything: a genuine read failure
+    /// must still be local, and the recovery must still be reached at all.
+    #[test]
+    fn a_destinations_missing_block_is_scoped_to_that_destination() {
+        // The production constructor, not a hand-rolled copy: mapping the call site back to a
+        // read error has to fail here.
+        let hash = CryptoHash::test_hash("nonexistent");
+        let from_destination = missing_block_error(hash);
+        assert!(!is_local_scoped(&from_destination));
+        assert!(!is_chain_scoped(&from_destination));
+
+        // Control: a real local read failure is still ours, so the halving still has a trigger.
+        assert!(is_local_scoped(
+            &chain_client::Error::ReadCertificatesError(vec![hash])
+        ));
+        // Control: sibling recoveries keep their own scopes.
+        assert!(is_chain_scoped(&chain_client::Error::RemoteNodeError(
+            NodeError::BlobsNotFound(vec![])
+        )));
+    }
 
     /// Every rejection in `check()` guards a distinct failure mode, so each invalid field must be
     /// caught on its own — including `max_retry_delay`, whose zero used to slip through and turn

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -413,8 +413,8 @@ struct ChainAnnouncement {
     /// The height after the chain's newest announced block.
     tip: BlockHeight,
     /// The chain's latest checkpoint, read from the view the *worker* owns. Export must never
-    /// load the chain itself: `Storage::load_chain` opens the chain partition exclusively, and a
-    /// second live `ChainStateView` racing the worker's is documented as corrupting.
+    /// open the chain's own partition: `Storage` does so exclusively, and a second live
+    /// `ChainStateView` racing the worker's is documented as corrupting.
     checkpoint: Option<BlockHeight>,
 }
 
@@ -2097,7 +2097,7 @@ where
     /// still correct wherever a checkpoint cannot be had.
     ///
     /// `checkpoint_height` is announced by the chain's own worker rather than read here. Export
-    /// must not call `Storage::load_chain`: it opens the chain partition exclusively, and a
+    /// must never open the chain's partition to find it: `Storage` opens it exclusively, and a
     /// second live `ChainStateView` racing the worker's is documented as causing "invalid states
     /// and data corruption".
     async fn push_checkpoint_if_useful(

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -1933,6 +1933,13 @@ fn is_chain_scoped(error: &chain_client::Error) -> bool {
 /// Halving the destination's window for it would punish the wrong side, but backing off only the
 /// one pair leaves every other pair reading at full rate — so the control loop cannot see the
 /// bottleneck it is creating. These shrink the queue's *global* budget instead.
+fn is_local_scoped(error: &chain_client::Error) -> bool {
+    matches!(
+        error,
+        chain_client::Error::ReadCertificatesError(_) | chain_client::Error::ViewError(_)
+    )
+}
+
 /// How a block the *destination* asked for but we cannot supply is reported.
 ///
 /// Deliberately not a read error: `is_local_scoped` would halve the queue's shared budget, so one
@@ -1940,13 +1947,6 @@ fn is_chain_scoped(error: &chain_client::Error) -> bool {
 /// client can map this to a read error safely because it has no shared window; export cannot.
 fn missing_block_error(hash: CryptoHash) -> chain_client::Error {
     chain_client::Error::RemoteNodeError(NodeError::BlocksNotFound(vec![hash]))
-}
-
-fn is_local_scoped(error: &chain_client::Error) -> bool {
-    matches!(
-        error,
-        chain_client::Error::ReadCertificatesError(_) | chain_client::Error::ViewError(_)
-    )
 }
 
 /// Escalating backoff shared by both scopes: doubles from `retry_delay` per consecutive failure,
@@ -2055,9 +2055,19 @@ where
             }
         };
         if next_height.0.saturating_add(max_blocks) < target_next_height.0 {
-            next_height = self
+            // Best-effort, deliberately: a destination may refuse a checkpoint and must still be
+            // caught up by replaying. Propagating here would fail the round before the replay
+            // below runs, leaving such a destination permanently behind.
+            match self
                 .push_checkpoint_if_useful(chain_id, next_height, checkpoint)
-                .await?;
+                .await
+            {
+                Ok(reached) => next_height = reached,
+                Err(error) => debug!(
+                    %chain_id, %error,
+                    "Checkpoint push rejected; falling back to replaying blocks",
+                ),
+            }
         }
         let last = target_next_height
             .0
@@ -2093,8 +2103,9 @@ where
     /// already restores rather than preprocesses a block that starts with one.
     ///
     /// Mirrors the client's `RemoteNodeUpdater::push_checkpoint_if_useful`. A missing checkpoint
-    /// and an absent certificate are both *not useful*, never errors: the caller's replay path is
-    /// still correct wherever a checkpoint cannot be had.
+    /// and an absent certificate are both *not useful* rather than errors. A push the destination
+    /// **rejects** does return an error, which the caller swallows: replaying blocks is still
+    /// correct wherever a checkpoint cannot be had, and a validator is free not to accept one.
     ///
     /// `checkpoint_height` is announced by the chain's own worker rather than read here. Export
     /// must never open the chain's partition to find it: `Storage` opens it exclusively, and a

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1447,6 +1447,7 @@ where
             blobs,
             epoch,
             (**self.chain.exported_heights.get()).clone(),
+            *self.chain.latest_checkpoint_height.get(),
         );
 
         // Fold in what the queue has recorded so far — which never includes the block we just

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -5388,7 +5388,7 @@ where
         let before = reached;
         reached = Some(
             sender_task
-                .send_missing_blocks(chain_id, target, reached, MAX_CATCH_UP_BLOCKS)
+                .send_missing_blocks(chain_id, target, reached, MAX_CATCH_UP_BLOCKS, None)
                 .await?,
         );
         rounds += 1;
@@ -5544,7 +5544,7 @@ where
 
     // Re-offer an old block, exactly as a re-execution would.
     let reached = sender_task
-        .send_block(&certificate, &[], Some(tip), 100)
+        .send_block(&certificate, &[], Some(tip), 100, None)
         .await?;
     assert_eq!(
         reached, tip,
@@ -5655,12 +5655,90 @@ where
     // Ask with no cursor at all — the state a failed send leaves behind. One bounded round must
     // come back with what the validator actually holds, so the queue can act on the truth.
     let reached = sender_task
-        .send_missing_blocks(chain_id, tip, None, 2)
+        .send_missing_blocks(chain_id, tip, None, 2, None)
         .await?;
     assert_eq!(
         reached,
         BlockHeight(2),
         "a bounded round must report the validator's own height afterwards",
+    );
+    Ok(())
+}
+
+/// A catch-up window that cannot reach the chain's checkpoint pushes the checkpoint itself, so
+/// the destination installs the state instead of crawling towards it.
+///
+/// Without this the window is not merely slow, it can stall outright: `send_missing_blocks` skips
+/// heights whose certificates are not in storage, and a checkpointed chain is exactly where those
+/// are liable to be gone. A window sitting entirely below the checkpoint then sends nothing, the
+/// reported height never moves, and the pair retries the same empty window forever.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_send_missing_blocks_pushes_a_checkpoint_past_the_window<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    use crate::remote_node::RemoteNode;
+
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let chain = builder.add_root_chain(1, Amount::from_tokens(7)).await?;
+    let target = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = chain.chain_id();
+
+    // Validator 3 misses the whole chain, so it stays at height 0 with the checkpoint above it.
+    builder.set_fault_type([3], FaultType::Offline);
+    chain
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    chain
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    let checkpoint_cert = chain.checkpoint().await.unwrap().unwrap();
+    assert_eq!(checkpoint_cert.block().header.height, BlockHeight::from(2));
+    for _ in 0..2 {
+        chain
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(target.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+    let tip = chain.chain_info().await?.next_block_height;
+    assert_eq!(tip, BlockHeight(5));
+    builder.set_fault_type([3], FaultType::Honest);
+    assert_eq!(builder.next_block_height(3, chain_id).await, BlockHeight(0));
+
+    let storage = builder.validator_storage(0);
+    let node = builder.node(3);
+    let mut sender_task = crate::chain_worker::export::BlockSender {
+        remote_node: RemoteNode {
+            public_key: node.name(),
+            node,
+        },
+        storage,
+        certificate_upload_batch_size: 100,
+    };
+
+    // A window of 2 from height 0 stops at height 2 — the checkpoint — and would need another
+    // round to cross it. Pushing the checkpoint first lets the same single round finish the
+    // chain, so reaching the tip is what distinguishes the two behaviours.
+    //
+    // The height is passed in, as the queue passes it: it is announced by the chain's own
+    // worker, because export loading the chain itself would race the worker's `ChainStateView`.
+    let checkpoint_height = checkpoint_cert.block().header.height;
+    let reached = sender_task
+        .send_missing_blocks(chain_id, tip, None, 2, Some(checkpoint_height))
+        .await?;
+    assert_eq!(
+        reached, tip,
+        "the checkpoint push must carry the destination past a window it could not reach",
     );
     Ok(())
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -5742,3 +5742,65 @@ where
     );
     Ok(())
 }
+
+/// A destination that refuses checkpoints is still caught up, by replaying blocks.
+///
+/// Validators are free not to adopt someone else's execution state. Failing the round when a push
+/// is rejected would leave such a destination permanently behind — strictly worse than never
+/// having offered the checkpoint, because the replay below never runs.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_a_destination_refusing_checkpoints_still_replays<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    use crate::remote_node::RemoteNode;
+
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let chain = builder.add_root_chain(1, Amount::from_tokens(7)).await?;
+    let chain_id = chain.chain_id();
+
+    builder.set_fault_type([3], FaultType::Offline);
+    chain
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    chain
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    let checkpoint_cert = chain.checkpoint().await.unwrap().unwrap();
+    let checkpoint_height = checkpoint_cert.block().header.height;
+    assert_eq!(checkpoint_height, BlockHeight::from(2));
+    let tip = chain.chain_info().await?.next_block_height;
+
+    // Honest for ordinary blocks, refuses only the checkpoint.
+    builder.set_fault_type([3], FaultType::RejectCheckpoints);
+    assert_eq!(builder.next_block_height(3, chain_id).await, BlockHeight(0));
+
+    let storage = builder.validator_storage(0);
+    let node = builder.node(3);
+    let mut sender_task = crate::chain_worker::export::BlockSender {
+        remote_node: RemoteNode {
+            public_key: node.name(),
+            node,
+        },
+        storage,
+        certificate_upload_batch_size: 100,
+    };
+
+    // The window (2) cannot reach the tip, so the push is attempted and rejected. The round must
+    // still return the height replaying reached, not an error.
+    let reached = sender_task
+        .send_missing_blocks(chain_id, tip, None, 2, Some(checkpoint_height))
+        .await?;
+    assert_eq!(
+        reached,
+        BlockHeight(2),
+        "a rejected checkpoint must fall back to replaying, not fail the round",
+    );
+    Ok(())
+}

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -78,6 +78,9 @@ pub enum FaultType {
     DontSendConfirmVote,
     DontProcessValidated,
     DontSendValidateVote,
+    /// Refuses blocks that install a checkpoint, and behaves honestly for everything else — a
+    /// validator that declines to adopt someone else's execution state but still replays history.
+    RejectCheckpoints,
 }
 
 /// A validator used for testing. "Faulty" validators ignore block proposals (but not
@@ -162,6 +165,16 @@ where
         certificate: CacheArc<ConfirmedBlockCertificate>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
+        // Checked here as well as on the lite path: a validator that declines checkpoints declines
+        // them however they arrive, and export sends the full certificate when the destination
+        // never signed the block.
+        if self.fault_type == FaultType::RejectCheckpoints
+            && certificate.block().starts_with_checkpoint()
+        {
+            return Err(NodeError::ClientIoError {
+                error: "refusing to install a checkpoint".to_string(),
+            });
+        }
         self.spawn_and_receive(move |validator, sender| {
             validator.do_handle_certificate::<ConfirmedBlock>(
                 CacheArc::unwrap_or_clone(certificate),
@@ -398,7 +411,8 @@ where
                 error: "offline".to_string(),
             }),
             FaultType::NoChains => Err(NodeError::InactiveChain(proposal.content.block.chain_id)),
-            FaultType::DontSendValidateVote
+            FaultType::RejectCheckpoints
+            | FaultType::DontSendValidateVote
             | FaultType::Honest
             | FaultType::DontSendConfirmVote
             | FaultType::DontProcessValidated => {
@@ -432,6 +446,14 @@ where
         let validator = client.lock().await;
         let result = async move {
             match validator.state.full_certificate(certificate).await? {
+                Either::Left(confirmed)
+                    if self.fault_type == FaultType::RejectCheckpoints
+                        && confirmed.block().starts_with_checkpoint() =>
+                {
+                    Err(NodeError::ClientIoError {
+                        error: "refusing to install a checkpoint".to_string(),
+                    })
+                }
                 Either::Left(confirmed) => {
                     self.do_handle_certificate_internal::<ConfirmedBlock>(confirmed, &validator)
                         .await
@@ -459,6 +481,7 @@ where
             }
             FaultType::NoChains => Err(NodeError::InactiveChain(certificate.value().chain_id())),
             FaultType::Honest
+            | FaultType::RejectCheckpoints
             | FaultType::DontSendConfirmVote
             | FaultType::DontProcessValidated
             | FaultType::DontSendValidateVote => {
@@ -507,6 +530,7 @@ where
             }),
             FaultType::NoChains => Err(NodeError::InactiveChain(query.chain_id)),
             FaultType::Honest
+            | FaultType::RejectCheckpoints
             | FaultType::DontSendConfirmVote
             | FaultType::DontProcessValidated
             | FaultType::DontSendValidateVote


### PR DESCRIPTION
## Motivation

Block export catches a lagging validator up by replaying blocks from storage, at most
`--block-export-max-catch-up-blocks` (default 200) per round. `send_missing_blocks` skips heights
whose certificates it cannot read — correct for a chain we only receive from, which is stored only
at its message-bearing blocks.

On a **checkpointed** chain that skipping stops being harmless, because a validator can legitimately
not hold its own early history. `execute_block_with_checkpoint_restore` installs state from the
checkpoint's `execution_state_blobs` and acquires only the checkpoint block plus the pre-checkpoint
blocks named in `outbox_block_hashes` — this chain's blocks at heights with unacknowledged outbox
entries (`collect_unfinalized_block_hashes`, reading `self.block_hashes`). It never fetches the rest
of `0..C`.

So a validator that bootstrapped from a checkpoint, acting as an export **sender** to a destination
below `C`, reads heights it does not hold, skips them, sends nothing, and the height the destination
reports never moves. `record_reached` sees no advance, backs the pair off, and the next round
retries the same empty window. It does not converge.

**This is prospective, not a live bug.** Nothing creates checkpoints automatically —
`ChainClient::checkpoint()`'s only non-test caller is `cli/main.rs` — and `testnet_conway` has no
checkpoint machinery at all. The point is to be correct before that changes, not to fix an
outage.

*(An earlier version of this description said pre-checkpoint certificates "may be pruned". That
overstates: pruning is a property the spec permits — `linera-chain/src/proof/checkpoints.rs`
describes a checkpoint as pruning "this chain's *history* — its older blocks" — but nothing in
`linera-storage/src` deletes certificates today. The reachable mechanism is the one above.)*

## Proposal

When the window cannot reach the target, offer the chain's latest checkpoint certificate first. The
destination installs the execution state, its reported height jumps past the checkpoint, and the
remaining heights are sent from there. The receiving side already dispatches on
`(mode, gap, starts_with_checkpoint)` and restores rather than preprocesses; the client's
`RemoteNodeUpdater::push_checkpoint_if_useful` already does this. Only export did not.

**The push is best-effort.** A validator is free to refuse someone else's execution state, so a
rejected push falls through to replaying blocks rather than failing the round. Propagating there
would leave a refusing destination permanently behind — strictly worse than never offering the
checkpoint, since the replay below never runs. Thanks @ma2bd for raising this; the first version
propagated.

**The checkpoint height is announced by the chain's own worker, never read by export.**
`Storage::load_chain` is not a read: it opens the chain partition exclusively, and two live
`ChainStateView`s for one chain are documented as causing "invalid states and data corruption". The
export queue is deliberately not serialized with the chain worker, so it takes the height along the
existing tip announcement, where the worker already holds `self.chain`:

```
state.rs  →  ChainAnnouncement { tip, checkpoint }  →  ChainRecord.checkpoint
          →  spawn_job  →  send_block / send_missing_blocks  →  push_checkpoint_if_useful
```

Both fields merge by maximum, as the tip already did.

`send_confirmed_certificate` also gains a once-only `BlocksNotFound` arm, because a checkpoint push
provokes it: the destination trust-marks the pre-checkpoint sender blocks it lacks and refuses the
restore until it has them. A hash the destination named but we do not hold is reported as **that
destination's** error, not a read failure — `is_local_scoped` matches `ReadCertificatesError` and
halves the queue's *shared* in-flight budget, so mapping it the way the client does would let one
peer throttle export to every other validator while the log blamed our storage.

### Known trade-off

A destination that always refuses checkpoints costs one rejected push per catch-up round. Recording
the refusal would avoid that, but it means per-(chain, destination) state, and `ChainDest` is
allocated per pair — 246 B/chain at the sizes this queue is built for. One extra RPC against a round
that already sends up to 200 certificates seemed the better trade; happy to revisit.

## Test Plan

```
cargo test -p linera-core --lib
cargo clippy --locked --workspace --all-targets --all-features --exclude linera-web -- -D warnings
cargo +nightly fmt
./scripts/check_chain_loads.sh
```

Three new tests, each verified to **fail** against the unfixed code rather than merely pass:

- `test_send_missing_blocks_pushes_a_checkpoint_past_the_window` — 5-block chain checkpointed at
  height 2, destination at 0, window 2. Reaches the tip in one round; without the push it returns
  `BlockHeight(2)`.
- `test_a_destination_refusing_checkpoints_still_replays` — new `FaultType::RejectCheckpoints`
  refuses checkpoint blocks and is honest otherwise. Passes at `BlockHeight(2)` via replay; with the
  push propagating it fails with `refusing to install a checkpoint`. The fault is injected on the
  **full**-certificate path as well as the lite one — the first attempt wired it only into the lite
  path, where export never sends, and the test passed for the wrong reason.
- `a_destinations_missing_block_is_scoped_to_that_destination` — calls the production constructor,
  so reverting the mapping to `ReadCertificatesError` fails it; carries a positive control that a
  genuine read failure is still local, and that the sibling `BlobsNotFound` keeps its own scope.

**What the tests cannot show.** All are `MemoryStorageBuilder`-only, and memory's `clear_journal` is
a no-op, so nothing here exercises the journaling behaviour that made the original `load_chain`
approach unsafe. That is why the fix is structural — export has no `load_chain` call at all — rather
than something a test guards.

Main-only: `testnet_conway` has neither `push_checkpoint_if_useful` nor the restore dispatch, so
there is nothing to backport.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6639 / #6726 — block export, and its front-port to `main`
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
