### PR TITLE
Retire a chain worker on any storage write that evicts it

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -410,6 +410,18 @@ jobs:
       run: |
         ./scripts/check_chain_loads.sh
 
+  lint-chain-worker-writes:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+    - name: Check that chain worker storage writes poison on failure
+      run: |
+        ./scripts/check_chain_worker_writes.sh
+
   lint-metrics-registration:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -46,7 +46,7 @@ use linera_views::{
     ViewError,
 };
 use tokio::sync::oneshot;
-use tracing::{debug, info, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::{
     chain_worker::{
@@ -131,8 +131,8 @@ where
     chain_modes: Option<Arc<sync::RwLock<ChainModes>>>,
     delivery_notifier: DeliveryNotifier,
     knows_chain_is_active: bool,
-    /// Set to `true` once this instance has been retired: the cache has dropped it and a
-    /// replacement may already be serving the chain, so it must not write again.
+    /// Set to `true` once a storage write failed in a way that requires reloading the chain
+    /// view: this instance must not write again.
     poisoned: bool,
     /// The process-wide export queue, if the server enabled block export.
     block_export: Option<BlockExportHandle>,
@@ -243,23 +243,24 @@ where
         self.chain.rollback();
     }
 
-    /// Returns `WorkerError::PoisonedWorker` if this instance has been retired after a storage
-    /// write that also evicted it from the worker cache.
+    /// Returns `WorkerError::PoisonedWorker` if this instance has been poisoned by a storage
+    /// write that requires reloading the chain view.
     pub(crate) fn check_not_poisoned(&self) -> Result<(), WorkerError> {
         ensure!(!self.poisoned, WorkerError::PoisonedWorker);
         Ok(())
     }
 
-    /// Retires this instance if `result` carries an error that also evicts it from the worker
-    /// cache, so a writer already queued on our lock cannot go on using an instance the cache has
-    /// replaced. Must be called while the write guard is held.
+    /// Poisons this instance if `result` carries an error that requires reloading the chain view.
+    ///
+    /// Must be called while the write guard is held: `write_lock` checks the flag only *after*
+    /// acquiring the lock, so poisoning here also stops a writer already queued behind us.
     fn poison_if_must_reload<T>(&mut self, result: Result<T, ViewError>) -> Result<T, ViewError> {
         if let Err(error) = &result {
             if error.must_reload_view() {
-                tracing::warn!(
+                error!(
                     chain_id = %self.chain_id(),
                     ?error,
-                    "Storage write failed; retiring this chain worker instance"
+                    "Chain worker poisoned: storage write failed with a nonrecoverable error"
                 );
                 self.poisoned = true;
             }
@@ -2645,10 +2646,10 @@ where
     pub(crate) async fn save(&mut self) -> Result<(), WorkerError> {
         if let Err(error) = self.chain.save().await {
             if error.must_reload_view() {
-                tracing::error!(
-                    ?error,
+                error!(
                     chain_id = %self.chain_id(),
-                    "Chain save failed with a nonrecoverable error; marking worker as poisoned"
+                    ?error,
+                    "Chain worker poisoned: chain save failed with a nonrecoverable error"
                 );
                 self.poisoned = true;
             }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -43,6 +43,7 @@ use linera_storage::{Clock as _, Storage};
 use linera_views::{
     context::{Context, InactiveContext},
     views::{ReplaceContext as _, RootView as _, View as _},
+    ViewError,
 };
 use tokio::sync::oneshot;
 use tracing::{debug, info, instrument, trace, warn};
@@ -130,8 +131,8 @@ where
     chain_modes: Option<Arc<sync::RwLock<ChainModes>>>,
     delivery_notifier: DeliveryNotifier,
     knows_chain_is_active: bool,
-    /// Set to `true` if a database `save` failure has left storage potentially
-    /// inconsistent.
+    /// Set to `true` once this instance has been retired: the cache has dropped it and a
+    /// replacement may already be serving the chain, so it must not write again.
     poisoned: bool,
     /// The process-wide export queue, if the server enabled block export.
     block_export: Option<BlockExportHandle>,
@@ -242,11 +243,28 @@ where
         self.chain.rollback();
     }
 
-    /// Returns `WorkerError::PoisonedWorker` if the worker is poisoned due to a database
-    /// `save` failure.
+    /// Returns `WorkerError::PoisonedWorker` if this instance has been retired after a storage
+    /// write that also evicted it from the worker cache.
     pub(crate) fn check_not_poisoned(&self) -> Result<(), WorkerError> {
         ensure!(!self.poisoned, WorkerError::PoisonedWorker);
         Ok(())
+    }
+
+    /// Retires this instance if `result` carries an error that also evicts it from the worker
+    /// cache, so a writer already queued on our lock cannot go on using an instance the cache has
+    /// replaced. Must be called while the write guard is held.
+    fn poison_if_must_reload<T>(&mut self, result: Result<T, ViewError>) -> Result<T, ViewError> {
+        if let Err(error) = &result {
+            if error.must_reload_view() {
+                tracing::warn!(
+                    chain_id = %self.chain_id(),
+                    ?error,
+                    "Storage write failed; retiring this chain worker instance"
+                );
+                self.poisoned = true;
+            }
+        }
+        result
     }
 
     /// Updates the last-access timestamp to the current time.
@@ -929,24 +947,29 @@ where
             .map(|blobs| blobs.into_values().collect::<Vec<_>>());
 
         if let Ok(blobs) = &blobs_result {
-            self.storage
+            let result = self
+                .storage
                 .write_blobs_and_certificate(blobs, &certificate)
-                .await?;
+                .await;
+            self.poison_if_must_reload(result)?;
             let events = block
                 .body
                 .events
                 .iter()
                 .flatten()
                 .map(|event| (event.id(chain_id), event.value.clone()));
-            self.storage.write_events(events).await?;
+            let result = self.storage.write_events(events).await;
+            self.poison_if_must_reload(result)?;
         }
 
         // Update the blob state with last used certificate hash.
         let blob_state = certificate.value().to_blob_state(blobs_result.is_ok());
         let blob_ids = required_blob_ids.into_iter().collect::<Vec<_>>();
-        self.storage
+        let result = self
+            .storage
             .maybe_write_blob_states(&blob_ids, blob_state)
-            .await?;
+            .await;
+        self.poison_if_must_reload(result)?;
 
         let blobs = blobs_result?
             .into_iter()

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1048,7 +1048,7 @@ where
     {
         let this = self.clone();
         linera_base::Task::spawn(async move {
-            let requests = {
+            let result = {
                 let mut guard = match handle::write_lock(&state).await {
                     Ok(guard) => guard,
                     Err(error) => {
@@ -1056,18 +1056,25 @@ where
                             %chain_id, %error,
                             "Failed to acquire write lock to reset corrupted chain state"
                         );
+                        if error.must_reload_view() {
+                            this.evict_poisoned_worker(chain_id, &state);
+                        }
                         return;
                     }
                 };
-                match guard.maybe_reset_corrupted_chain_state().await {
-                    Ok(Some(requests)) => requests,
-                    Ok(None) => return,
-                    Err(error) => {
-                        tracing::error!(
-                            %chain_id, %error, "Failed to reset corrupted chain state"
-                        );
-                        return;
+                guard.maybe_reset_corrupted_chain_state().await
+            };
+            let requests = match result {
+                Ok(Some(requests)) => requests,
+                Ok(None) => return,
+                Err(error) => {
+                    tracing::error!(
+                        %chain_id, %error, "Failed to reset corrupted chain state"
+                    );
+                    if error.must_reload_view() {
+                        this.evict_poisoned_worker(chain_id, &state);
                     }
+                    return;
                 }
             };
             if let Some(sender) = &this.outbound_cross_chain_sender {
@@ -1291,11 +1298,16 @@ where
         )
         .await?;
 
-        Ok(handle::create_chain_worker(
-            state,
-            is_tracked,
-            &self.chain_worker_config,
-        ))
+        let worker = handle::create_chain_worker(state, is_tracked, &self.chain_worker_config);
+        // Two instances of one chain racing on storage is the corruption mode we cannot
+        // otherwise observe; simultaneously live instances cannot share an address, so the
+        // Arc pointer is enough to tell them apart in the logs.
+        tracing::info!(
+            %chain_id,
+            instance = ?Arc::as_ptr(&worker),
+            "Loaded chain worker instance"
+        );
+        Ok(worker)
     }
 
     /// Tries to execute a block proposal without any verification other than block execution.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -428,7 +428,7 @@ pub enum WorkerError {
 
     #[error("Fallback mode is not available on this network")]
     NoFallbackMode,
-    #[error("Chain worker was poisoned by a journal resolution failure")]
+    #[error("Chain worker was retired after a storage write that may not have been applied")]
     PoisonedWorker,
     #[error("Cross-chain batch was rolled back due to an error in another request")]
     BatchRolledBack,

--- a/scripts/check_chain_worker_writes.sh
+++ b/scripts/check_chain_worker_writes.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Check that every chain-worker storage write goes through `poison_if_must_reload`.
+#
+# A storage write failing with `must_reload_view` evicts the chain worker from the cache, but
+# eviction alone does not stop the evicted instance from writing: `chain_workers` holds a `Weak`,
+# and the per-chain lock lives inside the instance, so a writer already queued on that lock keeps
+# going while the next request loads a second `ChainStateView` for the same chain. Two live views
+# race on storage and split the durable state by write granularity, which is data corruption.
+#
+# `poison_if_must_reload` sets the `poisoned` flag while the write guard is still held, so the
+# queued writer fails its own `check_not_poisoned` instead of writing through a retired instance.
+# A write that skips the helper silently reopens that window, and nothing else catches it: the
+# error still propagates, the worker is still evicted, and every test still passes.
+
+set -uo pipefail
+
+# Make sure we're at the source of the repo.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+status=0
+
+# Fail loudly rather than vacuously: if the chain worker moves or the helper is renamed, the scan
+# below would find nothing to complain about and this check would pass while guarding nothing.
+if [ ! -d linera-core/src/chain_worker ]; then
+    echo "ERROR: linera-core/src/chain_worker does not exist; update this script's scan root."
+    exit 1
+fi
+if ! grep -rq 'fn poison_if_must_reload' linera-core/src/chain_worker; then
+    echo "ERROR: poison_if_must_reload is gone from linera-core/src/chain_worker."
+    echo "       If it was renamed, rename it here too; if it was removed, this check is moot"
+    echo "       and the invariant it protects needs a new home."
+    exit 1
+fi
+
+# Rust wraps long method chains, so lines starting with `.` are folded into the statement above
+# before matching, and `//` comments are dropped so prose cannot satisfy the check. The helper
+# must appear on the same statement or the one immediately after — that is the only shape in use,
+# and a wider window would let one guarded write vouch for an unguarded neighbour.
+while read -r file; do
+    awk -v file="$file" '
+        {
+            line = $0
+            sub(/\/\/.*/, "", line)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+            if (line ~ /^\./ && n > 0) {
+                buf[n] = buf[n] line
+            } else {
+                n++
+                buf[n] = line
+                lineno[n] = NR
+            }
+        }
+        END {
+            for (i = 1; i <= n; i++) {
+                if (buf[i] !~ /storage\.[a-z_]*(write|save|delete|remove|persist)[a-z_]*\(/)
+                    continue
+                if (buf[i] ~ /poison_if_must_reload/) continue
+                if (i < n && buf[i + 1] ~ /poison_if_must_reload/) continue
+                printf "ERROR: %s:%d: storage write is not guarded by poison_if_must_reload.\n", \
+                    file, lineno[i]
+                printf "       %s\n", buf[i]
+                bad = 1
+            }
+            exit bad
+        }
+    ' "$file" || status=1
+done < <(find linera-core/src/chain_worker -name '*.rs')
+
+if [ "$status" -ne 0 ]; then
+    echo
+    echo "Wrap the write so the failure poisons this instance before the guard is released:"
+    echo "    let result = self.storage.write_something(..).await;"
+    echo "    self.poison_if_must_reload(result)?;"
+    echo
+    echo "See scripts/check_chain_worker_writes.sh for why this matters."
+fi
+
+exit "$status"


### PR DESCRIPTION
## Motivation

A `must_reload_view` storage error evicts a chain worker from the cache, but **eviction alone does
not stop that instance from writing**. The result is that two `ChainStateView`s for the same chain
can be live and writing at once.

The mechanics, all on `testnet_conway`:

- `chain_workers` maps `ChainId` to a **`Weak`** (`worker.rs:1182-1246`), so removing the entry does
  not destroy the instance.
- The per-chain lock lives **inside** the instance — `create_chain_worker` returns
  `Arc<RwLock<ChainWorkerState<S>>>` (`chain_worker/handle.rs:131-148`). Two instances for one chain
  therefore have two independent locks and are not serialised against each other.
- `chain_write` (`worker.rs:1004-1030`) hands every concurrent caller its own strong `Arc` and runs
  the closure in `run_detached`, which survives caller cancellation. The write guard is dropped when
  the inner block resolves — **before** `evict_poisoned_worker` runs.
- So writers already queued on the lock proceed on the old instance, while the next request misses
  the cache and calls `load_chain` for the same chain.
- `poisoned` — the one flag that would stop the old instance, checked at every lock acquisition via
  `check_not_poisoned` — was set in **exactly one place**: `ChainWorkerState::save()`.

So an error from a **non-`save`** storage write evicted the worker *without* poisoning it, leaving
it writable. `load_chain`'s own doc already warns where that leads
(`linera-storage/src/lib.rs:74-81`):

> Each time this method is called, a new `ChainStateView` is created. If there are multiple
> instances of the same chain active at any given moment, they will race to access persistent
> storage. This can lead to invalid states and data corruption.

Concretely, when two views race, the durable state splits by **write granularity**: whole-value
views regress (`tip_state`, `outbox_counters`, `nonempty_outboxes` are `RegisterView`s whose
`pre_save` rewrites the entire value; `confirmed_log` rewrites its count key in lockstep), while
per-key views keep the other view's deltas (`preprocessed_blocks` is a `MapView` emitting only its
own `updates`; `outboxes` writes only the sub-views it loaded). That yields an outbox scheduled past
a height whose `preprocessed_blocks` entry is gone, with the tip behind it.

## Proposal

Set `poisoned` on **any** `must_reload_view` error from the certificate path's storage writes —
`write_blobs_and_certificate`, `write_events`, `maybe_write_blob_states` — not just on a failed
`save()`.

Placement matters: the flag is set **while the write guard is still held**. `write_lock`
(`handle.rs:188-195`) awaits the lock and *then* calls `check_not_poisoned`, so a writer queued
behind us cannot have passed the check yet, and fails once it acquires the lock. Poisoning at the
eviction site instead would be too late for the first queued writer.

Scope note, from review: these three writes target *different partitions* than the chain view
(`RootKey::Blob`/`ConfirmedBlock`/`BlockByHeight`/`Event` vs `RootKey::ChainState`, and
`DbStorage::write_batch` opens a store per root key). A failure there says nothing about the
in-memory chain view being untrustworthy — the reason to retire the instance is narrower and purely
that **this error class evicts it**, so it must not keep writing. The helper is named and documented
for that reason, not for view distrust.

### The reset path evicts too

`reset_and_reexecute_chain` commits `self.chain.clear()` and then re-executes every confirmed block,
so a reset runs the three now-poisoning writes once per block — a chain with N blocks gains ~3N
poison opportunities per reset attempt.

Poisoning *during* a reset is the behaviour we want: if re-execution aborts partway, the on-disk
chain sits at a partial tip and the cached in-memory instance is the last thing that should go on
serving it. What was missing is the **eviction**. `spawn_reset_corrupted_chain_state` runs under
`Task::spawn` rather than `chain_write` and only logged its error, so a poisoned instance stayed in
the cache. It now evicts on `must_reload_view` exactly as `chain_write` does.

That hole predates this PR — `save()` already poisoned mid-reset, and the poisoned instance survived
in the cache until some later `chain_read`/`chain_write` happened to trip `check_not_poisoned` — but
this PR would have made it roughly 4x more likely by adding three more poisoning sites per
re-executed block. Fixing it here rather than leaving it for the follow-up.

### Both poison sites now log the same way

`save()` logged at `error!` with `"Chain save failed with a nonrecoverable error"`; the new site
logged at `warn!` with an unrelated message. Same event class, two levels, no shared substring.
Our alerting matches Loki **substrings** — `linera-infra`'s `argo/app-values/loki/infra-values.yaml`
builds `linera:corrupted_chains:count` from `|= "Corrupted chain state"` — so a rule written against
one site would have silently missed the other. Both now log at `error!` behind the shared prefix
`Chain worker poisoned:`.

Correcting an earlier version of this description: the storage error was **not** previously
invisible on the main request paths. `linera-rpc/src/grpc/server.rs`'s `log_error` logs at `error!`
whenever `WorkerError::is_local()` is true, and every `ViewError` except `NotFound` is in that arm
(`worker.rs:441-473`); it also increments `linera_server_request_error`. What genuinely was not
logged is the **cross-chain batch** path — `classify_processing_error` hands the real error to
`chain_write` for recovery and returns `BatchRolledBack` to the caller, so the store error never
reaches `log_error` — and the detached reset task. Both are covered now, at the poison site itself.

### Making the second view observable

Nothing logged the creation of a second `ChainStateView` for a chain. That is precisely why the
incident below is circumstantial rather than proven, and it would have stayed that way next time.

`load_chain_worker` now logs `chain_id` plus the worker's `Arc` address at `info!` (prod runs at
`info`). Two simultaneously live instances cannot share an allocation, so the pointer is a sound
discriminator for exactly this question: two `Loaded chain worker instance` lines for one chain with
no eviction between them is direct evidence of the race, instead of an inference from timing.

### A guardrail for the invariant

The new rule — every storage write under a chain-worker guard goes through `poison_if_must_reload` —
was enforced by nothing. The repo already has the idiom for the sibling bug class:
`scripts/check_chain_loads.sh`, wired into `.github/workflows/rust.yml`.

`scripts/check_chain_worker_writes.sh` follows it, failing if a `storage.*(write|save|delete|remove|
persist)*` call under `linera-core/src/chain_worker/` is not guarded by the helper on its own
statement or the next one. It folds Rust's wrapped method chains back together first (the real call
sites span four lines) and strips `//` comments so prose cannot satisfy it.

Verified against a probe file with five shapes: it flags an unguarded inline write, an unguarded
multi-line chain, and a write whose only "guard" is a comment naming the helper, while passing both
guarded forms — and passes on the tree as it stands.

## Test Plan

```
cargo check  -p linera-core --all-targets    # Finished, 0 errors
cargo clippy -p linera-core --all-targets    # 0 warnings
cargo test   -p linera-core --lib            # 187 passed, 0 failed
./scripts/check_chain_worker_writes.sh       # exit 0; exit 1 on the probe
```

**This PR ships no new test, and that is its main weakness.** The poison/evict machinery — both the
pre-existing `save()` path and these new sites — has no executable coverage at all:
`grep -rn "poison\|PoisonedWorker" linera-core/src/unit_tests/ linera-core/tests/` returns nothing.

The test that should exist: a store wrapper that fails one `write_batch` with
`ViewError::StoreError { must_reload_view: true, .. }`, asserting (a) `poisoned` is set, (b) it is
*not* set for a benign store error, (c) the next request is served by a freshly loaded worker. That
needs a fault-injecting `KeyValueDatabase`/`KeyValueStore` wrapper plus `StorageBuilder` wiring —
new test infrastructure worth doing as its own change rather than appended here. Happy to land it
first if reviewers prefer.

## Prior art — and why this is not a revert of #6333

This area has been tuned deliberately, so to be explicit about where this sits:

- **#6053** (2026-04-19) made `save()` poison on **any** error, because "other write errors (e.g.
  possible ScyllaDB timeouts) left the worker loaded with potentially stale state."
- **#6333 / #6341** (2026-05-19) walked that back — *"for performance reasons, especially under
  heavy load"* — splitting errors into **recoverable** (transient read or single-row write; on-disk
  state hasn't moved, so roll back and continue) and **non-recoverable** (the write is *ambiguous*,
  e.g. a batch timeout, or *partially applied*, e.g. journal resolution). `must_reload_view` was
  defined as exactly that second set. Its historical description also listed a DynamoDB
  `TransactWriteItem` case; there is no DynamoDB backend in this tree any more
  (`linera-views/src/backends/` is `dual`, `indexed_db`, `journaling`, `lru_caching`, `memory`,
  `metering`, `rocks_db`, `scylla_db`, `value_splitting`). The **live** producers are ScyllaDB's
  `WriteBatchExecutionError` and journaling's `JournalResolutionFailed`, both reachable only through
  `write_batch`; local backends produce none.
- **#6507 / #6508** (2026-06-18) fixed `JournalingError::must_reload_view` not delegating for
  `Inner(_)`, which had been shadowing the backend's classification on the fast path.

**This PR poisons on `error.must_reload_view()` — #6333's exact narrow set — not on any storage
error.** It applies that existing classification to three write sites that were never wired to it.
It does not widen `must_reload_view`. The only new eviction is the reset path's, which brings
`spawn_reset_corrupted_chain_state` in line with `chain_write`; the three write sites add none,
since those errors already evicted through `chain_write`'s (unchanged) branch. The behavioural delta
is that writers queued on the already-evicted instance now fail fast instead of writing through it.
A second eviction attempt is harmless — **#5936** added the `ptr_eq` guard so eviction cannot
clobber a replacement.

One nuance worth a reviewer's eye: #6333's rationale is "the in-memory view can no longer be
trusted." That reasoning does **not** transfer to these three sites, whose writes target different
partitions than the chain view. The justification here is narrower — this error class *evicts* the
instance, and an evicted-but-still-writable instance races its replacement.

Related: `#6497` describes the intended contract, that `must_reload_view` is the **fail-closed**
path ("the next `read_lock`/`write_lock` hits `check_not_poisoned()` … and the worker is evicted"),
whereas `CorruptedChainState` is not self-healing. This change puts three more sites on the
fail-closed path.

### Relationship to `afck/conway-save-cancel-safe`

That unmerged branch (2026-04-21) carries two commits:

1. *"Poison chain worker on cancelled save"* — makes the poison sticky across cancellation between
   `write_batch` landing and `post_save`. **Superseded**: #6090/#6091 ("Make chain worker writes
   cancel-safe", 2026-04-22) fixed that at the source by running the write and `save()` under
   `run_detached`, so caller cancellation cannot tear a save apart mid-flight. Not reproduced here.
2. *"Generalize PoisonedWorker error and doc wording"* — **never landed**; `testnet_conway` still
   says "poisoned by a journal resolution failure", which is wrong now that a plain Scylla write
   timeout is the other producer. This PR fixes that independently. afck proposed
   *"Chain worker in-memory state is stale and must be reloaded from storage"*; this PR uses wording
   that also covers the non-`save` sites, where the chain view is not what went stale. Happy to take
   his phrasing instead if preferred.

## Known limitations

Found during review; all pre-existing and none introduced by this change, but they bound what it
fixes:

1. **The gate is acquisition-only.** Setting `poisoned` mid-guard does not stop the rest of the
   current guard's work. `maybe_reset_corrupted_chain_state` drives `process_confirmed_block` over
   many blocks under a single guard and is safe only because both call sites end in `?`. A future
   `.ok()` would silently reopen the window.
2. **Poison-without-evict lanes remain.** `describe_application` and `read_certificate` reach
   `save()` through `read_lock_initialized` → `initialize_and_save_if_needed`, and
   `chain_state_view` calls `read_lock` directly (`worker.rs:1369`, `:1528`, `:1546`). A poisoned
   instance there sits in the cache until some later `chain_read`/`chain_write` evicts it.
   `spawn_reset_corrupted_chain_state` was the fourth such lane and is fixed here.
3. **The three writes are still not atomic with each other.** `write_blobs_and_certificate` commits
   before `write_events` runs, and `WriteBatchExecutionError` is documented as "may or may not have
   happened" (`scylla_db.rs:821-824`). This change converts an unbounded stale-view race into a
   bounded partial write; it does not make the sequence atomic.

Verified *not* a problem: no stall, hot-loop or livelock — a poisoned worker is always replaced by
`get_or_create_chain_worker`, and a failed load re-inserts a loading slot rather than wedging. Blast
radius under a storage outage is unchanged, since these same errors already caused eviction (and
therefore a reload) before this change; the only delta is that queued writers now fail fast instead
of attempting their own doomed writes.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

  Targets `testnet_conway` directly.

## Links

Found while investigating a `CorruptedChainState` on one `testnet_conway` chain, where a worker was
evicted 5.6s before the chain's first `"missing entry in preprocessed_blocks"`, with no
`"Chain save failed"` log — i.e. an eviction of exactly the non-poisoning kind this PR addresses.
That incident motivated the change but is not offered as proof of it: the creation of the second
view was not logged anywhere, so the evidence chain is exclusive but not directly observed. The new
`Loaded chain worker instance` line is what makes the next occurrence directly checkable.
