### PR TITLE
Print why a validator is faulty, not just how many errors it had

### DIFF
--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -694,6 +694,11 @@ impl List {
             println!("\nFaulty validators:");
             for ((name, address), errors) in faulty_validators {
                 println!("  {} at {}: {} error(s)", name, address, errors.len());
+                // A bare count sends the reader hunting for the cause in the log
+                // above; the errors are already in hand.
+                for error in errors {
+                    println!("    {error}");
+                }
             }
             anyhow::bail!("Found faulty validators");
         }


### PR DESCRIPTION
## Motivation

When `linera validator list` finds a faulty validator, it reports how many errors it hit and
never says what they were:

```
Faulty validators:
  03285210…df at grpcs:linera-testnet.rubynodes.io:443: 1 error(s)
```

`1 error(s)` is not a diagnosis. It does not say whether the validator refused the connection,
timed out, returned a gRPC error, or is missing a blob — and those need completely different
responses from whoever is on call.

This bit us in production. A daily automated check reported exactly the line above for an
external validator; the operator running it had no way to tell what was wrong, who to escalate
to, or whether it was our problem or the validator's. Over the last two weeks that same one-line
report covered two entirely different faults — an HTTP 502 from the operator's reverse proxy,
and `Blobs not found` for a chain description — which were indistinguishable in the output.

The errors are already in hand at that point. `faulty_validators` maps each validator to the
`Vec` of errors that made it faulty, and only `.len()` is read.

## Proposal

Print them, indented under the validator they belong to:

```
Faulty validators:
  03285210…df at grpcs:linera-testnet.rubynodes.io:443: 1 error(s)
    Failed to get chain info for validator grpcs:linera-testnet.rubynodes.io:443 and chain
    291794fc…: Grpc error: remote request [handle_chain_info_query] failed with status:
    Status { code: Unavailable, message: "grpc-status header missing, mapped from HTTP status
    code 502", metadata: MetadataMap { headers: {"server": "Caddy", …} }, source: None }
```

The count line is kept, so anything parsing it is unaffected; the detail is added beneath.

These same values are already rendered with `tracing::error!("{}", error)` a few lines above,
so this adds no new formatting requirement — it puts the same text in the summary a reader is
actually looking at, instead of leaving them to correlate it by hand against log output that
may be far above, interleaved, or suppressed by the log level.

## Test Plan

`cargo check -p linera-service --bin linera` — clean, exit 0, no warnings.
`cargo clippy --locked -p linera-service --bin linera --all-targets` — clean.

CI's `cargo clippy --all-features --workspace` was not reproducible locally: on this aarch64
host `linera-wasmer-compiler-singlepass` fails to build (`E0463: can't find crate for
wasmer_types`), which is unrelated to this change and does not occur on CI's
`x86_64-unknown-linux-gnu`. Leaving that to CI.

**The printed text is predictable rather than guessed.** The values iterated here are the same
ones passed to `tracing::error!("{}", error)` at `validator.rs:671`, and that call's real
rendered output was captured from a production run:

```
ERROR linera_service::cli::validator: Failed to get chain info for validator
grpcs:linera-testnet.rubynodes.io:443 and chain 291794fc…: Grpc error: remote request
[handle_chain_info_query] failed with status: Status { code: Unavailable, message:
"grpc-status header missing, mapped from HTTP status code 502", … }
```

Same `Display` impl, same values, so that is the string this prints.

**Not verified**: the output was not exercised end to end, because that needs a genuinely
faulty validator in the committee — the failure path only triggers when a real validator fails
to answer. The change is a print of values already proven to implement `Display` at this exact
call site.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
