### PR TITLE
Backport #6752 to testnet_conway: merge the lite benchmark into linera benchmark

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -653,6 +653,21 @@ Start a single benchmark process, maintaining a given TPS
 * `--delay-between-chains-ms <DELAY_BETWEEN_CHAINS_MS>` — The delay between chains, in milliseconds. For example, if set to 200ms, the first chain will start, then the second will start 200 ms after the first one, the third 200 ms after the second one, and so on. This is used for slowly ramping up the TPS, so we don't pound the validators with the full TPS all at once
 * `--config-path <CONFIG_PATH>` — Path to YAML file containing chain IDs to send transfers to. If not provided, only transfers between chains in the same wallet
 * `--single-destination-per-block` — Transaction distribution mode. If false (default), distributes transactions evenly across chains within each block. If true, sends all transactions in each block to a single chain, rotating through chains for subsequent blocks
+* `--client-mode <CLIENT_MODE>` — Which client to drive the chains with
+
+  Default value: `full`
+
+  Possible values:
+  - `full`:
+    A real `ChainClient`: executes every block locally and keeps chain state, so it measures what a client experiences
+  - `lite`:
+    A storage-free proposer: keeps no chain state and executes nothing, so the generator stops being part of what is measured
+
+* `--fan-out <FAN_OUT>` — How many distinct destination chains each chain sends to. Unset means every other benchmarked chain, so cross-chain fan-out grows with `--num-chains` and cannot be varied on its own; setting it pins fan-out while everything else is held fixed
+* `--skip-message-processing` — Keep sending cross-chain messages but never drain the inboxes they fill, isolating the sending side. Inboxes then grow for the whole run, which is fine for a short benchmark and is not a realistic steady state. `--client-mode lite` only
+* `--max-incoming-bundles-per-block <MAX_INCOMING_BUNDLES_PER_BLOCK>` — The maximum number of incoming message bundles to drain into each block, on top of its own operations. Defaults to twice the block's operation count, so a backlog is spread over several blocks instead of one huge one. `--client-mode lite` only
+* `--mixed-self-transfers` — Mix self-transfers in with the cross-chain ones, so roughly half the traffic stays on its own chain. Which half is random, not alternating: the generator shuffles its destination list, so this sets the ratio rather than an order. Without this a chain only ever sends elsewhere; with `--fan-out 0` it only ever sends to itself, and this flag is then ignored. Under `--single-destination-per-block` the mix applies per block rather than per transaction, so whole blocks are self-transfers
+* `--light-certificates` — Broadcast each confirmed certificate in its compact, value-free form (hash plus signatures) where possible. A validator that has forgotten the value transparently gets a retry with the full certificate. `--client-mode lite` only
 
 
 
@@ -687,6 +702,21 @@ Run multiple benchmark processes in parallel
 * `--delay-between-chains-ms <DELAY_BETWEEN_CHAINS_MS>` — The delay between chains, in milliseconds. For example, if set to 200ms, the first chain will start, then the second will start 200 ms after the first one, the third 200 ms after the second one, and so on. This is used for slowly ramping up the TPS, so we don't pound the validators with the full TPS all at once
 * `--config-path <CONFIG_PATH>` — Path to YAML file containing chain IDs to send transfers to. If not provided, only transfers between chains in the same wallet
 * `--single-destination-per-block` — Transaction distribution mode. If false (default), distributes transactions evenly across chains within each block. If true, sends all transactions in each block to a single chain, rotating through chains for subsequent blocks
+* `--client-mode <CLIENT_MODE>` — Which client to drive the chains with
+
+  Default value: `full`
+
+  Possible values:
+  - `full`:
+    A real `ChainClient`: executes every block locally and keeps chain state, so it measures what a client experiences
+  - `lite`:
+    A storage-free proposer: keeps no chain state and executes nothing, so the generator stops being part of what is measured
+
+* `--fan-out <FAN_OUT>` — How many distinct destination chains each chain sends to. Unset means every other benchmarked chain, so cross-chain fan-out grows with `--num-chains` and cannot be varied on its own; setting it pins fan-out while everything else is held fixed
+* `--skip-message-processing` — Keep sending cross-chain messages but never drain the inboxes they fill, isolating the sending side. Inboxes then grow for the whole run, which is fine for a short benchmark and is not a realistic steady state. `--client-mode lite` only
+* `--max-incoming-bundles-per-block <MAX_INCOMING_BUNDLES_PER_BLOCK>` — The maximum number of incoming message bundles to drain into each block, on top of its own operations. Defaults to twice the block's operation count, so a backlog is spread over several blocks instead of one huge one. `--client-mode lite` only
+* `--mixed-self-transfers` — Mix self-transfers in with the cross-chain ones, so roughly half the traffic stays on its own chain. Which half is random, not alternating: the generator shuffles its destination list, so this sets the ratio rather than an order. Without this a chain only ever sends elsewhere; with `--fan-out 0` it only ever sends to itself, and this flag is then ignored. Under `--single-destination-per-block` the mix applies per block rather than per transaction, so whole blocks are self-transfers
+* `--light-certificates` — Broadcast each confirmed certificate in its compact, value-free form (hash plus signatures) where possible. A validator that has forgotten the value transparently gets a retry with the full certificate. `--client-mode lite` only
 * `--processes <PROCESSES>` — The number of benchmark processes to run in parallel
 
   Default value: `1`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5095,6 +5095,7 @@ version = "0.15.21"
 dependencies = [
  "amm",
  "anyhow",
+ "async-trait",
  "base64 0.22.1",
  "bcs",
  "cfg_aliases",
@@ -5110,6 +5111,7 @@ dependencies = [
  "gloo-utils",
  "hdrhistogram",
  "linera-base",
+ "linera-cache",
  "linera-chain",
  "linera-client",
  "linera-core",
@@ -5721,6 +5723,7 @@ dependencies = [
  "http 1.3.1",
  "indicatif",
  "linera-base",
+ "linera-cache",
  "linera-chain",
  "linera-client",
  "linera-core",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4048,6 +4048,7 @@ name = "linera-client"
 version = "0.15.21"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bcs",
  "cfg_aliases",
  "clap",
@@ -4056,6 +4057,7 @@ dependencies = [
  "futures",
  "hdrhistogram",
  "linera-base",
+ "linera-cache",
  "linera-chain",
  "linera-core",
  "linera-execution",

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -4016,12 +4016,14 @@ name = "linera-client"
 version = "0.15.21"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bcs",
  "cfg_aliases",
  "clap",
  "futures",
  "hdrhistogram",
  "linera-base",
+ "linera-cache",
  "linera-chain",
  "linera-core",
  "linera-execution",

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -45,11 +45,13 @@ web-default = ["web", "wasmer", "indexed-db"]
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 bcs.workspace = true
 clap.workspace = true
 futures.workspace = true
 hdrhistogram.workspace = true
 linera-base.workspace = true
+linera-cache.workspace = true
 linera-chain.workspace = true
 linera-core.workspace = true
 linera-execution.workspace = true

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -842,22 +842,33 @@ impl<Env: Environment> Benchmark<Env> {
         let owner = chain_client.owner().await?;
 
         loop {
-            tokio::select! {
-                biased;
+            // Deliberately NOT raced against the shutdown signal. `select!` drops the losing
+            // future, and dropping a commit mid-flight abandons a block the validators have
+            // already voted on: the storage-free client keeps no local record of it, so the
+            // chain is left with an uncertified proposal at that height and every later
+            // proposal there is rejected with "Already voted to confirm a different block".
+            // Finishing the block first costs at most one block of shutdown latency.
+            if shutdown_notifier.is_cancelled() {
+                info!("Shutdown signal received, stopping benchmark");
+                break;
+            }
 
-                _ = shutdown_notifier.cancelled() => {
-                    info!("Shutdown signal received, stopping benchmark");
-                    break;
-                }
-                result = chain_client.commit_operations(
-                    generator.generate_operations(owner, transactions_per_block),
-                ) => {
-                    result?;
+            chain_client
+                .commit_operations(generator.generate_operations(owner, transactions_per_block))
+                .await?;
 
-                    let current_bps_count = bps_count.fetch_add(1, Ordering::Relaxed) + 1;
-                    if current_bps_count >= bps {
-                        notifier.notified().await;
+            let current_bps_count = bps_count.fetch_add(1, Ordering::Relaxed) + 1;
+            if current_bps_count >= bps {
+                // Safe to race: waiting on the notifier holds no chain state, and it would
+                // otherwise block until the next tick even after shutdown.
+                tokio::select! {
+                    biased;
+
+                    _ = shutdown_notifier.cancelled() => {
+                        info!("Shutdown signal received, stopping benchmark");
+                        break;
                     }
+                    _ = notifier.notified() => {}
                 }
             }
         }

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -48,6 +48,45 @@ pub trait OperationGenerator: Send + 'static {
     fn generate_operations(&mut self, owner: AccountOwner, count: usize) -> Vec<Operation>;
 }
 
+/// A client the benchmark can drive, so the same harness runs against either the full
+/// [`ChainClient`] or a storage-free proposer.
+///
+/// The benchmark loop only ever asks a client to commit one block of operations, which is
+/// what makes the two interchangeable: everything else -- rate control, block sizing,
+/// destination selection, reporting -- is the harness's job and is shared.
+#[cfg_attr(not(web), async_trait::async_trait)]
+#[cfg_attr(web, async_trait::async_trait(?Send))]
+pub trait BenchmarkClient: Send + Sync + 'static {
+    /// The chain this client proposes on.
+    fn chain_id(&self) -> ChainId;
+
+    /// The owner the generated operations are attributed to.
+    async fn owner(&self) -> Result<AccountOwner, BenchmarkError>;
+
+    /// Proposes a block carrying `operations` and returns once it is committed.
+    async fn commit_operations(&self, operations: Vec<Operation>) -> Result<(), BenchmarkError>;
+}
+
+#[cfg_attr(not(web), async_trait::async_trait)]
+#[cfg_attr(web, async_trait::async_trait(?Send))]
+impl<Env: Environment> BenchmarkClient for ChainClient<Env> {
+    fn chain_id(&self) -> ChainId {
+        ChainClient::chain_id(self)
+    }
+
+    async fn owner(&self) -> Result<AccountOwner, BenchmarkError> {
+        self.identity().await.map_err(BenchmarkError::ChainClient)
+    }
+
+    async fn commit_operations(&self, operations: Vec<Operation>) -> Result<(), BenchmarkError> {
+        self.execute_operations(operations, vec![])
+            .await
+            .map_err(BenchmarkError::ChainClient)?
+            .expect("should execute block with operations");
+        Ok(())
+    }
+}
+
 /// Generates native fungible token transfer operations between chains.
 pub struct NativeFungibleTransferGenerator {
     source_chain_id: ChainId,
@@ -55,14 +94,22 @@ pub struct NativeFungibleTransferGenerator {
     destination_index: usize,
     rng: SmallRng,
     single_destination_per_block: bool,
+    avoid_self: bool,
 }
 
 impl NativeFungibleTransferGenerator {
     /// Creates a generator that sends native token transfers from the source chain.
+    ///
+    /// If `avoid_self` is true, `self.source_chain_id` is skipped whenever the destination
+    /// list has more than one entry (the historical behavior: a caller that wants a mix of
+    /// self- and cross-chain traffic should build a destination list that already includes
+    /// `source_chain_id` explicitly and pass `avoid_self = false`, otherwise it would never
+    /// actually be selected).
     pub fn new(
         source_chain_id: ChainId,
         mut destination_chains: Vec<ChainId>,
         single_destination_per_block: bool,
+        avoid_self: bool,
     ) -> Result<Self, BenchmarkError> {
         // With a single chain, send to self.
         if destination_chains.is_empty() {
@@ -76,6 +123,7 @@ impl NativeFungibleTransferGenerator {
             destination_index: 0,
             rng,
             single_destination_per_block,
+            avoid_self,
         })
     }
 
@@ -87,7 +135,10 @@ impl NativeFungibleTransferGenerator {
         let destination_chain_id = self.destination_chains[self.destination_index];
         self.destination_index += 1;
         // Skip self when there are other destinations available.
-        if destination_chain_id == self.source_chain_id && self.destination_chains.len() > 1 {
+        if destination_chain_id == self.source_chain_id
+            && self.destination_chains.len() > 1
+            && self.avoid_self
+        {
             self.next_destination()
         } else {
             destination_chain_id
@@ -132,15 +183,22 @@ pub struct FungibleTransferGenerator {
     destination_index: usize,
     rng: SmallRng,
     single_destination_per_block: bool,
+    avoid_self: bool,
 }
 
 impl FungibleTransferGenerator {
     /// Creates a generator that sends fungible token transfers from the source chain.
+    ///
+    /// `avoid_self` has the same meaning as on [`NativeFungibleTransferGenerator::new`]: with
+    /// it set, `source_chain_id` is skipped whenever the destination list has more than one
+    /// entry, so a caller wanting a mix of self- and cross-chain traffic passes `false` and a
+    /// list that already contains `source_chain_id`.
     pub fn new(
         application_id: ApplicationId,
         source_chain_id: ChainId,
         mut destination_chains: Vec<ChainId>,
         single_destination_per_block: bool,
+        avoid_self: bool,
     ) -> Result<Self, BenchmarkError> {
         // With a single chain, send to self (matching old behavior).
         if destination_chains.is_empty() {
@@ -155,6 +213,7 @@ impl FungibleTransferGenerator {
             destination_index: 0,
             rng,
             single_destination_per_block,
+            avoid_self,
         })
     }
 
@@ -166,7 +225,10 @@ impl FungibleTransferGenerator {
         let destination_chain_id = self.destination_chains[self.destination_index];
         self.destination_index += 1;
         // Skip self when there are other destinations available.
-        if destination_chain_id == self.source_chain_id && self.destination_chains.len() > 1 {
+        if destination_chain_id == self.source_chain_id
+            && self.destination_chains.len() > 1
+            && self.avoid_self
+        {
             self.next_destination()
         } else {
             destination_chain_id
@@ -204,6 +266,10 @@ pub enum BenchmarkError {
     JoinError(#[from] task::JoinError),
     #[error("Chain client error: {0}")]
     ChainClient(#[from] chain_client::Error),
+    /// The storage-free client has no `chain_client::Error` to wrap, so its failures arrive
+    /// as a message.
+    #[error("Lite client error: {0}")]
+    LiteClient(String),
     #[error("Current histogram count is less than previous histogram count")]
     HistogramCountMismatch,
     #[error("Expected histogram value, got {0:?}")]
@@ -282,13 +348,13 @@ impl<Env: Environment> Benchmark<Env> {
     #[expect(clippy::too_many_arguments)]
     pub async fn run_benchmark<C: ClientContext<Environment = Env> + 'static>(
         bps: usize,
-        chain_clients: Vec<ChainClient<Env>>,
+        chain_clients: Vec<Arc<dyn BenchmarkClient>>,
         generators: Vec<Box<dyn OperationGenerator>>,
         transactions_per_block: usize,
         health_check_endpoints: Option<String>,
         runtime_in_seconds: Option<u64>,
         delay_between_chains_ms: Option<u64>,
-        chain_listener: ChainListener<C>,
+        chain_listener: Option<ChainListener<C>>,
         command_sender: mpsc::UnboundedSender<ListenerCommand>,
         shutdown_notifier: &CancellationToken,
     ) -> Result<(), BenchmarkError> {
@@ -304,20 +370,28 @@ impl<Env: Environment> Benchmark<Env> {
         let notifier = Arc::new(Notify::new());
         let barrier = Arc::new(Barrier::new(num_chains + 1));
 
-        let chain_listener_result = chain_listener.run().await;
+        // Only the full client needs it: it keeps local chain state in sync in the
+        // background. The storage-free client has no local state to sync, and running one
+        // anyway would put exactly the work it avoids back onto the load generator.
+        let chain_listener_handle = match chain_listener {
+            Some(chain_listener) => {
+                let chain_listener_result = chain_listener.run().await;
+                let handle =
+                    tokio::spawn(async move { chain_listener_result?.await }.in_current_span());
 
-        let chain_listener_handle =
-            tokio::spawn(async move { chain_listener_result?.await }.in_current_span());
-
-        // Register benchmark chains with the ChainListener so it sets up
-        // validator notification listeners for incoming cross-chain messages.
-        let chain_map: BTreeMap<_, _> = chain_clients
-            .iter()
-            .map(|c| (c.chain_id(), c.preferred_owner()))
-            .collect();
-        if let Err(e) = command_sender.send(ListenerCommand::Listen(chain_map)) {
-            warn!("Failed to register benchmark chains with listener: {e}");
-        }
+                // Register benchmark chains with the ChainListener so it sets up
+                // validator notification listeners for incoming cross-chain messages.
+                let mut chain_map = BTreeMap::new();
+                for client in &chain_clients {
+                    chain_map.insert(client.chain_id(), Some(client.owner().await?));
+                }
+                if let Err(e) = command_sender.send(ListenerCommand::Listen(chain_map)) {
+                    warn!("Failed to register benchmark chains with listener: {e}");
+                }
+                Some(handle)
+            }
+            None => None,
+        };
 
         let bps_control_task = Self::bps_control_task(
             &barrier,
@@ -396,8 +470,10 @@ impl<Env: Environment> Benchmark<Env> {
             runtime_control_task.await?;
         }
 
-        if let Err(e) = chain_listener_handle.await? {
-            tracing::error!("chain listener error: {e}");
+        if let Some(chain_listener_handle) = chain_listener_handle {
+            if let Err(e) = chain_listener_handle.await? {
+                tracing::error!("chain listener error: {e}");
+            }
         }
 
         Ok(())
@@ -740,7 +816,7 @@ impl<Env: Environment> Benchmark<Env> {
         chain_idx: usize,
         chain_id: ChainId,
         bps: usize,
-        chain_client: ChainClient<Env>,
+        chain_client: Arc<dyn BenchmarkClient>,
         mut generator: Box<dyn OperationGenerator>,
         transactions_per_block: usize,
         shutdown_notifier: CancellationToken,
@@ -763,10 +839,7 @@ impl<Env: Environment> Benchmark<Env> {
             runtime_control_sender.send(()).await?;
         }
 
-        let owner = chain_client
-            .identity()
-            .await
-            .map_err(BenchmarkError::ChainClient)?;
+        let owner = chain_client.owner().await?;
 
         loop {
             tokio::select! {
@@ -776,13 +849,10 @@ impl<Env: Environment> Benchmark<Env> {
                     info!("Shutdown signal received, stopping benchmark");
                     break;
                 }
-                result = chain_client.execute_operations(
+                result = chain_client.commit_operations(
                     generator.generate_operations(owner, transactions_per_block),
-                    vec![]
                 ) => {
-                    result
-                        .map_err(BenchmarkError::ChainClient)?
-                        .expect("should execute block with operations");
+                    result?;
 
                     let current_bps_count = bps_count.fetch_add(1, Ordering::Relaxed) + 1;
                     if current_bps_count >= bps {
@@ -880,5 +950,80 @@ pub fn fungible_transfer(
     Operation::User {
         application_id,
         bytes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use linera_base::{crypto::CryptoHash, identifiers::ChainId};
+
+    use super::*;
+
+    fn chain(seed: &str) -> ChainId {
+        ChainId(CryptoHash::test_hash(seed))
+    }
+
+    /// `avoid_self` is what makes a mixed self/cross-chain workload expressible, and both
+    /// generators must honour it: the CLI hands them the same interleaved destination list,
+    /// so one ignoring the flag would silently measure 100% cross-chain traffic.
+    #[test]
+    fn avoid_self_decides_whether_the_source_is_a_destination() {
+        let source = chain("source");
+        let other = chain("other");
+        // As the CLI builds it for --mixed-self-transfers: one self entry per cross entry.
+        let interleaved = vec![other, source];
+
+        for avoid_self in [true, false] {
+            let mut native = NativeFungibleTransferGenerator::new(
+                source,
+                interleaved.clone(),
+                false,
+                avoid_self,
+            )
+            .unwrap();
+            let mut fungible = FungibleTransferGenerator::new(
+                ApplicationId::new(CryptoHash::test_hash("app")),
+                source,
+                interleaved.clone(),
+                false,
+                avoid_self,
+            )
+            .unwrap();
+
+            let native_hits = (0..100)
+                .filter(|_| native.next_destination() == source)
+                .count();
+            let fungible_hits = (0..100)
+                .filter(|_| fungible.next_destination() == source)
+                .count();
+
+            if avoid_self {
+                assert_eq!(native_hits, 0, "native sent to itself despite avoid_self");
+                assert_eq!(
+                    fungible_hits, 0,
+                    "fungible sent to itself despite avoid_self"
+                );
+            } else {
+                // The list is shuffled, so this is a ratio and not an alternation.
+                assert!(
+                    (30..=70).contains(&native_hits),
+                    "native self-share {native_hits}/100 is not ~half"
+                );
+                assert!(
+                    (30..=70).contains(&fungible_hits),
+                    "fungible self-share {fungible_hits}/100 is not ~half"
+                );
+            }
+        }
+    }
+
+    /// A lone destination is kept even when it is the source, or the generator would recurse
+    /// forever looking for somewhere else to send.
+    #[test]
+    fn a_sole_self_destination_survives_avoid_self() {
+        let source = chain("source");
+        let mut generator =
+            NativeFungibleTransferGenerator::new(source, vec![], false, true).unwrap();
+        assert_eq!(generator.next_destination(), source);
     }
 }

--- a/linera-client/src/lib.rs
+++ b/linera-client/src/lib.rs
@@ -27,6 +27,9 @@ pub mod util;
 /// Tooling for running throughput benchmarks against a network.
 #[cfg(not(web))]
 pub mod benchmark;
+/// A storage-free client used as a benchmark load generator.
+#[cfg(not(web))]
+pub mod lite_client;
 
 #[cfg(test)]
 mod unit_tests;

--- a/linera-client/src/lite_client.rs
+++ b/linera-client/src/lite_client.rs
@@ -1,0 +1,646 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A storage-free client that proposes blocks directly to validators.
+//!
+//! Unlike [`ChainClient`](linera_core::client::chain_client::ChainClient) this keeps no
+//! local storage and executes nothing: it tracks just enough chain state to keep
+//! proposing valid blocks. That makes it cheap enough that a load generator stops being
+//! part of what a benchmark measures, at the cost of three round trips per block instead
+//! of two.
+
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    sync::Arc,
+};
+
+use anyhow::{anyhow, bail, Context as _, Result};
+use futures::future::join_all;
+use linera_base::{
+    crypto::{CryptoHash, ValidatorPublicKey, ValidatorSignature},
+    data_types::{BlockHeight, Epoch, Round, Timestamp},
+    identifiers::{AccountOwner, ChainId},
+};
+use linera_cache::ValueCache;
+use linera_chain::{
+    data_types::{BlockProposal, IncomingBundle, MessageBundle, ProposedBlock, Transaction},
+    types::{
+        CertificateKind, CertificateValue as _, ConfirmedBlock, ConfirmedBlockCertificate,
+        GenericCertificate,
+    },
+};
+use linera_core::{
+    client::Client as CoreClient,
+    data_types::ChainInfoQuery,
+    environment::Environment,
+    node::{CrossChainMessageDelivery, ValidatorNode},
+    remote_node::RemoteNode,
+};
+use linera_execution::{committee::Committee, Operation};
+use linera_rpc::Client;
+use tokio::sync::Mutex;
+use tracing::warn;
+
+use crate::benchmark::{BenchmarkClient, BenchmarkError};
+
+/// A bundle's position in its origin chain's outbox.
+///
+/// `main` has `MessageBundle::cursor()` for this; on this branch the pair is spelled out. Drop
+/// this in favour of the method whenever that lands here.
+fn cursor_of(bundle: &MessageBundle) -> (BlockHeight, u32) {
+    (bundle.height, bundle.transaction_index)
+}
+
+/// Tracks just enough state about one chain to keep proposing valid blocks, without any
+/// local storage or execution.
+pub struct LiteChainClient<Env: Environment> {
+    chain_id: ChainId,
+    owner: AccountOwner,
+    epoch: Epoch,
+    height: linera_base::data_types::BlockHeight,
+    previous_block_hash: Option<CryptoHash>,
+    nodes: Vec<(ValidatorPublicKey, Client)>,
+    committee: Committee,
+    /// Shared with every other chain this process drives; only its signer is used.
+    client: Arc<CoreClient<Env>>,
+    value_cache: ValueCache<CryptoHash, ConfirmedBlockCertificate>,
+    /// The incoming message bundles to drain into the *next* block, computed as a side effect
+    /// of the previous block's confirmed-value fetch (see `propose_and_commit`). Held across
+    /// blocks so that draining costs no extra round trip; empty before the first block and in
+    /// `independent` mode.
+    pending_bundles: Vec<IncomingBundle>,
+    /// Whether to broadcast the confirmed certificate in its compact, value-free form where
+    /// possible (see `--light-certificates`).
+    light_certificates: bool,
+}
+
+impl<Env: Environment> LiteChainClient<Env> {
+    /// Seeds the client's state for `chain_id` from the first validator that answers.
+    pub async fn seed(
+        chain_id: ChainId,
+        owner: AccountOwner,
+        nodes: Vec<(ValidatorPublicKey, Client)>,
+        committee: Committee,
+        client: Arc<CoreClient<Env>>,
+        light_certificates: bool,
+    ) -> Result<Self> {
+        for (public_key, node) in &nodes {
+            let query = ChainInfoQuery::new(chain_id);
+            match node.handle_chain_info_query(query).await {
+                Ok(response) => {
+                    let info = response.info;
+                    return Ok(Self {
+                        chain_id,
+                        owner,
+                        epoch: info.epoch,
+                        height: info.next_block_height,
+                        previous_block_hash: info.block_hash,
+                        nodes,
+                        committee,
+                        client,
+                        value_cache: ValueCache::new("lite-benchmark", 64, 60),
+                        pending_bundles: Vec::new(),
+                        light_certificates,
+                    });
+                }
+                Err(error) => {
+                    warn!(%public_key, %error, "validator did not answer the initial chain info query");
+                }
+            }
+        }
+        bail!("no validator answered the initial chain info query");
+    }
+
+    /// Builds, signs, and submits a block with the given operations, then drives it to a
+    /// committed certificate. Uses `Round::Fast`, so this only works on chains owned by a
+    /// single super owner.
+    ///
+    /// If `process_messages` is set, the block first drains up to `bundle_cap` incoming message
+    /// bundles from this chain's inboxes (as `Transaction::ReceiveMessages`, before the
+    /// operations), so the inboxes don't grow without bound in cross-chain traffic modes.
+    /// Returns the number of bundles that were included.
+    ///
+    /// The bundles come from `self.pending_bundles`, which the *previous* block's confirmed-value
+    /// fetch computed for us -- so draining costs no extra round trip. This is sound because a
+    /// block only removes its bundles from the validators' inboxes once it commits: the bundles
+    /// we carried over are still pending (nothing else drains this chain), and still present in
+    /// the validators that reported them, so the proposal is accepted. `self.pending_bundles` is
+    /// only refreshed after this block commits, so a failed block simply retries the same set.
+    pub async fn propose_and_commit(
+        &mut self,
+        operations: Vec<linera_execution::Operation>,
+        process_messages: bool,
+        bundle_cap: usize,
+    ) -> Result<usize> {
+        let bundles: Vec<IncomingBundle> = if process_messages {
+            self.pending_bundles
+                .iter()
+                .take(bundle_cap)
+                .cloned()
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let num_bundles = bundles.len();
+        // The bundles this block consumes, so the next block's pending set can exclude them (the
+        // confirmed-value fetch below sees them still in the inboxes, since our certificate has
+        // not been broadcast yet).
+        let consumed: HashSet<_> = bundles
+            .iter()
+            .map(|bundle| (bundle.origin, cursor_of(&bundle.bundle)))
+            .collect();
+        let transactions = bundles
+            .into_iter()
+            .map(Transaction::ReceiveMessages)
+            .chain(operations.into_iter().map(Transaction::ExecuteOperation))
+            .collect();
+        let block = ProposedBlock {
+            chain_id: self.chain_id,
+            epoch: self.epoch,
+            transactions,
+            height: self.height,
+            timestamp: Timestamp::now(),
+            authenticated_signer: Some(self.owner),
+            previous_block_hash: self.previous_block_hash,
+        };
+        let proposal =
+            BlockProposal::new_initial(self.owner, Round::Fast, block, self.client.signer())
+                .await
+                .map_err(|error| anyhow!("failed to sign the block proposal: {error}"))?;
+
+        // Broadcast the proposal to every validator and collect their `ConfirmedBlock` votes.
+        let responses = join_all(self.nodes.iter().map(|(public_key, node)| {
+            let proposal = proposal.clone();
+            let public_key = *public_key;
+            let node = node.clone();
+            async move { (public_key, node.handle_block_proposal(proposal).await) }
+        }))
+        .await;
+        let votes = responses
+            .into_iter()
+            .filter_map(|(public_key, result)| match result {
+                Ok(response) => response.info.manager.pending.map(|vote| (public_key, vote)),
+                Err(error) => {
+                    warn!(%public_key, %error, "validator rejected the block proposal");
+                    None
+                }
+            });
+        let (value_hash, signatures) =
+            find_confirming_quorum(self.chain_id, votes, &self.committee)
+                .context("no quorum of validators voted to confirm the proposed block")?;
+
+        // Fetch the confirmed value (with its real execution outcome) instead of executing the
+        // block ourselves, and -- folded into the same round trip -- the inboxes' pending
+        // bundles, from which we compute the set to drain into the *next* block.
+        let (confirmed_block, next_pending) = self
+            .fetch_confirmed_and_pending(value_hash, process_messages, &consumed)
+            .await?;
+
+        // The vote's `first_round` attestation must be reproduced exactly, since it is part of
+        // what every signature covers (see `Vote::new_with_first_round`); a single super owner's
+        // `Round::Fast` is always the chain's designated first round, so this is always `true`.
+        let certificate = GenericCertificate::new(confirmed_block, Round::Fast, signatures);
+        // Hoisted so the certificate can be moved into the cache: cloning it here deep-copies
+        // the whole confirmed block on every single block.
+        let certificate_hash = certificate.hash();
+        let cached_certificate = self.value_cache.insert(&certificate_hash, certificate);
+
+        // Broadcast the certificate so every validator commits the block. Only advance our own
+        // state once at least one validator actually accepted it, so we don't get out of sync
+        // with the chain if the certificate is rejected everywhere.
+        //
+        // With --light-certificates, prefer sending each validator just the certificate's hash
+        // and signatures (no block value) via RemoteNode::handle_optimized_confirmed_certificate
+        // -- every validator here voted on this block in the first round trip, so it already has
+        // the value cached and can reconstruct the full certificate locally. A validator that
+        // fell behind and forgot the value it signed gets a transparent fallback to the full
+        // certificate (see that method's doc comment). This only shrinks this round trip's
+        // payload; it doesn't remove it.
+        let light_certificates = self.light_certificates;
+        let results = join_all(self.nodes.iter().map(|(public_key, node)| {
+            let node = node.clone();
+            let cached_certificate = cached_certificate.clone();
+            async move {
+                if light_certificates {
+                    let remote_node = RemoteNode {
+                        public_key: *public_key,
+                        node,
+                    };
+                    remote_node
+                        .handle_optimized_confirmed_certificate(
+                            &cached_certificate,
+                            CrossChainMessageDelivery::NonBlocking,
+                        )
+                        .await
+                        .map(|_| ())
+                } else {
+                    node.handle_confirmed_certificate(
+                        cached_certificate,
+                        CrossChainMessageDelivery::NonBlocking,
+                    )
+                    .await
+                    .map(|_| ())
+                }
+            }
+        }))
+        .await;
+        let mut committed = false;
+        for result in results {
+            if let Err(error) = result {
+                warn!(%error, "validator failed to process the confirmed certificate");
+            } else {
+                committed = true;
+            }
+        }
+        anyhow::ensure!(committed, "no validator accepted the confirmed certificate");
+
+        self.previous_block_hash = Some(certificate_hash);
+        self.height = self.height.try_add_one()?;
+        // Only now that the block committed (so its bundles are being removed from the inboxes)
+        // do we adopt the next pending set. On a failed block we keep `self.pending_bundles` as
+        // it was, so the next attempt retries the same, still-pending bundles.
+        self.pending_bundles = next_pending;
+        Ok(num_bundles)
+    }
+
+    /// In one parallel round trip to every validator, fetches the confirmed block value for
+    /// `value_hash` (from any validator that has it) and, if `process_messages` is set, the
+    /// bundles to drain into the *next* block.
+    ///
+    /// The next pending set is the per-origin prefix that *every* responding validator agrees
+    /// on, minus `consumed` (the bundles this block is about to remove, which are still in the
+    /// inboxes at query time since our certificate has not been broadcast yet). We take only the
+    /// agreed prefix because certificates are delivered non-blocking, so the validators' inboxes
+    /// are not in lockstep: a bundle one validator already holds may not have reached another. A
+    /// proposal is rejected wholesale if it receives a bundle a validator lacks
+    /// (`MissingCrossChainUpdate`), and a given origin's bundles must be consumed in cursor order
+    /// (`IncorrectOrder`), so anything not yet everywhere is simply left for a later block. No
+    /// validator response is trusted for anything but which bundles exist; they are copied
+    /// verbatim into the block. The result is not capped here -- the cap is applied when the
+    /// bundles are actually included, so a backlog beyond one block's cap carries forward.
+    async fn fetch_confirmed_and_pending(
+        &self,
+        value_hash: CryptoHash,
+        process_messages: bool,
+        consumed: &HashSet<(ChainId, (BlockHeight, u32))>,
+    ) -> Result<(ConfirmedBlock, Vec<IncomingBundle>)> {
+        let responses = join_all(self.nodes.iter().map(|(public_key, node)| {
+            let node = node.clone();
+            let mut query = ChainInfoQuery::new(self.chain_id);
+            // Only `manager.requested_confirmed` is read below, but the flag is all-or-
+            // nothing on the wire (`add_values` also attaches the proposed and locking
+            // blocks), so each validator returns roughly two extra block-sized payloads per
+            // block. Narrowing it needs a new query field, not a change here.
+            query.request_manager_values = true;
+            if process_messages {
+                query = query.with_pending_message_bundles();
+            }
+            let public_key = *public_key;
+            async move {
+                match node.handle_chain_info_query(query).await {
+                    Ok(response) => Some(response.info),
+                    Err(error) => {
+                        warn!(%public_key, %error, "validator did not answer the confirmed-value query");
+                        None
+                    }
+                }
+            }
+        }))
+        .await;
+
+        let mut confirmed_block: Option<ConfirmedBlock> = None;
+        let mut per_node: Vec<Vec<IncomingBundle>> = Vec::new();
+        for info in responses.into_iter().flatten() {
+            if process_messages {
+                per_node.push(info.requested_pending_message_bundles);
+            }
+            if confirmed_block.is_none() {
+                if let Some(value) = info.manager.requested_confirmed {
+                    if value.hash() == value_hash {
+                        confirmed_block = Some(*value);
+                    }
+                }
+            }
+        }
+        let confirmed_block =
+            confirmed_block.context("could not fetch the confirmed block value")?;
+
+        let next_pending = if process_messages {
+            common_prefix_bundles(per_node)
+                .into_iter()
+                .filter(|bundle| !consumed.contains(&(bundle.origin, cursor_of(&bundle.bundle))))
+                .collect()
+        } else {
+            Vec::new()
+        };
+        Ok((confirmed_block, next_pending))
+    }
+}
+
+/// Given each responding validator's list of pending incoming bundles, returns the bundles that
+/// appear -- as an in-order per-origin prefix -- in *every* list. Bundles from one origin are
+/// FIFO by cursor, so for each origin this compares the lists element by element and keeps the
+/// longest common leading run; an origin missing from any list contributes nothing. Origins are
+/// visited in a deterministic (sorted) order. See `fetch_confirmed_and_pending` for why only this
+/// safe intersection is used.
+fn common_prefix_bundles(per_node: Vec<Vec<IncomingBundle>>) -> Vec<IncomingBundle> {
+    let Some((first, rest)) = per_node.split_first() else {
+        return Vec::new();
+    };
+    // Group each node's bundles by origin, preserving each origin's cursor order.
+    let group = |bundles: &[IncomingBundle]| -> BTreeMap<ChainId, Vec<IncomingBundle>> {
+        let mut by_origin: BTreeMap<ChainId, Vec<IncomingBundle>> = BTreeMap::new();
+        for bundle in bundles {
+            by_origin
+                .entry(bundle.origin)
+                .or_default()
+                .push(bundle.clone());
+        }
+        by_origin
+    };
+    let base = group(first);
+    let others: Vec<_> = rest.iter().map(|node| group(node)).collect();
+    let mut result = Vec::new();
+    for (origin, base_bundles) in base {
+        let mut prefix_len = base_bundles.len();
+        for other in &others {
+            let other_bundles = other.get(&origin).map_or(&[][..], Vec::as_slice);
+            let matching = base_bundles
+                .iter()
+                .zip(other_bundles)
+                .take_while(|(a, b)| cursor_of(&a.bundle) == cursor_of(&b.bundle))
+                .count();
+            prefix_len = prefix_len.min(matching);
+            if prefix_len == 0 {
+                break;
+            }
+        }
+        result.extend(base_bundles.into_iter().take(prefix_len));
+    }
+    result
+}
+
+/// Groups the given validator votes by the `ConfirmedBlock` value hash they attest to, and
+/// returns the first hash (and its signatures) whose combined committee weight reaches the
+/// quorum threshold. Votes for the wrong chain or of the wrong kind are ignored. No signature
+/// is verified here: the caller trusts every vote at face value.
+fn find_confirming_quorum(
+    chain_id: ChainId,
+    votes: impl IntoIterator<Item = (ValidatorPublicKey, linera_chain::data_types::LiteVote)>,
+    committee: &Committee,
+) -> Option<(CryptoHash, Vec<(ValidatorPublicKey, ValidatorSignature)>)> {
+    let mut signatures_by_hash: HashMap<CryptoHash, Vec<(ValidatorPublicKey, ValidatorSignature)>> =
+        HashMap::new();
+    let mut weight_by_hash: HashMap<CryptoHash, u64> = HashMap::new();
+    for (public_key, vote) in votes {
+        if vote.value.chain_id != chain_id || vote.value.kind != CertificateKind::Confirmed {
+            continue;
+        }
+        let hash = vote.value.value_hash;
+        signatures_by_hash
+            .entry(hash)
+            .or_default()
+            .push((public_key, vote.signature));
+        let weight = weight_by_hash.entry(hash).or_insert(0);
+        *weight += committee.weight(&public_key);
+        if *weight >= committee.quorum_threshold() {
+            let signatures = signatures_by_hash
+                .remove(&hash)
+                .expect("just inserted above");
+            return Some((hash, signatures));
+        }
+    }
+    None
+}
+
+/// Adapts [`LiteChainClient`] to the shared benchmark harness.
+///
+/// The harness holds each client behind a shared reference and drives one chain per task, so
+/// the mutable proposal state (height, previous hash, pending bundles) sits behind a mutex
+/// that is only ever contended if a caller drives the same chain from two places -- which
+/// would be a bug regardless, since block heights are sequential.
+pub struct LiteBenchmarkClient<Env: Environment> {
+    chain_id: ChainId,
+    owner: AccountOwner,
+    inner: Mutex<LiteChainClient<Env>>,
+    process_messages: bool,
+    bundle_cap: Option<usize>,
+}
+
+impl<Env: Environment> LiteBenchmarkClient<Env> {
+    /// Wraps a seeded client. `bundle_cap` defaults to twice the block's operation count, so a
+    /// backlog is drained over several blocks rather than one oversized one.
+    pub fn new(
+        client: LiteChainClient<Env>,
+        process_messages: bool,
+        bundle_cap: Option<usize>,
+    ) -> Self {
+        Self {
+            chain_id: client.chain_id,
+            owner: client.owner,
+            inner: Mutex::new(client),
+            process_messages,
+            bundle_cap,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<Env: Environment> BenchmarkClient for LiteBenchmarkClient<Env> {
+    fn chain_id(&self) -> ChainId {
+        self.chain_id
+    }
+
+    async fn owner(&self) -> Result<AccountOwner, BenchmarkError> {
+        Ok(self.owner)
+    }
+
+    async fn commit_operations(&self, operations: Vec<Operation>) -> Result<(), BenchmarkError> {
+        let bundle_cap = self
+            .bundle_cap
+            .unwrap_or_else(|| operations.len().saturating_mul(2));
+        self.inner
+            .lock()
+            .await
+            .propose_and_commit(operations, self.process_messages, bundle_cap)
+            .await
+            .map_err(|error| BenchmarkError::LiteClient(error.to_string()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use linera_base::{
+        crypto::{AccountSecretKey, CryptoHash, ValidatorKeypair},
+        data_types::BlockHeight,
+    };
+    use linera_chain::data_types::{LiteValue, LiteVote, MessageAction, MessageBundle};
+
+    use super::*;
+
+    /// A pending bundle from `origin` whose cursor is `(height, index)`. The message list is
+    /// empty: `common_prefix_bundles` compares only cursors, so the contents are irrelevant.
+    fn bundle(origin: ChainId, height: u64, index: u32) -> IncomingBundle {
+        IncomingBundle {
+            origin,
+            bundle: MessageBundle {
+                height: BlockHeight(height),
+                timestamp: Timestamp::from(0),
+                certificate_hash: CryptoHash::test_hash("cert"),
+                transaction_index: index,
+                messages: Vec::new(),
+            },
+            action: MessageAction::Accept,
+        }
+    }
+
+    /// The bundles' cursors, sorted by (origin, height, index). Sorting makes comparisons
+    /// insensitive to the order origins are emitted in (which is irrelevant, since each origin's
+    /// inbox is drained independently) while still exposing any per-origin reordering, because
+    /// within an origin the expected cursors are already ascending.
+    fn cursors(bundles: &[IncomingBundle]) -> Vec<(ChainId, u64, u32)> {
+        let mut cursors: Vec<_> = bundles
+            .iter()
+            .map(|b| (b.origin, b.bundle.height.0, b.bundle.transaction_index))
+            .collect();
+        cursors.sort();
+        cursors
+    }
+
+    fn sorted(mut cursors: Vec<(ChainId, u64, u32)>) -> Vec<(ChainId, u64, u32)> {
+        cursors.sort();
+        cursors
+    }
+
+    #[test]
+    fn common_prefix_takes_the_agreed_per_origin_prefix() {
+        let a = ChainId(CryptoHash::test_hash("a"));
+        let b = ChainId(CryptoHash::test_hash("b"));
+
+        // No responders at all -> nothing to drain.
+        assert!(common_prefix_bundles(Vec::new()).is_empty());
+
+        // A single responder: everything it lists is included (grouped by origin, in order).
+        let only = vec![bundle(a, 0, 0), bundle(a, 1, 0), bundle(b, 0, 0)];
+        assert_eq!(
+            cursors(&common_prefix_bundles(vec![only.clone()])),
+            sorted(vec![(a, 0, 0), (a, 1, 0), (b, 0, 0)]),
+        );
+
+        // Two responders agreeing fully: the whole thing survives.
+        assert_eq!(
+            common_prefix_bundles(vec![only.clone(), only.clone()]).len(),
+            3
+        );
+
+        // One responder is one bundle behind on origin `a`: only the shared prefix of `a`
+        // survives, and origin `b`, present in both, is kept.
+        let ahead = vec![bundle(a, 0, 0), bundle(a, 1, 0), bundle(b, 0, 0)];
+        let behind = vec![bundle(a, 0, 0), bundle(b, 0, 0)];
+        assert_eq!(
+            cursors(&common_prefix_bundles(vec![ahead, behind])),
+            sorted(vec![(a, 0, 0), (b, 0, 0)]),
+        );
+
+        // The lists diverge mid-origin (a different cursor at index 1): the prefix stops at the
+        // divergence, and nothing past it is included even though later cursors happen to match.
+        let left = vec![bundle(a, 0, 0), bundle(a, 1, 0), bundle(a, 2, 0)];
+        let right = vec![bundle(a, 0, 0), bundle(a, 5, 0), bundle(a, 2, 0)];
+        assert_eq!(
+            cursors(&common_prefix_bundles(vec![left, right])),
+            vec![(a, 0, 0)],
+        );
+
+        // An origin missing from one responder contributes nothing, but other shared origins
+        // are unaffected.
+        let with_b = vec![bundle(a, 0, 0), bundle(b, 0, 0)];
+        let without_b = vec![bundle(a, 0, 0)];
+        assert_eq!(
+            cursors(&common_prefix_bundles(vec![with_b, without_b])),
+            vec![(a, 0, 0)],
+        );
+    }
+
+    fn committee_of(size: usize) -> (Committee, Vec<ValidatorPublicKey>) {
+        let keys: Vec<_> = (0..size)
+            .map(|_| {
+                (
+                    ValidatorKeypair::generate().public_key,
+                    AccountSecretKey::generate().public(),
+                )
+            })
+            .collect();
+        let public_keys = keys.iter().map(|(key, _)| *key).collect();
+        (Committee::make_simple(keys), public_keys)
+    }
+
+    fn vote(chain_id: ChainId, value_hash: CryptoHash) -> LiteVote {
+        LiteVote {
+            value: LiteValue {
+                value_hash,
+                chain_id,
+                kind: CertificateKind::Confirmed,
+            },
+            round: Round::Fast,
+            unlocking_round: None,
+            first_round: true,
+            justification_commitment: None,
+            signature: ValidatorSignature::sign_prehash(
+                &ValidatorKeypair::generate().secret_key,
+                value_hash,
+            ),
+        }
+    }
+
+    #[test]
+    fn quorum_is_reached_once_enough_weight_agrees() {
+        let chain_id = ChainId(CryptoHash::test_hash("chain"));
+        let value_hash = CryptoHash::test_hash("confirmed-block");
+        let (committee, keys) = committee_of(4);
+
+        // Only 2 out of 4 equally-weighted validators agree: not a quorum yet.
+        let votes = keys[..2]
+            .iter()
+            .map(|key| (*key, vote(chain_id, value_hash)));
+        assert!(find_confirming_quorum(chain_id, votes, &committee).is_none());
+
+        // 3 out of 4 is enough.
+        let votes = keys[..3]
+            .iter()
+            .map(|key| (*key, vote(chain_id, value_hash)));
+        let (hash, signatures) = find_confirming_quorum(chain_id, votes, &committee)
+            .expect("3 out of 4 equally-weighted validators should reach the quorum threshold");
+        assert_eq!(hash, value_hash);
+        assert_eq!(signatures.len(), 3);
+    }
+
+    #[test]
+    fn votes_for_a_different_chain_are_ignored() {
+        let chain_id = ChainId(CryptoHash::test_hash("chain"));
+        let other_chain_id = ChainId(CryptoHash::test_hash("other-chain"));
+        let value_hash = CryptoHash::test_hash("confirmed-block");
+        let (committee, keys) = committee_of(4);
+
+        let votes = keys
+            .iter()
+            .map(|key| (*key, vote(other_chain_id, value_hash)));
+        assert!(find_confirming_quorum(chain_id, votes, &committee).is_none());
+    }
+
+    #[test]
+    fn a_split_vote_never_reaches_quorum_on_either_side() {
+        let chain_id = ChainId(CryptoHash::test_hash("chain"));
+        let hash_a = CryptoHash::test_hash("block-a");
+        let hash_b = CryptoHash::test_hash("block-b");
+        let (committee, keys) = committee_of(4);
+
+        let votes = vec![
+            (keys[0], vote(chain_id, hash_a)),
+            (keys[1], vote(chain_id, hash_a)),
+            (keys[2], vote(chain_id, hash_b)),
+            (keys[3], vote(chain_id, hash_b)),
+        ];
+        assert!(find_confirming_quorum(chain_id, votes, &committee).is_none());
+    }
+}

--- a/linera-client/src/lite_client.rs
+++ b/linera-client/src/lite_client.rs
@@ -583,9 +583,6 @@ mod tests {
                 kind: CertificateKind::Confirmed,
             },
             round: Round::Fast,
-            unlocking_round: None,
-            first_round: true,
-            justification_commitment: None,
             signature: ValidatorSignature::sign_prehash(
                 &ValidatorKeypair::generate().secret_key,
                 value_hash,

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -25,7 +25,8 @@ mod local_node;
 pub mod node;
 /// Utilities for notifying subscribers about chain events.
 pub mod notifier;
-mod remote_node;
+/// A validator node paired with the validator's public key.
+pub mod remote_node;
 /// Helpers for writing tests against the core protocol.
 #[cfg(with_testing)]
 #[path = "unit_tests/test_utils.rs"]

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -29,7 +29,9 @@ use crate::{
 /// A validator node together with the validator's name.
 #[derive(Clone, Debug)]
 pub struct RemoteNode<N> {
+    /// The validator's public key, used to attribute responses and votes to it.
     pub public_key: ValidatorPublicKey,
+    /// The client used to send requests to this validator.
     #[debug(skip)]
     pub node: N,
 }
@@ -110,7 +112,9 @@ impl<N: ValidatorNode> RemoteNode<N> {
         self.handle_validated_certificate(certificate.clone()).await
     }
 
-    pub(crate) async fn handle_optimized_confirmed_certificate(
+    /// Sends a confirmed certificate, preferring its compact lite form when this validator
+    /// signed it, and falling back to the full certificate otherwise.
+    pub async fn handle_optimized_confirmed_certificate(
         &self,
         certificate: &CacheArc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
@@ -197,6 +201,9 @@ impl<N: ValidatorNode> RemoteNode<N> {
         Ok(())
     }
 
+    /// Downloads a blob from this validator, returning `None` if it does not have it.
+    ///
+    /// The response is rejected if its hash does not match the requested ID.
     #[instrument(level = "trace")]
     pub async fn download_blob(&self, blob_id: BlobId) -> Result<Option<Blob>, NodeError> {
         match self.node.download_blob(blob_id).await {

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -100,6 +100,7 @@ heck.workspace = true
 http.workspace = true
 indicatif.workspace = true
 linera-base.workspace = true
+linera-cache.workspace = true
 linera-chain.workspace = true
 linera-client = { workspace = true, features = ["fs"] }
 linera-core.workspace = true

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -62,6 +62,32 @@ impl std::str::FromStr for ValidatorToAdd {
     }
 }
 
+/// Which client the benchmark drives its chains with.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ClientMode {
+    /// A real `ChainClient`: executes every block locally and keeps chain state, so it
+    /// measures what a client experiences.
+    ///
+    /// Two network round trips per block with the root `--allow-fast-blocks` option, which
+    /// is off by default; without it the client skips the fast round and pays a third for
+    /// the validated-then-confirmed path.
+    #[default]
+    Full,
+    /// A storage-free proposer: keeps no chain state and executes nothing, so the generator
+    /// stops being part of what is measured.
+    ///
+    /// Always proposes in `Round::Fast`, which a single-super-owner chain designates as its
+    /// first round; it cannot use the validated-then-confirmed path, so unlike `full` this
+    /// is unaffected by `--allow-fast-blocks`. Three round trips per block.
+    ///
+    /// Reads the validator set and quorum weights from the wallet's *genesis* committee, so
+    /// on a network whose committee has since changed it would target stale addresses. Fine
+    /// for a freshly provisioned benchmark network; check before pointing it at a long-lived
+    /// one.
+    Lite,
+}
+
 #[derive(Clone, clap::Args, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
 /// Options controlling the behavior of the benchmark command.
@@ -134,6 +160,43 @@ pub struct BenchmarkOptions {
     /// to a single chain, rotating through chains for subsequent blocks.
     #[arg(long)]
     pub single_destination_per_block: bool,
+
+    /// Which client to drive the chains with.
+    #[arg(long, value_enum, default_value_t = ClientMode::Full)]
+    pub client_mode: ClientMode,
+
+    /// How many distinct destination chains each chain sends to. Unset means every other
+    /// benchmarked chain, so cross-chain fan-out grows with `--num-chains` and cannot be
+    /// varied on its own; setting it pins fan-out while everything else is held fixed.
+    #[arg(long)]
+    pub fan_out: Option<usize>,
+
+    /// Keep sending cross-chain messages but never drain the inboxes they fill, isolating
+    /// the sending side. Inboxes then grow for the whole run, which is fine for a short
+    /// benchmark and is not a realistic steady state. `--client-mode lite` only.
+    #[arg(long)]
+    pub skip_message_processing: bool,
+
+    /// The maximum number of incoming message bundles to drain into each block, on top of
+    /// its own operations. Defaults to twice the block's operation count, so a backlog is
+    /// spread over several blocks instead of one huge one. `--client-mode lite` only.
+    #[arg(long)]
+    pub max_incoming_bundles_per_block: Option<usize>,
+
+    /// Mix self-transfers in with the cross-chain ones, so roughly half the traffic stays
+    /// on its own chain. Which half is random, not alternating: the generator shuffles its
+    /// destination list, so this sets the ratio rather than an order. Without this a chain
+    /// only ever sends elsewhere; with `--fan-out 0` it only ever sends to itself, and this
+    /// flag is then ignored. Under `--single-destination-per-block` the mix applies per
+    /// block rather than per transaction, so whole blocks are self-transfers.
+    #[arg(long)]
+    pub mixed_self_transfers: bool,
+
+    /// Broadcast each confirmed certificate in its compact, value-free form (hash plus
+    /// signatures) where possible. A validator that has forgotten the value transparently
+    /// gets a retry with the full certificate. `--client-mode lite` only.
+    #[arg(long)]
+    pub light_certificates: bool,
 }
 
 impl Default for BenchmarkOptions {
@@ -152,6 +215,12 @@ impl Default for BenchmarkOptions {
             delay_between_chains_ms: None,
             config_path: None,
             single_destination_per_block: false,
+            client_mode: ClientMode::default(),
+            fan_out: None,
+            mixed_self_transfers: false,
+            skip_message_processing: false,
+            max_incoming_bundles_per_block: None,
+            light_certificates: false,
         }
     }
 }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -957,6 +957,22 @@ impl Runnable for Job {
                         )
                         .await?;
 
+                        // A lite run that is cut off by --runtime-in-seconds can leave a
+                        // block it proposed but never certified, so validators hold a vote
+                        // for a height nothing has committed. These `ChainClient`s know
+                        // nothing about it -- they executed none of those blocks and lite
+                        // mode runs no `ChainListener` -- so wrapping up proposes a
+                        // *different* block at that height and validators reject it with
+                        // "Already voted to confirm a different block for height N".
+                        // `process_pending_block` both syncs and drives the dangling
+                        // proposal to confirmation, which is what makes the chain
+                        // proposable again.
+                        if client_mode == ClientMode::Lite && close_chains {
+                            for chain_client in &chain_clients {
+                                chain_client.process_pending_block().await?;
+                            }
+                        }
+
                         let mut context = std::sync::Arc::try_unwrap(shared_context)
                             .map_err(|_| anyhow::anyhow!("Failed to unwrap shared context"))?
                             .into_inner();

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -957,22 +957,6 @@ impl Runnable for Job {
                         )
                         .await?;
 
-                        // A lite run that is cut off by --runtime-in-seconds can leave a
-                        // block it proposed but never certified, so validators hold a vote
-                        // for a height nothing has committed. These `ChainClient`s know
-                        // nothing about it -- they executed none of those blocks and lite
-                        // mode runs no `ChainListener` -- so wrapping up proposes a
-                        // *different* block at that height and validators reject it with
-                        // "Already voted to confirm a different block for height N".
-                        // `process_pending_block` both syncs and drives the dangling
-                        // proposal to confirmation, which is what makes the chain
-                        // proposable again.
-                        if client_mode == ClientMode::Lite && close_chains {
-                            for chain_client in &chain_clients {
-                                chain_client.process_pending_block().await?;
-                            }
-                        }
-
                         let mut context = std::sync::Arc::try_unwrap(shared_context)
                             .map_err(|_| anyhow::anyhow!("Failed to unwrap shared context"))?
                             .into_inner();

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -45,15 +45,17 @@ use linera_base::{
 };
 use linera_client::{
     benchmark::{
-        BenchmarkConfig, FungibleTransferGenerator, NativeFungibleTransferGenerator,
-        OperationGenerator,
+        BenchmarkClient, BenchmarkConfig, FungibleTransferGenerator,
+        NativeFungibleTransferGenerator, OperationGenerator,
     },
     chain_listener::{ChainListener, ChainListenerConfig, ClientContext as _},
     config::{CommitteeConfig, GenesisConfig},
+    lite_client::{LiteBenchmarkClient, LiteChainClient},
 };
 use linera_core::{
     client::{chain_client, ListeningMode},
     data_types::ClientOutcome,
+    node::ValidatorNodeProvider as _,
     wallet,
     worker::Reason,
     JoinSetExt as _, LocalNodeError,
@@ -66,8 +68,8 @@ use linera_persistent::{self as persistent, Persist as _};
 use linera_service::{
     cli::{
         command::{
-            BenchmarkCommand, BenchmarkOptions, ChainCommand, ClientCommand, DatabaseToolCommand,
-            NetCommand, ProjectCommand, WalletCommand,
+            BenchmarkCommand, BenchmarkOptions, ChainCommand, ClientCommand, ClientMode,
+            DatabaseToolCommand, NetCommand, ProjectCommand, WalletCommand,
         },
         net_up_utils,
     },
@@ -720,6 +722,12 @@ impl Runnable for Job {
                         options: benchmark_options,
                     } => {
                         let BenchmarkOptions {
+                            client_mode,
+                            fan_out,
+                            mixed_self_transfers,
+                            skip_message_processing,
+                            max_incoming_bundles_per_block,
+                            light_certificates,
                             num_chains,
                             tokens_per_chain,
                             transactions_per_block,
@@ -806,45 +814,138 @@ impl Runnable for Job {
                         let shared_context =
                             std::sync::Arc::new(futures::lock::Mutex::new(context));
                         let (command_sender, command_receiver) = mpsc::unbounded_channel();
-                        let chain_listener = ChainListener::new(
-                            listener_config,
-                            shared_context.clone(),
-                            storage.clone(),
-                            shutdown_notifier.clone(),
-                            command_receiver,
-                            true, // Enabling background sync for benchmarks
-                        );
+                        let chain_listener = match client_mode {
+                            ClientMode::Full => Some(ChainListener::new(
+                                listener_config,
+                                shared_context.clone(),
+                                storage.clone(),
+                                shutdown_notifier.clone(),
+                                command_receiver,
+                                true, // Enabling background sync for benchmarks
+                            )),
+                            // The storage-free client keeps no local state to sync.
+                            ClientMode::Lite => None,
+                        };
                         let all_chain_ids: Vec<ChainId> =
                             chain_clients.iter().map(|c| c.chain_id()).collect();
                         let generators: Vec<Box<dyn OperationGenerator>> = chain_clients
                             .iter()
                             .map(|client| -> anyhow::Result<Box<dyn OperationGenerator>> {
                                 let source = client.chain_id();
-                                let destinations: Vec<ChainId> = all_chain_ids
+                                // Without --fan-out every chain messages every other, so
+                                // cross-chain cost is a side effect of --num-chains rather
+                                // than a variable that can be swept on its own.
+                                let others: Vec<ChainId> = all_chain_ids
                                     .iter()
                                     .copied()
                                     .filter(|id| *id != source)
                                     .collect();
+                                // Each source takes a window starting at its own index, so
+                                // every chain has the same in-degree. Truncating the same
+                                // list for every source instead would point all traffic at
+                                // the first `fan_out` chains and measure a hotspot.
+                                let destinations = match fan_out {
+                                    None => others,
+                                    Some(_) if others.is_empty() => others,
+                                    Some(fan_out) => {
+                                        let start = all_chain_ids
+                                            .iter()
+                                            .position(|id| *id == source)
+                                            .unwrap_or(0);
+                                        (0..fan_out.min(others.len()))
+                                            .map(|offset| others[(start + offset) % others.len()])
+                                            .collect()
+                                    }
+                                };
+                                // Restores the old `mixed` traffic mode: one self entry
+                                // per cross-chain entry, which the generator then shuffles,
+                                // giving a ~50/50 ratio rather than an alternation. It must
+                                // also be told not to skip its own chain.
+                                let destinations =
+                                    if mixed_self_transfers && !destinations.is_empty() {
+                                        destinations
+                                            .into_iter()
+                                            .flat_map(|other| [other, source])
+                                            .collect()
+                                    } else {
+                                        destinations
+                                    };
+
                                 if let Some(app_id) = fungible_application_id {
                                     Ok(Box::new(FungibleTransferGenerator::new(
                                         app_id,
                                         source,
                                         destinations,
                                         single_destination_per_block,
+                                        !mixed_self_transfers,
                                     )?))
                                 } else {
                                     Ok(Box::new(NativeFungibleTransferGenerator::new(
                                         source,
                                         destinations,
                                         single_destination_per_block,
+                                        !mixed_self_transfers,
                                     )?))
                                 }
                             })
                             .collect::<Result<_, _>>()?;
 
+                        // Both modes drive the same chains through the same harness; they
+                        // differ only in what proposes the blocks.
+                        let benchmark_clients: Vec<Arc<dyn BenchmarkClient>> = match client_mode {
+                            ClientMode::Full => chain_clients
+                                .iter()
+                                .cloned()
+                                .map(|client| Arc::new(client) as Arc<dyn BenchmarkClient>)
+                                .collect(),
+                            ClientMode::Lite => {
+                                let ctx = shared_context.lock().await;
+                                let committee = ctx.wallet().genesis_config().committee.clone();
+                                let nodes: Vec<_> = ctx
+                                    .make_node_provider()
+                                    .make_nodes(&committee)
+                                    .context("failed to create validator node clients")?
+                                    .collect();
+                                anyhow::ensure!(
+                                    !nodes.is_empty(),
+                                    "the committee has no validators"
+                                );
+                                // Shared by every chain this process drives; the lite
+                                // client uses it only to sign proposals.
+                                let core_client = ctx.client.clone();
+                                drop(ctx);
+
+                                // The full client always drains its inbox, so the lite
+                                // client must too or the two modes measure different
+                                // blocks. Only meaningful with cross-chain traffic.
+                                let process_messages = num_chains > 1 && !skip_message_processing;
+
+                                let mut clients: Vec<Arc<dyn BenchmarkClient>> =
+                                    Vec::with_capacity(chain_clients.len());
+                                for client in &chain_clients {
+                                    let owner = client.identity().await?;
+                                    let lite = LiteChainClient::seed(
+                                        client.chain_id(),
+                                        owner,
+                                        nodes.clone(),
+                                        committee.clone(),
+                                        core_client.clone(),
+                                        light_certificates,
+                                    )
+                                    .await?;
+                                    clients.push(Arc::new(LiteBenchmarkClient::new(
+                                        lite,
+                                        process_messages,
+                                        max_incoming_bundles_per_block,
+                                    )));
+                                }
+                                clients
+                            }
+                        };
+
                         linera_client::benchmark::Benchmark::run_benchmark(
                             bps,
-                            chain_clients.clone(),
+                            benchmark_clients,
                             generators,
                             transactions_per_block,
                             health_check_endpoints.clone(),

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -35,6 +35,7 @@ pub use linera_wallet_json::PersistentWallet as Wallet;
 #[cfg(with_metrics)]
 pub fn init_metrics() {
     linera_base::init_metrics();
+    linera_cache::init_metrics();
     linera_chain::init_metrics();
     linera_core::init_metrics();
     linera_execution::init_metrics();

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -835,7 +835,7 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
     use std::collections::BTreeMap;
 
     use fungible::{FungibleTokenAbi, InitialState, Parameters};
-    use linera_service::cli::command::{BenchmarkCommand, BenchmarkOptions};
+    use linera_service::cli::command::{BenchmarkCommand, BenchmarkOptions, ClientMode};
 
     config.num_other_initial_chains = 2;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -885,6 +885,42 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
                 bps: 2,
                 runtime_in_seconds: Some(5),
                 fungible_application_id: Some(application_id.forget_abi()),
+                close_chains: true,
+                ..Default::default()
+            },
+        })
+        .await?;
+
+    // And once more with the storage-free client, which proposes blocks straight to the
+    // validators instead of going through a ChainClient. It shares every other part of the
+    // harness, so this is what proves the two are actually interchangeable.
+    client
+        .benchmark(BenchmarkCommand::Single {
+            options: BenchmarkOptions {
+                num_chains: 2,
+                transactions_per_block: 10,
+                bps: 2,
+                runtime_in_seconds: Some(5),
+                client_mode: ClientMode::Lite,
+                close_chains: true,
+                ..Default::default()
+            },
+        })
+        .await?;
+
+    // Cross-chain traffic at a pinned fan-out, with roughly half the transfers staying on
+    // their own chain: exercises the destination window, the inbox draining the lite client
+    // does by default, and `avoid_self` on the generator.
+    client
+        .benchmark(BenchmarkCommand::Single {
+            options: BenchmarkOptions {
+                num_chains: 2,
+                transactions_per_block: 10,
+                bps: 2,
+                runtime_in_seconds: Some(5),
+                client_mode: ClientMode::Lite,
+                fan_out: Some(1),
+                mixed_self_transfers: true,
                 close_chains: true,
                 ..Default::default()
             },


### PR DESCRIPTION
## Motivation

Backport of #6752, which folded the standalone lite benchmark generator into `linera benchmark`
behind `--client-mode full|lite`.

This is **not** a mechanical cherry-pick. The lite client proposes blocks directly to validators,
so it touches chain and certificate internals — exactly the surface that has moved between `main`
and this branch. It also carries a **correctness fix that `main` does not have yet**; see below.

## Proposal

The net diff of #6752, adapted. Five merge conflicts and nine API divergences, each resolved
against this branch's actual shape rather than forced:

| conflict | resolution |
|---|---|
| `linera-core/src/lib.rs` | this branch has no `proof` module; kept its shape, applied the `pub mod remote_node` change |
| `benchmark.rs` (signature) | `run_benchmark` here also takes a `command_sender`; kept it and made only the listener `Option` |
| `benchmark.rs` (startup) | the chain registration with `ListenerCommand::Listen` is now gated on the listener existing, and the chain map is built through the new `BenchmarkClient` trait (`owner()` covers `preferred_owner()`, since `identity()` returns exactly that) |
| `main.rs` (imports) | this branch has no `ResourceControlPolicyOverrides` |
| `main.rs` (listener) | kept the real command channel, passing `command_receiver` into the `Some` arm |

| API on `main` | here |
|---|---|
| `JustificationChain` + `ConfirmedBlockCertificate::from_parts` | absent — the certificate is plain `GenericCertificate::new` |
| `new_with_payload(v, r, None, true, None, sigs)` | `new(v, r, sigs)` |
| `ProposedBlock::authenticated_owner` | `authenticated_signer` |
| `MessageBundle::cursor()` returning `Cursor` | absent — the pair is `(height, transaction_index)` |
| `LiteVote { unlocking_round, first_round, justification_commitment, .. }` | `{ value, round, signature }` |
| `ValidatorNodeProvider` already in scope in `main.rs` | needed importing |

For the cursor I added one `cursor_of()` helper rather than inlining the tuple at four sites,
commented to be deleted when `MessageBundle::cursor()` lands here.

### The correctness fix — `main` needs this too

The end-to-end test caught a real bug that #6752 shipped and that seven rounds of adversarial
review did not find:

```
Chain error: Already voted to confirm a different block for height BlockHeight(5) at round Fast
```

The benchmark loop races each block against the shutdown signal, and `select!` drops the losing
future. When `--runtime-in-seconds` fires mid-block, the in-flight commit is dropped **after the
proposal has reached the validators but before the certificate exists**, leaving an uncertified
proposal at that height that blocks every later proposal there. The full `ChainClient` records its
pending block locally and can resume it; the storage-free client keeps no such record, so nothing
can.

The fix stops abandoning in-flight blocks: check shutdown *before* starting a block, let a started
block finish, and race only the rate-limiter wait (which holds no chain state). At most one block
of extra shutdown latency.

**It is a race, which is why `main` is green.** The fix-forward PR against `main` is #6766.

## Test Plan

`cargo clippy --locked --all-targets --all-features --workspace --exclude linera-web` clean;
`cargo fmt --check` clean; `CLI.md` regenerated and consistent.

`cargo test -p linera-client --lib` — **14 passed**, including all six tests ported with the lite
client (quorum reached / split vote / votes for another chain / common-prefix bundles, and both
`avoid_self` cases).

`test_end_to_end_benchmark` against real local networks on both transports, running four benchmark
configurations each: native, fungible, lite, and lite with `--fan-out 1 --mixed-self-transfers`.

The sequence is the evidence, so it is worth stating in full rather than just the final result:

| attempt | diagnosis | outcome |
|---|---|---|
| 1 | — | gRPC ok, **TCP failed** on the height conflict |
| 2 | stale wrap-up state → `synchronize_from_validators()` | **TCP ok, gRPC failed** — transports swapped |
| 3 | adopt the pending proposal → `process_pending_block()` | passed 3x locally, **failed in CI** on plain lite |
| 4 | the commit future is dropped mid-flight → stop racing it | **6/6**: three runs x two transports |

Attempts 2 and 3 were both wrong and both looked right at the time. Syncing cannot help when
nothing has been committed to sync, and `process_pending_block` cannot adopt a proposal the client
has no local record of — it proposes a *fresh* block at the same height and hits the identical
conflict, which is exactly what CI showed.

A single green run cannot distinguish a fix from a lucky schedule on a timing-dependent failure,
so the final fix was run three times on each branch.

Two environment notes, so nobody re-debugs them: the workspace clippy failed twice on third-party
crates unable to find their own dependencies (`reqwest`, `sec1`, `linera-cache`). Both were stale
artifacts in an 18 GB `target/` that had survived an OOM-killed link; `cargo clean -p <crate>`
cleared them. And these e2e test binaries need `CARGO_PROFILE_TEST_DEBUG=0` and bounded `-j` to
link in a 20 GB sandbox.

## Release Plan

- These changes should be backported to the latest `testnet` branch. (This *is* that backport.)

## Links

Backports #6752. The wedged-chain fix also needs to land on `main`, where #6752 is already merged.
