### PR TITLE
Never abandon a block already sent to validators on shutdown

### DIFF
--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -834,22 +834,33 @@ impl<Env: Environment> Benchmark<Env> {
         let owner = chain_client.owner().await?;
 
         loop {
-            tokio::select! {
-                biased;
+            // Deliberately NOT raced against the shutdown signal. `select!` drops the losing
+            // future, and dropping a commit mid-flight abandons a block the validators have
+            // already voted on: the storage-free client keeps no local record of it, so the
+            // chain is left with an uncertified proposal at that height and every later
+            // proposal there is rejected with "Already voted to confirm a different block".
+            // Finishing the block first costs at most one block of shutdown latency.
+            if shutdown_notifier.is_cancelled() {
+                info!("Shutdown signal received, stopping benchmark");
+                break;
+            }
 
-                _ = shutdown_notifier.cancelled() => {
-                    info!("Shutdown signal received, stopping benchmark");
-                    break;
-                }
-                result = chain_client.commit_operations(
-                    generator.generate_operations(owner, transactions_per_block),
-                ) => {
-                    result?;
+            chain_client
+                .commit_operations(generator.generate_operations(owner, transactions_per_block))
+                .await?;
 
-                    let current_bps_count = bps_count.fetch_add(1, Ordering::Relaxed) + 1;
-                    if current_bps_count >= bps {
-                        notifier.notified().await;
+            let current_bps_count = bps_count.fetch_add(1, Ordering::Relaxed) + 1;
+            if current_bps_count >= bps {
+                // Safe to race: waiting on the notifier holds no chain state, and it would
+                // otherwise block until the next tick even after shutdown.
+                tokio::select! {
+                    biased;
+
+                    _ = shutdown_notifier.cancelled() => {
+                        info!("Shutdown signal received, stopping benchmark");
+                        break;
                     }
+                    _ = notifier.notified() => {}
                 }
             }
         }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1040,6 +1040,21 @@ impl Runnable for Job {
                         )
                         .await?;
 
+                        // A lite run cut off by --runtime-in-seconds can leave a block it
+                        // proposed but never certified, so validators hold a vote at a height
+                        // nothing has committed. These `ChainClient`s know nothing about it --
+                        // they executed none of those blocks and lite mode runs no
+                        // `ChainListener` -- so wrapping up proposes a *different* block at
+                        // that height and validators reject it with "Already voted to confirm
+                        // a different block for height N". `process_pending_block` both syncs
+                        // and drives the dangling proposal to confirmation, which is what
+                        // makes the chain proposable again.
+                        if client_mode == ClientMode::Lite && close_chains {
+                            for chain_client in &chain_clients {
+                                chain_client.process_pending_block().await?;
+                            }
+                        }
+
                         let mut context = std::sync::Arc::try_unwrap(shared_context)
                             .map_err(|_| anyhow::anyhow!("Failed to unwrap shared context"))?
                             .into_inner();

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1040,21 +1040,6 @@ impl Runnable for Job {
                         )
                         .await?;
 
-                        // A lite run cut off by --runtime-in-seconds can leave a block it
-                        // proposed but never certified, so validators hold a vote at a height
-                        // nothing has committed. These `ChainClient`s know nothing about it --
-                        // they executed none of those blocks and lite mode runs no
-                        // `ChainListener` -- so wrapping up proposes a *different* block at
-                        // that height and validators reject it with "Already voted to confirm
-                        // a different block for height N". `process_pending_block` both syncs
-                        // and drives the dangling proposal to confirmation, which is what
-                        // makes the chain proposable again.
-                        if client_mode == ClientMode::Lite && close_chains {
-                            for chain_client in &chain_clients {
-                                chain_client.process_pending_block().await?;
-                            }
-                        }
-
                         let mut context = std::sync::Arc::try_unwrap(shared_context)
                             .map_err(|_| anyhow::anyhow!("Failed to unwrap shared context"))?
                             .into_inner();


### PR DESCRIPTION
## Motivation

#6752 shipped a race that can wedge a benchmark chain. It is on `main` now.

`linera benchmark --client-mode lite --close-chains` can fail with:

```
Chain error: Already voted to confirm a different block for height BlockHeight(5) at round Fast
```

The benchmark loop races each block against the shutdown signal:

```rust
tokio::select! {
    biased;
    _ = shutdown_notifier.cancelled() => { break; }        // wins
    result = chain_client.commit_operations(...) => { ... } // future is DROPPED
}
```

`select!` drops the losing future. When `--runtime-in-seconds` fires mid-block, the in-flight
commit is dropped **after the proposal has reached the validators but before the certificate
exists**, so the chain is left with an uncertified proposal at that height and every later
proposal there is rejected.

The full `ChainClient` survives this — it records its pending block locally and can resume it. The
storage-free client keeps no such record, so nothing can resume the abandoned block.

It is a race, which is why `main` is green: whether it bites depends on where the runtime limit
lands relative to a block.

## Proposal

Stop abandoning blocks that are already in flight. Check the shutdown signal *before* starting a
block, let a block that has begun finish, and race only the rate-limiter wait — which holds no
chain state and would otherwise block past shutdown.

The cost is at most one block of extra shutdown latency; in exchange no proposal is ever orphaned
at the validators. This applies to both client modes: the full client merely tolerated the old
behaviour rather than benefiting from it.

## Test Plan

`test_end_to_end_benchmark` against real local networks, both transports, four benchmark
configurations each (native, fungible, lite, and lite with `--fan-out 1 --mixed-self-transfers`):

```
run 1: 2 configs ok, 0 failed
run 2: 2 configs ok, 0 failed
run 3: 2 configs ok, 0 failed
```

Three runs, not one: the failure is timing-dependent, so a single pass cannot distinguish a fix
from a lucky schedule.

`cargo clippy --locked --workspace --all-targets --all-features --exclude linera-web` clean;
`cargo fmt --check` clean.

### How this was found, and why the first fix was wrong

The bug did not surface on `main` — it surfaced while backporting to `testnet_conway`, where the
same test failed. It took four attempts, and the wrong ones are instructive:

| attempt | diagnosis | outcome |
|---|---|---|
| 1 | — | gRPC ok, **TCP failed** on the height conflict |
| 2 | wrap-up client's state is stale → `synchronize_from_validators()` | **TCP ok, gRPC failed** — transports swapped |
| 3 | there is a pending proposal to adopt → `process_pending_block()` | passed 3x locally, **failed in CI** on the plain lite case |
| 4 | the commit future is dropped mid-flight → stop racing it | **6/6**: three runs x two transports |

Attempts 2 and 3 were both wrong, and both looked right at the time. Syncing cannot help when
nothing has been committed to sync. `process_pending_block` cannot adopt a proposal the client has
no local record of — it proposes a *fresh* block at the same height and hits the identical
conflict, which is precisely what CI showed.

Two process notes worth stating, since they are the reason the earlier attempts shipped: a single
green run cannot distinguish "fixed" from "got lucky" on a timing-dependent failure, so this one
was run three times; and the case that finally exposed it was plain `--client-mode lite`, which CI
exercised and my local runs had not.

Worth recording plainly: seven rounds of adversarial multi-agent review over #6752 ended with zero
findings, and the unit tests pass, and it compiles. None of that caught this. Running it against
real validators did.

## Release Plan

- These changes should be backported to the latest `testnet` branch. The conway backport (#6765)
  already carries this fix.

## Links

Fixes a defect introduced in #6752. Conway backport: #6765.
