### PR TITLE
Search for the latency knee in-process with --rate-auto

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -685,7 +685,7 @@ Start a single benchmark process, maintaining a given TPS
 * `--delay-between-chains-ms <DELAY_BETWEEN_CHAINS_MS>` — The delay between chains, in milliseconds. For example, if set to 200ms, the first chain will start, then the second will start 200 ms after the first one, the third 200 ms after the second one, and so on. This is used for slowly ramping up the TPS, so we don't pound the validators with the full TPS all at once
 * `--config-path <CONFIG_PATH>` — Path to YAML file containing chain IDs to send transfers to. If not provided, only transfers between chains in the same wallet
 * `--single-destination-per-block` — Transaction distribution mode. If false (default), distributes transactions evenly across chains within each block. If true, sends all transactions in each block to a single chain, rotating through chains for subsequent blocks
-* `--rate-auto` — Search for the highest rate the network sustains within `--target-p99-ms`, instead of holding `--bps` fixed. Reports the knee: the highest rate whose tail latency stayed inside the budget, which is the number that means something. `--bps` becomes the starting point for the climb
+* `--rate-auto` — Search for the highest rate the network sustains within `--target-p99-ms`, instead of holding `--bps` fixed. Reports the knee: the highest rate whose tail latency stayed inside the budget, which is the number that means something. The climb starts at `--rate-start-bps`; `--bps` is ignored in this mode
 * `--target-p99-ms <TARGET_P99_MS>` — The tail-latency budget for `--rate-auto`, in milliseconds
 
   Default value: `1000`
@@ -765,7 +765,7 @@ Run multiple benchmark processes in parallel
 * `--delay-between-chains-ms <DELAY_BETWEEN_CHAINS_MS>` — The delay between chains, in milliseconds. For example, if set to 200ms, the first chain will start, then the second will start 200 ms after the first one, the third 200 ms after the second one, and so on. This is used for slowly ramping up the TPS, so we don't pound the validators with the full TPS all at once
 * `--config-path <CONFIG_PATH>` — Path to YAML file containing chain IDs to send transfers to. If not provided, only transfers between chains in the same wallet
 * `--single-destination-per-block` — Transaction distribution mode. If false (default), distributes transactions evenly across chains within each block. If true, sends all transactions in each block to a single chain, rotating through chains for subsequent blocks
-* `--rate-auto` — Search for the highest rate the network sustains within `--target-p99-ms`, instead of holding `--bps` fixed. Reports the knee: the highest rate whose tail latency stayed inside the budget, which is the number that means something. `--bps` becomes the starting point for the climb
+* `--rate-auto` — Search for the highest rate the network sustains within `--target-p99-ms`, instead of holding `--bps` fixed. Reports the knee: the highest rate whose tail latency stayed inside the budget, which is the number that means something. The climb starts at `--rate-start-bps`; `--bps` is ignored in this mode
 * `--target-p99-ms <TARGET_P99_MS>` — The tail-latency budget for `--rate-auto`, in milliseconds
 
   Default value: `1000`

--- a/CLI.md
+++ b/CLI.md
@@ -685,6 +685,10 @@ Start a single benchmark process, maintaining a given TPS
 * `--delay-between-chains-ms <DELAY_BETWEEN_CHAINS_MS>` — The delay between chains, in milliseconds. For example, if set to 200ms, the first chain will start, then the second will start 200 ms after the first one, the third 200 ms after the second one, and so on. This is used for slowly ramping up the TPS, so we don't pound the validators with the full TPS all at once
 * `--config-path <CONFIG_PATH>` — Path to YAML file containing chain IDs to send transfers to. If not provided, only transfers between chains in the same wallet
 * `--single-destination-per-block` — Transaction distribution mode. If false (default), distributes transactions evenly across chains within each block. If true, sends all transactions in each block to a single chain, rotating through chains for subsequent blocks
+* `--rate-auto` — Search for the highest rate the network sustains within `--target-p99-ms`, instead of holding `--bps` fixed. Reports the knee: the highest rate whose tail latency stayed inside the budget, which is the number that means something. `--bps` becomes the starting point for the climb
+* `--target-p99-ms <TARGET_P99_MS>` — The tail-latency budget for `--rate-auto`, in milliseconds
+
+  Default value: `1000`
 * `--client-mode <CLIENT_MODE>` — Which client to drive the chains with
 
   Default value: `full`
@@ -734,6 +738,10 @@ Run multiple benchmark processes in parallel
 * `--delay-between-chains-ms <DELAY_BETWEEN_CHAINS_MS>` — The delay between chains, in milliseconds. For example, if set to 200ms, the first chain will start, then the second will start 200 ms after the first one, the third 200 ms after the second one, and so on. This is used for slowly ramping up the TPS, so we don't pound the validators with the full TPS all at once
 * `--config-path <CONFIG_PATH>` — Path to YAML file containing chain IDs to send transfers to. If not provided, only transfers between chains in the same wallet
 * `--single-destination-per-block` — Transaction distribution mode. If false (default), distributes transactions evenly across chains within each block. If true, sends all transactions in each block to a single chain, rotating through chains for subsequent blocks
+* `--rate-auto` — Search for the highest rate the network sustains within `--target-p99-ms`, instead of holding `--bps` fixed. Reports the knee: the highest rate whose tail latency stayed inside the budget, which is the number that means something. `--bps` becomes the starting point for the climb
+* `--target-p99-ms <TARGET_P99_MS>` — The tail-latency budget for `--rate-auto`, in milliseconds
+
+  Default value: `1000`
 * `--client-mode <CLIENT_MODE>` — Which client to drive the chains with
 
   Default value: `full`

--- a/CLI.md
+++ b/CLI.md
@@ -689,6 +689,33 @@ Start a single benchmark process, maintaining a given TPS
 * `--target-p99-ms <TARGET_P99_MS>` — The tail-latency budget for `--rate-auto`, in milliseconds
 
   Default value: `1000`
+* `--rate-start-bps <RATE_START_BPS>` — Where the `--rate-auto` climb starts, in blocks per second. Defaults to 1: the climb doubles, so starting low costs a handful of levels and avoids opening above the knee
+
+  Default value: `1`
+* `--rate-growth <RATE_GROWTH>` — Multiplier applied to the target while the network keeps up
+
+  Default value: `2`
+* `--rate-resolution <RATE_RESOLUTION>` — Stop once the bracket is this close, as a fraction of its lower bound
+
+  Default value: `0.1`
+* `--rate-confirmations <RATE_CONFIRMATIONS>` — Consecutive agreeing windows required before the search acts on a verdict
+
+  Default value: `2`
+* `--rate-min-achieved-fraction <RATE_MIN_ACHIEVED_FRACTION>` — A window delivering less than this fraction of its target counts as failing, even with good latency
+
+  Default value: `0.8`
+* `--rate-min-p99-samples <RATE_MIN_P99_SAMPLES>` — Blocks a window must hold before its p99 is believed. Below ~100 the reported tail is really a maximum
+
+  Default value: `200`
+* `--rate-max-window-secs <RATE_MAX_WINDOW_SECS>` — How long a window may wait for `--rate-min-p99-samples` before being judged on what it has. Bounds the search on networks too slow to ever reach the floor
+
+  Default value: `3`
+* `--rate-settle-secs <RATE_SETTLE_SECS>` — Warm-up held before the first judged window, on top of the chain-start ramp
+
+  Default value: `5`
+* `--rate-max-commit-failure-secs <RATE_MAX_COMMIT_FAILURE_SECS>` — How long one chain may fail every commit before the run is abandoned. Overshoot failures are measurements; only a streak outlasting the controller's back-off is a wedged chain
+
+  Default value: `30`
 * `--client-mode <CLIENT_MODE>` — Which client to drive the chains with
 
   Default value: `full`
@@ -742,6 +769,33 @@ Run multiple benchmark processes in parallel
 * `--target-p99-ms <TARGET_P99_MS>` — The tail-latency budget for `--rate-auto`, in milliseconds
 
   Default value: `1000`
+* `--rate-start-bps <RATE_START_BPS>` — Where the `--rate-auto` climb starts, in blocks per second. Defaults to 1: the climb doubles, so starting low costs a handful of levels and avoids opening above the knee
+
+  Default value: `1`
+* `--rate-growth <RATE_GROWTH>` — Multiplier applied to the target while the network keeps up
+
+  Default value: `2`
+* `--rate-resolution <RATE_RESOLUTION>` — Stop once the bracket is this close, as a fraction of its lower bound
+
+  Default value: `0.1`
+* `--rate-confirmations <RATE_CONFIRMATIONS>` — Consecutive agreeing windows required before the search acts on a verdict
+
+  Default value: `2`
+* `--rate-min-achieved-fraction <RATE_MIN_ACHIEVED_FRACTION>` — A window delivering less than this fraction of its target counts as failing, even with good latency
+
+  Default value: `0.8`
+* `--rate-min-p99-samples <RATE_MIN_P99_SAMPLES>` — Blocks a window must hold before its p99 is believed. Below ~100 the reported tail is really a maximum
+
+  Default value: `200`
+* `--rate-max-window-secs <RATE_MAX_WINDOW_SECS>` — How long a window may wait for `--rate-min-p99-samples` before being judged on what it has. Bounds the search on networks too slow to ever reach the floor
+
+  Default value: `3`
+* `--rate-settle-secs <RATE_SETTLE_SECS>` — Warm-up held before the first judged window, on top of the chain-start ramp
+
+  Default value: `5`
+* `--rate-max-commit-failure-secs <RATE_MAX_COMMIT_FAILURE_SECS>` — How long one chain may fail every commit before the run is abandoned. Overshoot failures are measurements; only a streak outlasting the controller's back-off is a wedged chain
+
+  Default value: `30`
 * `--client-mode <CLIENT_MODE>` — Which client to drive the chains with
 
   Default value: `full`

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -441,6 +441,10 @@ impl<Env: Environment> Benchmark<Env> {
             None => None,
         };
 
+        // Captured before `rate_search` is moved into the controller. Workers need it to know
+        // whether a failed commit is an overshoot to report or a genuine error to raise.
+        let rate_auto = rate_search.is_some();
+
         // One share per chain, held in an atomic so `--rate-auto` can move the whole fleet's
         // target mid-run: the controller rewrites these, the workers re-read them per block.
         let bps_shares: Vec<Arc<AtomicUsize>> = Self::split_bps(bps, num_chains);
@@ -489,6 +493,7 @@ impl<Env: Environment> Benchmark<Env> {
                         notifier_clone,
                         runtime_control_sender_clone,
                         delay_between_chains_ms,
+                        rate_auto,
                     ))
                     .await?;
 
@@ -513,7 +518,13 @@ impl<Env: Environment> Benchmark<Env> {
         }
         info!("All benchmark tasks completed successfully");
 
-        bps_control_task.await?;
+        if let Some(knee_bps) = bps_control_task.await? {
+            info!(
+                knee_bps,
+                knee_tps = knee_bps * transactions_per_block,
+                "rate search converged; the highest rate that held the latency budget"
+            );
+        }
         if let Some(metrics_watcher) = metrics_watcher {
             metrics_watcher.await??;
         }
@@ -568,7 +579,7 @@ impl<Env: Environment> Benchmark<Env> {
         bps_shares: Vec<Arc<AtomicUsize>>,
         latencies: LatencyRecorder,
         mut search: Option<rate::RateSearch>,
-    ) -> task::JoinHandle<()> {
+    ) -> task::JoinHandle<Option<usize>> {
         let shutdown_notifier = shutdown_notifier.clone();
         let bps_counts = bps_counts.to_vec();
         let notifier = notifier.clone();
@@ -584,18 +595,9 @@ impl<Env: Environment> Benchmark<Env> {
                 // one second holds too few samples for a p99, so a window can span several ticks.
                 let mut window_blocks = 0usize;
                 let mut window_start = time::Instant::now();
+                let mut converged = None;
                 loop {
                     if shutdown_notifier.is_cancelled() {
-                        // A run cut short by `--runtime-in-seconds` still has a measurement to
-                        // report: without this the search is dropped unread and the run is
-                        // indistinguishable from one that found no sustainable rate at all.
-                        if let Some(search) = search.as_ref() {
-                            info!(
-                                knee_bps = search.best_so_far(),
-                                knee_tps = search.best_so_far() * transactions_per_block,
-                                "rate search cut short; highest rate confirmed within the budget"
-                            );
-                        }
                         info!("Shutdown signal received in bps control task");
                         break;
                     }
@@ -630,10 +632,14 @@ impl<Env: Environment> Benchmark<Env> {
                     // whatever it asks for next.
                     if let Some(search) = search.as_mut() {
                         window_blocks += current_bps_count;
-                        let Some((p99, samples)) = latencies.take_p99(rate::MIN_P99_SAMPLES) else {
-                            // Too few blocks so far to support a p99. Keep widening the window
-                            // rather than judging on a maximum dressed up as a tail, and rather
-                            // than counting a slow startup as a failure.
+                        // Wait for enough samples to support a p99, but not forever: a slow
+                        // network never reaches the floor, and a stalled search measures nothing.
+                        let floor = if window_start.elapsed().as_secs() >= rate::MAX_WINDOW_SECS {
+                            1
+                        } else {
+                            rate::MIN_P99_SAMPLES
+                        };
+                        let Some((p99, samples)) = latencies.take_p99(floor) else {
                             continue;
                         };
                         // Rate over the SAME window the p99 came from: the window may span
@@ -660,12 +666,7 @@ impl<Env: Environment> Benchmark<Env> {
                                 );
                             }
                             rate::Decision::Converged { best_bps } => {
-                                info!(
-                                    knee_bps = best_bps,
-                                    knee_tps = best_bps * transactions_per_block,
-                                    "rate search converged; the highest rate that held the \
-                                     latency budget"
-                                );
+                                converged = Some(best_bps);
                                 shutdown_notifier.cancel();
                                 break;
                             }
@@ -674,6 +675,9 @@ impl<Env: Environment> Benchmark<Env> {
                 }
 
                 info!("Exiting bps control task");
+                // Returned rather than logged in-task: the runtime limit cancels, the workers
+                // stop and the process unwinds, so anything emitted from here races the exit.
+                converged.or_else(|| search.as_ref().map(rate::RateSearch::best_so_far))
             }
             .instrument(tracing::info_span!("bps_control")),
         )
@@ -970,6 +974,7 @@ impl<Env: Environment> Benchmark<Env> {
         notifier: Arc<Notify>,
         runtime_control_sender: Option<mpsc::Sender<()>>,
         delay_between_chains_ms: Option<u64>,
+        rate_auto: bool,
     ) -> Result<(), BenchmarkError> {
         barrier.wait().await;
         if let Some(delay_between_chains_ms) = delay_between_chains_ms {
@@ -985,6 +990,7 @@ impl<Env: Environment> Benchmark<Env> {
         }
 
         let owner = chain_client.owner().await?;
+        let mut consecutive_failures = 0u32;
 
         loop {
             // Deliberately NOT raced against the shutdown signal. `select!` drops the losing
@@ -999,10 +1005,30 @@ impl<Env: Environment> Benchmark<Env> {
             }
 
             let started = Instant::now();
-            chain_client
+            let commit = chain_client
                 .commit_operations(generator.generate_operations(owner, transactions_per_block))
-                .await?;
-            latencies.record(started.elapsed());
+                .await;
+            match commit {
+                Ok(()) => {
+                    consecutive_failures = 0;
+                    latencies.record(started.elapsed());
+                }
+                // The search has to overshoot to bracket the knee, so a commit that fails at
+                // the overshoot rate is the measurement: it lands as missing throughput and
+                // the rate is judged unsustained. Only meaningful under `--rate-auto`, which
+                // will come back down; at a fixed rate there is nothing to back off to.
+                Err(error) if rate_auto => {
+                    consecutive_failures += 1;
+                    warn!(%error, consecutive_failures, "commit failed; counting this rate as unsustained");
+                    // A chain wedged by an uncertified proposal fails identically to an
+                    // overshoot but never recovers, and would silently drag every later
+                    // measurement down. Repeated failures are that, not congestion.
+                    if consecutive_failures >= rate::MAX_CONSECUTIVE_COMMIT_FAILURES {
+                        return Err(error);
+                    }
+                }
+                Err(error) => return Err(error),
+            }
 
             // Read the share fresh each block: under `--rate-auto` the controller moves the
             // target while the run is in flight, and a share captured at startup would pin

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -29,9 +29,9 @@ impl LatencyRecorder {
     pub fn record(&self, elapsed: std::time::Duration) {
         let micros = elapsed.as_micros().min(u64::MAX as u128) as u64;
         if let Ok(mut histogram) = self.histogram.lock() {
-            // Saturates rather than failing: a block slower than the upper bound is still a
-            // data point, and losing it would flatter the tail.
-            let _ = histogram.saturating_record(micros);
+            // Saturating rather than plain `record`: a block slower than the upper bound is
+            // still a data point, and dropping it would flatter the tail.
+            histogram.saturating_record(micros);
         }
     }
 

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -3,6 +3,60 @@
 
 pub mod rate;
 
+/// Per-interval latency, shared between the workers that measure it and the controller that
+/// reads it.
+///
+/// A `Mutex<Histogram>` rather than anything cleverer: it is taken once per committed block,
+/// which is orders of magnitude rarer than the block itself is expensive, and the alternative
+/// (per-worker histograms merged on read) buys nothing measurable while making the p99 harder
+/// to reason about.
+#[derive(Clone)]
+pub struct LatencyRecorder {
+    histogram: Arc<std::sync::Mutex<hdrhistogram::Histogram<u64>>>,
+}
+
+impl LatencyRecorder {
+    /// Records microseconds, covering 1us to 5 minutes at three significant figures.
+    pub fn new() -> Self {
+        let histogram = hdrhistogram::Histogram::new_with_bounds(1, 300_000_000, 3)
+            .expect("valid histogram bounds");
+        Self {
+            histogram: Arc::new(std::sync::Mutex::new(histogram)),
+        }
+    }
+
+    /// Adds one committed block's latency.
+    pub fn record(&self, elapsed: std::time::Duration) {
+        let micros = elapsed.as_micros().min(u64::MAX as u128) as u64;
+        if let Ok(mut histogram) = self.histogram.lock() {
+            // Saturates rather than failing: a block slower than the upper bound is still a
+            // data point, and losing it would flatter the tail.
+            let _ = histogram.saturating_record(micros);
+        }
+    }
+
+    /// Returns the p99 for this interval and starts a new one.
+    ///
+    /// Draining is what makes the controller responsive: a cumulative histogram would carry
+    /// every slow block from every earlier rate forward, so the tail could never recover once
+    /// the search had overshot.
+    pub fn take_p99(&self) -> Option<std::time::Duration> {
+        let mut histogram = self.histogram.lock().ok()?;
+        if histogram.is_empty() {
+            return None;
+        }
+        let p99 = histogram.value_at_quantile(0.99);
+        histogram.reset();
+        Some(std::time::Duration::from_micros(p99))
+    }
+}
+
+impl Default for LatencyRecorder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 use std::{
     collections::HashMap,
     path::Path,
@@ -359,6 +413,7 @@ impl<Env: Environment> Benchmark<Env> {
         runtime_in_seconds: Option<u64>,
         delay_between_chains_ms: Option<u64>,
         chain_listener: Option<ChainListener<C>>,
+        rate_search: Option<rate::RateSearch>,
         shutdown_notifier: &CancellationToken,
     ) -> Result<(), BenchmarkError> {
         assert_eq!(
@@ -387,6 +442,11 @@ impl<Env: Environment> Benchmark<Env> {
             None => None,
         };
 
+        // One share per chain, held in an atomic so `--rate auto` can move the whole fleet's
+        // target mid-run: the controller rewrites these, the workers re-read them per block.
+        let bps_shares: Vec<Arc<AtomicUsize>> = Self::split_bps(bps, num_chains);
+        let latencies = LatencyRecorder::new();
+
         let bps_control_task = Self::bps_control_task(
             &barrier,
             shutdown_notifier,
@@ -394,13 +454,14 @@ impl<Env: Environment> Benchmark<Env> {
             &notifier,
             transactions_per_block,
             bps,
+            bps_shares.clone(),
+            latencies.clone(),
+            rate_search,
         );
 
         let (runtime_control_task, runtime_control_sender) =
             Self::runtime_control_task(shutdown_notifier, runtime_in_seconds, num_chains);
 
-        let bps_initial_share = bps / num_chains;
-        let mut bps_remainder = bps % num_chains;
         let mut join_set = task::JoinSet::<Result<(), BenchmarkError>>::new();
         for (chain_idx, (chain_client, generator)) in
             chain_clients.into_iter().zip(generators).enumerate()
@@ -411,18 +472,15 @@ impl<Env: Environment> Benchmark<Env> {
             let bps_count_clone = bps_counts[chain_idx].clone();
             let notifier_clone = notifier.clone();
             let runtime_control_sender_clone = runtime_control_sender.clone();
-            let bps_share = if bps_remainder > 0 {
-                bps_remainder -= 1;
-                bps_initial_share + 1
-            } else {
-                bps_initial_share
-            };
+            let bps_share = bps_shares[chain_idx].clone();
+            let latencies_clone = latencies.clone();
             join_set.spawn(
                 async move {
                     Box::pin(Self::run_benchmark_internal(
                         chain_idx,
                         chain_id,
                         bps_share,
+                        latencies_clone,
                         chain_client,
                         generator,
                         transactions_per_block,
@@ -474,6 +532,33 @@ impl<Env: Environment> Benchmark<Env> {
     }
 
     // The bps control task will control the BPS from the threads.
+    /// Splits a fleet-wide target into per-chain shares, distributing the remainder so the
+    /// shares sum to exactly `bps` rather than losing up to `num_chains - 1` to truncation.
+    fn split_bps(bps: usize, num_chains: usize) -> Vec<Arc<AtomicUsize>> {
+        let base = bps / num_chains;
+        let remainder = bps % num_chains;
+        (0..num_chains)
+            .map(|i| {
+                Arc::new(AtomicUsize::new(if i < remainder {
+                    base + 1
+                } else {
+                    base
+                }))
+            })
+            .collect()
+    }
+
+    /// Rewrites the shares in place for a new fleet-wide target.
+    fn set_bps(shares: &[Arc<AtomicUsize>], bps: usize) {
+        let base = bps / shares.len();
+        let remainder = bps % shares.len();
+        for (i, share) in shares.iter().enumerate() {
+            let value = if i < remainder { base + 1 } else { base };
+            share.store(value, Ordering::Relaxed);
+        }
+    }
+
+    #[expect(clippy::too_many_arguments)]
     fn bps_control_task(
         barrier: &Arc<Barrier>,
         shutdown_notifier: &CancellationToken,
@@ -481,6 +566,9 @@ impl<Env: Environment> Benchmark<Env> {
         notifier: &Arc<Notify>,
         transactions_per_block: usize,
         bps: usize,
+        bps_shares: Vec<Arc<AtomicUsize>>,
+        latencies: LatencyRecorder,
+        mut search: Option<rate::RateSearch>,
     ) -> task::JoinHandle<()> {
         let shutdown_notifier = shutdown_notifier.clone();
         let bps_counts = bps_counts.to_vec();
@@ -520,6 +608,41 @@ impl<Env: Environment> Benchmark<Env> {
                             formatted_current_bps,
                             formatted_current_tps,
                         );
+                    }
+
+                    // `--rate auto`: feed the interval to the search and move the fleet to
+                    // whatever it asks for next.
+                    if let Some(search) = search.as_mut() {
+                        let Some(p99) = latencies.take_p99() else {
+                            // No blocks committed this interval: nothing to judge. Judging it
+                            // as a failure would let a slow startup end the search.
+                            continue;
+                        };
+                        let observation = rate::Observation {
+                            achieved_bps: current_bps_count as f64,
+                            p99,
+                        };
+                        match search.observe(observation) {
+                            rate::Decision::Hold(target) => {
+                                Self::set_bps(&bps_shares, target);
+                                info!(
+                                    target_bps = target,
+                                    p99_ms = p99.as_millis() as u64,
+                                    achieved_bps = current_bps_count,
+                                    "rate search"
+                                );
+                            }
+                            rate::Decision::Converged { best_bps } => {
+                                info!(
+                                    knee_bps = best_bps,
+                                    knee_tps = best_bps * transactions_per_block,
+                                    "rate search converged; the highest rate that held the \
+                                     latency budget"
+                                );
+                                shutdown_notifier.cancel();
+                                break;
+                            }
+                        }
                     }
                 }
 
@@ -809,7 +932,8 @@ impl<Env: Environment> Benchmark<Env> {
     async fn run_benchmark_internal(
         chain_idx: usize,
         chain_id: ChainId,
-        bps: usize,
+        bps_share: Arc<AtomicUsize>,
+        latencies: LatencyRecorder,
         chain_client: Arc<dyn BenchmarkClient>,
         mut generator: Box<dyn OperationGenerator>,
         transactions_per_block: usize,
@@ -847,12 +971,18 @@ impl<Env: Environment> Benchmark<Env> {
                 break;
             }
 
+            let started = Instant::now();
             chain_client
                 .commit_operations(generator.generate_operations(owner, transactions_per_block))
                 .await?;
+            latencies.record(started.elapsed());
 
+            // Read the share fresh each block: under `--rate auto` the controller moves the
+            // target while the run is in flight, and a share captured at startup would pin
+            // every worker to the rate the search began at.
+            let share = bps_share.load(Ordering::Relaxed);
             let current_bps_count = bps_count.fetch_add(1, Ordering::Relaxed) + 1;
-            if current_bps_count >= bps {
+            if current_bps_count >= share {
                 // Safe to race: waiting on the notifier holds no chain state, and it would
                 // otherwise block until the next tick even after shutdown.
                 tokio::select! {

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -463,7 +463,7 @@ impl<Env: Environment> Benchmark<Env> {
             &bps_counts,
             &notifier,
             transactions_per_block,
-            bps,
+            initial_bps,
             bps_shares.clone(),
             latencies.clone(),
             rate_search,
@@ -605,7 +605,7 @@ impl<Env: Environment> Benchmark<Env> {
         bps_counts: &[Arc<AtomicUsize>],
         notifier: &Arc<Notify>,
         transactions_per_block: usize,
-        bps: usize,
+        initial_bps: usize,
         bps_shares: Vec<Arc<AtomicUsize>>,
         latencies: LatencyRecorder,
         mut search: Option<rate::RateSearch>,
@@ -621,9 +621,11 @@ impl<Env: Environment> Benchmark<Env> {
             async move {
                 barrier.wait().await;
                 let mut one_second_interval = time::interval(time::Duration::from_secs(1));
-                // The rate the fleet is currently being asked for. Under `--rate-auto` the
-                // search moves this every interval, so the parameter `bps` is only the start.
-                let mut current_target = bps;
+                // The rate the fleet is currently being asked for, and the same value
+                // `bps_shares` was seeded with. Under `--rate-auto` the search moves it every
+                // window; seeding it from `--bps` instead would make the shortfall warning
+                // name a rate the fleet was never driven at.
+                let mut current_target = initial_bps;
                 // When the window being assembled started. At low rates one second holds too
                 // few samples for a p99, so a window can span several ticks.
                 let mut window_start = time::Instant::now();
@@ -1103,8 +1105,22 @@ impl<Env: Environment> Benchmark<Env> {
                     // A chain wedged by an uncertified proposal fails identically to an
                     // overshoot but never recovers. Only a streak that outlasts the
                     // controller's back-off distinguishes the two.
+                    //
+                    // Ending the run rather than returning Err: by this point the search has
+                    // usually confirmed a knee, and that measurement is the whole point of the
+                    // run. Erroring out discards it and reports nothing at all, which is
+                    // strictly less useful than the number plus a loud warning about why the
+                    // run stopped early.
                     if failing_for >= std::time::Duration::from_secs(max_commit_failure_secs) {
-                        return Err(error);
+                        error!(
+                            %error,
+                            failing_for_ms = failing_for.as_millis() as u64,
+                            "chain has failed every commit for the whole bound and is not \
+                             recovering; ending the run so the rate confirmed so far is still \
+                             reported"
+                        );
+                        shutdown_notifier.cancel();
+                        break;
                     }
                 }
                 Err(error) => return Err(error),

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -35,19 +35,18 @@ impl LatencyRecorder {
         }
     }
 
-    /// Returns the p99 for this interval and starts a new one.
-    ///
-    /// Draining is what makes the controller responsive: a cumulative histogram would carry
-    /// every slow block from every earlier rate forward, so the tail could never recover once
-    /// the search had overshot.
-    pub fn take_p99(&self) -> Option<std::time::Duration> {
+    /// Returns the p99 and its sample count, draining the window — but only once `min_samples`
+    /// blocks back it; under the floor the histogram is left intact so the window widens instead.
+    /// Draining once supported is what lets the tail recover after the search overshoots.
+    pub fn take_p99(&self, min_samples: u64) -> Option<(std::time::Duration, u64)> {
         let mut histogram = self.histogram.lock().ok()?;
-        if histogram.is_empty() {
+        let count = histogram.len();
+        if count < min_samples.max(1) {
             return None;
         }
         let p99 = histogram.value_at_quantile(0.99);
         histogram.reset();
-        Some(std::time::Duration::from_micros(p99))
+        Some((std::time::Duration::from_micros(p99), count))
     }
 }
 
@@ -442,7 +441,7 @@ impl<Env: Environment> Benchmark<Env> {
             None => None,
         };
 
-        // One share per chain, held in an atomic so `--rate auto` can move the whole fleet's
+        // One share per chain, held in an atomic so `--rate-auto` can move the whole fleet's
         // target mid-run: the controller rewrites these, the workers re-read them per block.
         let bps_shares: Vec<Arc<AtomicUsize>> = Self::split_bps(bps, num_chains);
         let latencies = LatencyRecorder::new();
@@ -578,8 +577,25 @@ impl<Env: Environment> Benchmark<Env> {
             async move {
                 barrier.wait().await;
                 let mut one_second_interval = time::interval(time::Duration::from_secs(1));
+                // The rate the fleet is currently being asked for. Under `--rate-auto` the
+                // search moves this every interval, so the parameter `bps` is only the start.
+                let mut current_target = bps;
+                // Blocks and elapsed time backing the observation being assembled. At low rates
+                // one second holds too few samples for a p99, so a window can span several ticks.
+                let mut window_blocks = 0usize;
+                let mut window_start = time::Instant::now();
                 loop {
                     if shutdown_notifier.is_cancelled() {
+                        // A run cut short by `--runtime-in-seconds` still has a measurement to
+                        // report: without this the search is dropped unread and the run is
+                        // indistinguishable from one that found no sustainable rate at all.
+                        if let Some(search) = search.as_ref() {
+                            info!(
+                                knee_bps = search.best_so_far(),
+                                knee_tps = search.best_so_far() * transactions_per_block,
+                                "rate search cut short; highest rate confirmed within the budget"
+                            );
+                        }
                         info!("Shutdown signal received in bps control task");
                         break;
                     }
@@ -593,9 +609,9 @@ impl<Env: Environment> Benchmark<Env> {
                     let formatted_current_tps = (current_bps_count * transactions_per_block)
                         .to_formatted_string(&Locale::en);
                     let formatted_tps_goal =
-                        (bps * transactions_per_block).to_formatted_string(&Locale::en);
-                    let formatted_bps_goal = bps.to_formatted_string(&Locale::en);
-                    if current_bps_count >= bps {
+                        (current_target * transactions_per_block).to_formatted_string(&Locale::en);
+                    let formatted_bps_goal = current_target.to_formatted_string(&Locale::en);
+                    if current_bps_count >= current_target {
                         info!(
                             "Achieved {} BPS/{} TPS",
                             formatted_current_bps, formatted_current_tps
@@ -610,25 +626,36 @@ impl<Env: Environment> Benchmark<Env> {
                         );
                     }
 
-                    // `--rate auto`: feed the interval to the search and move the fleet to
+                    // `--rate-auto`: feed the window to the search and move the fleet to
                     // whatever it asks for next.
                     if let Some(search) = search.as_mut() {
-                        let Some(p99) = latencies.take_p99() else {
-                            // No blocks committed this interval: nothing to judge. Judging it
-                            // as a failure would let a slow startup end the search.
+                        window_blocks += current_bps_count;
+                        let Some((p99, samples)) = latencies.take_p99(rate::MIN_P99_SAMPLES) else {
+                            // Too few blocks so far to support a p99. Keep widening the window
+                            // rather than judging on a maximum dressed up as a tail, and rather
+                            // than counting a slow startup as a failure.
                             continue;
                         };
+                        // Rate over the SAME window the p99 came from: the window may span
+                        // several ticks at low rates, and dividing by one second would then
+                        // understate the rate the tail was measured at.
+                        let elapsed = window_start.elapsed().as_secs_f64().max(f64::EPSILON);
                         let observation = rate::Observation {
-                            achieved_bps: current_bps_count as f64,
+                            achieved_bps: window_blocks as f64 / elapsed,
                             p99,
                         };
+                        window_blocks = 0;
+                        window_start = time::Instant::now();
                         match search.observe(observation) {
                             rate::Decision::Hold(target) => {
                                 Self::set_bps(&bps_shares, target);
+                                current_target = target;
                                 info!(
                                     target_bps = target,
                                     p99_ms = p99.as_millis() as u64,
-                                    achieved_bps = current_bps_count,
+                                    achieved_bps = observation.achieved_bps,
+                                    samples = samples,
+                                    window_s = elapsed,
                                     "rate search"
                                 );
                             }
@@ -977,7 +1004,7 @@ impl<Env: Environment> Benchmark<Env> {
                 .await?;
             latencies.record(started.elapsed());
 
-            // Read the share fresh each block: under `--rate auto` the controller moves the
+            // Read the share fresh each block: under `--rate-auto` the controller moves the
             // target while the run is in flight, and a share captured at startup would pin
             // every worker to the rate the search began at.
             let share = bps_share.load(Ordering::Relaxed);

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -682,22 +682,20 @@ impl<Env: Environment> Benchmark<Env> {
                         }
                         // Wait for enough samples to support a p99, but not forever: a slow
                         // network never reaches the floor, and a stalled search measures nothing.
-                        let aged_out =
-                            window_start.elapsed().as_secs() >= rate_control.max_window_secs;
-                        let floor = if aged_out {
-                            1
-                        } else {
-                            rate_control.min_p99_samples
-                        };
-                        let (p99, samples) = match latencies.take_p99(floor) {
-                            Some(measured) => measured,
-                            // An aged-out window with NO committed blocks is the most important
-                            // observation there is: every commit failed, so there are no
-                            // latencies to summarise. Skipping it leaves the search blind to
-                            // the one condition it must react to -- it would hold the
-                            // unservable rate forever, never learning to back off.
-                            None if aged_out => (window_start.elapsed(), 0),
-                            None => continue,
+                        let (p99, samples) = match rate_control
+                            .window_action(window_start.elapsed())
+                        {
+                            rate::WindowAction::Wait(floor) => match latencies.take_p99(floor) {
+                                Some(measured) => measured,
+                                None => continue,
+                            },
+                            // An aged-out window with NO committed blocks is the most
+                            // important observation there is: every commit failed, so there
+                            // is nothing to summarise. Skipping it leaves the search blind
+                            // to the one condition it must react to.
+                            rate::WindowAction::Judge => {
+                                latencies.take_p99(1).unwrap_or((window_start.elapsed(), 0))
+                            }
                         };
                         // Rate over the SAME window the p99 came from, counted from COMMITTED
                         // blocks: `samples` is the histogram's length, and the histogram is

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod rate;
+
 use std::{
     collections::HashMap,
     path::Path,

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -520,15 +520,20 @@ impl<Env: Environment> Benchmark<Env> {
         }
         info!("All benchmark tasks completed successfully");
 
+        // Both figures, always: `offered` is what the search bracketed on, `achieved` is what
+        // the network actually committed, and a level is confirmed while delivering as little
+        // as 80% of its target. Reporting only the offered rate overstates throughput.
         match bps_control_task.await? {
-            Some(rate::SearchOutcome::Converged(knee_bps)) => info!(
-                knee_bps,
-                knee_tps = knee_bps * transactions_per_block,
+            Some(rate::SearchOutcome::Converged(knee)) => info!(
+                knee_bps = knee.offered_bps,
+                knee_achieved_bps = knee.achieved_bps,
+                knee_achieved_tps = knee.achieved_bps * transactions_per_block as f64,
                 "rate search converged; the highest rate that held the latency budget"
             ),
-            Some(rate::SearchOutcome::CutShort(best_bps)) => warn!(
-                best_bps,
-                best_tps = best_bps * transactions_per_block,
+            Some(rate::SearchOutcome::CutShort(best)) => warn!(
+                best_bps = best.offered_bps,
+                best_achieved_bps = best.achieved_bps,
+                best_achieved_tps = best.achieved_bps * transactions_per_block as f64,
                 "rate search cut short by the runtime limit; this is a LOWER BOUND on the knee, \
                  not the knee"
             ),
@@ -690,8 +695,10 @@ impl<Env: Environment> Benchmark<Env> {
                                     "rate search"
                                 );
                             }
-                            rate::Decision::Converged { best_bps } => {
-                                converged = Some(best_bps);
+                            rate::Decision::Converged { .. } => {
+                                // From the search, not the decision: it carries the delivered
+                                // rate alongside the offered one.
+                                converged = Some(search.best_so_far());
                                 shutdown_notifier.cancel();
                                 break;
                             }
@@ -705,7 +712,7 @@ impl<Env: Environment> Benchmark<Env> {
                 // Converged and cut-short stay distinct: a lower bound reported as a knee is
                 // the failure the e2e assertion exists to catch.
                 match converged {
-                    Some(best_bps) => Some(rate::SearchOutcome::Converged(best_bps)),
+                    Some(knee) => Some(rate::SearchOutcome::Converged(knee)),
                     None => search
                         .as_ref()
                         .map(|search| rate::SearchOutcome::CutShort(search.best_so_far())),
@@ -793,8 +800,16 @@ impl<Env: Environment> Benchmark<Env> {
                             break;
                         }
                     }
-                    time::sleep(time::Duration::from_secs(runtime_in_seconds)).await;
-                    shutdown_notifier.cancel();
+                    // Raced against the token: under `--rate-auto` an early exit is the NORMAL
+                    // ending -- convergence cancels -- and a bare sleep here would hold the run
+                    // open, chains and all, for the rest of `--runtime-in-seconds` after the
+                    // knee had already been reported.
+                    tokio::select! {
+                        _ = time::sleep(time::Duration::from_secs(runtime_in_seconds)) => {
+                            shutdown_notifier.cancel();
+                        }
+                        _ = shutdown_notifier.cancelled() => {}
+                    }
                 }
                 .instrument(tracing::info_span!("runtime_control")),
             );

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -6,10 +6,10 @@ pub mod rate;
 /// Per-interval latency, shared between the workers that measure it and the controller that
 /// reads it.
 ///
-/// A `Mutex<Histogram>` rather than anything cleverer: it is taken once per committed block,
-/// which is orders of magnitude rarer than the block itself is expensive, and the alternative
-/// (per-worker histograms merged on read) buys nothing measurable while making the p99 harder
-/// to reason about.
+/// One shared `Mutex<Histogram>`, taken once per committed block. Sharding per worker really is
+/// 5-10x faster on this line (measured: 22.7M vs 229M records/s at 32 threads), but the shared
+/// path still has ~3 orders of magnitude of headroom over any block rate one client can drive,
+/// so the ceiling is the commit path, not this lock.
 #[derive(Clone)]
 pub struct LatencyRecorder {
     histogram: Arc<std::sync::Mutex<hdrhistogram::Histogram<u64>>>,
@@ -413,6 +413,7 @@ impl<Env: Environment> Benchmark<Env> {
         delay_between_chains_ms: Option<u64>,
         chain_listener: Option<ChainListener<C>>,
         rate_search: Option<rate::RateSearch>,
+        rate_control: rate::RateControlConfig,
         shutdown_notifier: &CancellationToken,
     ) -> Result<(), BenchmarkError> {
         assert_eq!(
@@ -447,7 +448,13 @@ impl<Env: Environment> Benchmark<Env> {
 
         // One share per chain, held in an atomic so `--rate-auto` can move the whole fleet's
         // target mid-run: the controller rewrites these, the workers re-read them per block.
-        let bps_shares: Vec<Arc<AtomicUsize>> = Self::split_bps(bps, num_chains);
+        // Seeded from the search's own starting target when there is one: `--bps` is the fixed
+        // rate, `--rate-start-bps` is where the climb opens, and seeding from the wrong one
+        // makes the first window measure a rate the search does not think it asked for.
+        let initial_bps = rate_search
+            .as_ref()
+            .map_or(bps, |search| search.target_bps());
+        let bps_shares: Vec<Arc<AtomicUsize>> = Self::split_bps(initial_bps, num_chains);
         let latencies = LatencyRecorder::new();
 
         let bps_control_task = Self::bps_control_task(
@@ -462,6 +469,7 @@ impl<Env: Environment> Benchmark<Env> {
             rate_search,
             num_chains,
             delay_between_chains_ms,
+            rate_control,
         );
 
         let (runtime_control_task, runtime_control_sender) =
@@ -496,6 +504,7 @@ impl<Env: Environment> Benchmark<Env> {
                         runtime_control_sender_clone,
                         delay_between_chains_ms,
                         rate_auto,
+                        rate_control.max_commit_failure_secs,
                     ))
                     .await?;
 
@@ -602,6 +611,7 @@ impl<Env: Environment> Benchmark<Env> {
         mut search: Option<rate::RateSearch>,
         num_chains: usize,
         delay_between_chains_ms: Option<u64>,
+        rate_control: rate::RateControlConfig,
     ) -> task::JoinHandle<Option<rate::SearchOutcome>> {
         let shutdown_notifier = shutdown_notifier.clone();
         let bps_counts = bps_counts.to_vec();
@@ -624,7 +634,7 @@ impl<Env: Environment> Benchmark<Env> {
                     delay_between_chains_ms.unwrap_or(0) * (num_chains.saturating_sub(1)) as u64;
                 let settle_until = time::Instant::now()
                     + time::Duration::from_millis(ramp_ms)
-                    + time::Duration::from_secs(rate::SETTLE_SECS);
+                    + time::Duration::from_secs(rate_control.settle_secs);
                 let mut converged = None;
                 loop {
                     if shutdown_notifier.is_cancelled() {
@@ -670,13 +680,22 @@ impl<Env: Environment> Benchmark<Env> {
                         }
                         // Wait for enough samples to support a p99, but not forever: a slow
                         // network never reaches the floor, and a stalled search measures nothing.
-                        let floor = if window_start.elapsed().as_secs() >= rate::MAX_WINDOW_SECS {
+                        let aged_out =
+                            window_start.elapsed().as_secs() >= rate_control.max_window_secs;
+                        let floor = if aged_out {
                             1
                         } else {
-                            rate::MIN_P99_SAMPLES
+                            rate_control.min_p99_samples
                         };
-                        let Some((p99, samples)) = latencies.take_p99(floor) else {
-                            continue;
+                        let (p99, samples) = match latencies.take_p99(floor) {
+                            Some(measured) => measured,
+                            // An aged-out window with NO committed blocks is the most important
+                            // observation there is: every commit failed, so there are no
+                            // latencies to summarise. Skipping it leaves the search blind to
+                            // the one condition it must react to -- it would hold the
+                            // unservable rate forever, never learning to back off.
+                            None if aged_out => (window_start.elapsed(), 0),
+                            None => continue,
                         };
                         // Rate over the SAME window the p99 came from, counted from COMMITTED
                         // blocks: `samples` is the histogram's length, and the histogram is
@@ -1029,6 +1048,7 @@ impl<Env: Environment> Benchmark<Env> {
         runtime_control_sender: Option<mpsc::Sender<()>>,
         delay_between_chains_ms: Option<u64>,
         rate_auto: bool,
+        max_commit_failure_secs: u64,
     ) -> Result<(), BenchmarkError> {
         barrier.wait().await;
         if let Some(delay_between_chains_ms) = delay_between_chains_ms {
@@ -1044,7 +1064,8 @@ impl<Env: Environment> Benchmark<Env> {
         }
 
         let owner = chain_client.owner().await?;
-        let mut consecutive_failures = 0u32;
+        // When the current unbroken run of commit failures began; cleared by any success.
+        let mut failing_since: Option<Instant> = None;
 
         loop {
             // Deliberately NOT raced against the shutdown signal. `select!` drops the losing
@@ -1064,7 +1085,7 @@ impl<Env: Environment> Benchmark<Env> {
                 .await;
             match commit {
                 Ok(()) => {
-                    consecutive_failures = 0;
+                    failing_since = None;
                     latencies.record(started.elapsed());
                 }
                 // The search has to overshoot to bracket the knee, so a commit that fails at
@@ -1072,12 +1093,17 @@ impl<Env: Environment> Benchmark<Env> {
                 // the rate is judged unsustained. Only meaningful under `--rate-auto`, which
                 // will come back down; at a fixed rate there is nothing to back off to.
                 Err(error) if rate_auto => {
-                    consecutive_failures += 1;
-                    warn!(%error, consecutive_failures, "commit failed; counting this rate as unsustained");
+                    let since = *failing_since.get_or_insert_with(Instant::now);
+                    let failing_for = since.elapsed();
+                    warn!(
+                        %error,
+                        failing_for_ms = failing_for.as_millis() as u64,
+                        "commit failed; counting this rate as unsustained"
+                    );
                     // A chain wedged by an uncertified proposal fails identically to an
-                    // overshoot but never recovers, and would silently drag every later
-                    // measurement down. Repeated failures are that, not congestion.
-                    if consecutive_failures >= rate::MAX_CONSECUTIVE_COMMIT_FAILURES {
+                    // overshoot but never recovers. Only a streak that outlasts the
+                    // controller's back-off distinguishes the two.
+                    if failing_for >= std::time::Duration::from_secs(max_commit_failure_secs) {
                         return Err(error);
                     }
                 }

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -524,6 +524,13 @@ impl<Env: Environment> Benchmark<Env> {
         // the network actually committed, and a level is confirmed while delivering as little
         // as 80% of its target. Reporting only the offered rate overstates throughput.
         match bps_control_task.await? {
+            // Zero is the absence of a measurement, not a measurement of zero: the search
+            // bracketed all the way down without any rate holding the budget. Logging it on
+            // the success line would read as a knee of 0 rather than as no knee at all.
+            Some(rate::SearchOutcome::Converged(knee)) if knee.offered_bps == 0 => warn!(
+                "rate search found NO sustainable rate: every rate tried, down to the lowest \
+                 the generators can offer, missed the latency budget or was not delivered"
+            ),
             Some(rate::SearchOutcome::Converged(knee)) => info!(
                 knee_bps = knee.offered_bps,
                 knee_achieved_bps = knee.achieved_bps,

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -460,6 +460,8 @@ impl<Env: Environment> Benchmark<Env> {
             bps_shares.clone(),
             latencies.clone(),
             rate_search,
+            num_chains,
+            delay_between_chains_ms,
         );
 
         let (runtime_control_task, runtime_control_sender) =
@@ -518,12 +520,19 @@ impl<Env: Environment> Benchmark<Env> {
         }
         info!("All benchmark tasks completed successfully");
 
-        if let Some(knee_bps) = bps_control_task.await? {
-            info!(
+        match bps_control_task.await? {
+            Some(rate::SearchOutcome::Converged(knee_bps)) => info!(
                 knee_bps,
                 knee_tps = knee_bps * transactions_per_block,
                 "rate search converged; the highest rate that held the latency budget"
-            );
+            ),
+            Some(rate::SearchOutcome::CutShort(best_bps)) => warn!(
+                best_bps,
+                best_tps = best_bps * transactions_per_block,
+                "rate search cut short by the runtime limit; this is a LOWER BOUND on the knee, \
+                 not the knee"
+            ),
+            None => {}
         }
         if let Some(metrics_watcher) = metrics_watcher {
             metrics_watcher.await??;
@@ -579,7 +588,9 @@ impl<Env: Environment> Benchmark<Env> {
         bps_shares: Vec<Arc<AtomicUsize>>,
         latencies: LatencyRecorder,
         mut search: Option<rate::RateSearch>,
-    ) -> task::JoinHandle<Option<usize>> {
+        num_chains: usize,
+        delay_between_chains_ms: Option<u64>,
+    ) -> task::JoinHandle<Option<rate::SearchOutcome>> {
         let shutdown_notifier = shutdown_notifier.clone();
         let bps_counts = bps_counts.to_vec();
         let notifier = notifier.clone();
@@ -591,10 +602,17 @@ impl<Env: Environment> Benchmark<Env> {
                 // The rate the fleet is currently being asked for. Under `--rate-auto` the
                 // search moves this every interval, so the parameter `bps` is only the start.
                 let mut current_target = bps;
-                // Blocks and elapsed time backing the observation being assembled. At low rates
-                // one second holds too few samples for a p99, so a window can span several ticks.
-                let mut window_blocks = 0usize;
+                // When the window being assembled started. At low rates one second holds too
+                // few samples for a p99, so a window can span several ticks.
                 let mut window_start = time::Instant::now();
+                // Workers sleep their stagger AFTER this barrier, so the fleet is not complete
+                // until the last one wakes; judging before then measures the ramp, not the
+                // network.
+                let ramp_ms =
+                    delay_between_chains_ms.unwrap_or(0) * (num_chains.saturating_sub(1)) as u64;
+                let settle_until = time::Instant::now()
+                    + time::Duration::from_millis(ramp_ms)
+                    + time::Duration::from_secs(rate::SETTLE_SECS);
                 let mut converged = None;
                 loop {
                     if shutdown_notifier.is_cancelled() {
@@ -631,7 +649,13 @@ impl<Env: Environment> Benchmark<Env> {
                     // `--rate-auto`: feed the window to the search and move the fleet to
                     // whatever it asks for next.
                     if let Some(search) = search.as_mut() {
-                        window_blocks += current_bps_count;
+                        if time::Instant::now() < settle_until {
+                            // Drain rather than skip: warm-up latencies must not leak into the
+                            // first judged window.
+                            latencies.take_p99(1);
+                            window_start = time::Instant::now();
+                            continue;
+                        }
                         // Wait for enough samples to support a p99, but not forever: a slow
                         // network never reaches the floor, and a stalled search measures nothing.
                         let floor = if window_start.elapsed().as_secs() >= rate::MAX_WINDOW_SECS {
@@ -642,15 +666,16 @@ impl<Env: Environment> Benchmark<Env> {
                         let Some((p99, samples)) = latencies.take_p99(floor) else {
                             continue;
                         };
-                        // Rate over the SAME window the p99 came from: the window may span
-                        // several ticks at low rates, and dividing by one second would then
-                        // understate the rate the tail was measured at.
+                        // Rate over the SAME window the p99 came from, counted from COMMITTED
+                        // blocks: `samples` is the histogram's length, and the histogram is
+                        // written only on success. The per-chain counters tick on every
+                        // attempt, so using them would score a rate whose commits are failing
+                        // as fully delivered and climb straight past the ceiling.
                         let elapsed = window_start.elapsed().as_secs_f64().max(f64::EPSILON);
                         let observation = rate::Observation {
-                            achieved_bps: window_blocks as f64 / elapsed,
+                            achieved_bps: samples as f64 / elapsed,
                             p99,
                         };
-                        window_blocks = 0;
                         window_start = time::Instant::now();
                         match search.observe(observation) {
                             rate::Decision::Hold(target) => {
@@ -677,7 +702,14 @@ impl<Env: Environment> Benchmark<Env> {
                 info!("Exiting bps control task");
                 // Returned rather than logged in-task: the runtime limit cancels, the workers
                 // stop and the process unwinds, so anything emitted from here races the exit.
-                converged.or_else(|| search.as_ref().map(rate::RateSearch::best_so_far))
+                // Converged and cut-short stay distinct: a lower bound reported as a knee is
+                // the failure the e2e assertion exists to catch.
+                match converged {
+                    Some(best_bps) => Some(rate::SearchOutcome::Converged(best_bps)),
+                    None => search
+                        .as_ref()
+                        .map(|search| rate::SearchOutcome::CutShort(search.best_so_far())),
+                }
             }
             .instrument(tracing::info_span!("bps_control")),
         )

--- a/linera-client/src/benchmark/rate.rs
+++ b/linera-client/src/benchmark/rate.rs
@@ -62,6 +62,31 @@ pub struct RateControlConfig {
     pub max_commit_failure_secs: u64,
 }
 
+/// What to do with the observation window as it currently stands.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WindowAction {
+    /// Keep collecting until the histogram holds this many samples.
+    Wait(u64),
+    /// Judge it now, on whatever it holds — including nothing at all.
+    Judge,
+}
+
+impl RateControlConfig {
+    /// Whether a window open for `elapsed` should be judged yet.
+    ///
+    /// Past `max_window_secs` the answer is yes regardless of how little it holds, and an EMPTY
+    /// aged-out window is the case that matters: every commit failed, so there are no latencies
+    /// to summarise, and waiting for samples that will never arrive leaves the search unable to
+    /// learn that the rate it set is unservable.
+    pub fn window_action(&self, elapsed: Duration) -> WindowAction {
+        if elapsed.as_secs() >= self.max_window_secs {
+            WindowAction::Judge
+        } else {
+            WindowAction::Wait(self.min_p99_samples)
+        }
+    }
+}
+
 impl Default for RateControlConfig {
     fn default() -> Self {
         Self {
@@ -448,6 +473,25 @@ mod tests {
             "reported {} delivered at an offered {target}, but only {} was committed",
             knee.achieved_bps,
             target as f64 * 0.85
+        );
+    }
+
+    /// The floor applies only while the window is young; once it ages out the window is judged
+    /// on whatever it holds. Mutating the comparison here must fail this test — the inline
+    /// version of this decision was untestable, so the bug it hid survived five review rounds.
+    #[test]
+    fn an_aged_out_window_is_judged_however_little_it_holds() {
+        let config = RateControlConfig::default();
+        assert_eq!(
+            config.window_action(Duration::from_secs(0)),
+            WindowAction::Wait(config.min_p99_samples),
+            "a young window must still wait for enough samples to support a p99"
+        );
+        assert_eq!(
+            config.window_action(Duration::from_secs(config.max_window_secs)),
+            WindowAction::Judge,
+            "an aged-out window must be judged rather than waiting for samples that a dead \
+             fleet will never produce"
         );
     }
 

--- a/linera-client/src/benchmark/rate.rs
+++ b/linera-client/src/benchmark/rate.rs
@@ -15,6 +15,11 @@
 
 use std::time::Duration;
 
+/// Blocks an observation window must hold before its p99 is believed: `value_at_quantile(0.99)`
+/// returns the largest sample whenever n < 100, so below this the "tail" is really a maximum and
+/// one slow block decides the verdict. 200 puts two samples above the 99th percentile.
+pub const MIN_P99_SAMPLES: u64 = 200;
+
 /// One control interval's worth of measurement.
 #[derive(Clone, Copy, Debug)]
 pub struct Observation {
@@ -70,10 +75,12 @@ impl Default for RateSearchConfig {
 
 /// Climbs toward the highest rate that holds `target_p99`.
 ///
-/// Two phases. It first doubles (or `growth`s) until an interval misses the budget, which
-/// brackets the knee between the last good rate and the first bad one; then it bisects that
-/// bracket until the two are within `resolution`. Doubling first matters: an additive ramp puts
-/// its coarsest resolution exactly where the curve bends.
+/// Two phases. It first moves geometrically to bracket the knee — multiplying by `growth` while
+/// the network keeps up, halving while it does not — and then bisects the resulting bracket
+/// until its ends are within `resolution`. Moving geometrically first matters: an additive ramp
+/// puts its coarsest resolution exactly where the curve bends. Halving downward matters because
+/// `start_bps` is only a guess; a search that gave up when its opening guess was too high would
+/// report no knee precisely when the operator most needs the number.
 #[derive(Debug)]
 pub struct RateSearch {
     config: RateSearchConfig,
@@ -147,9 +154,17 @@ impl RateSearch {
                     .max(self.target + 1);
                 Decision::Hold(self.target)
             }
-            // The very first target already failed. There is no knee to report: the network
-            // cannot sustain even the starting rate inside the budget.
-            (None, Some(_)) => Decision::Converged { best_bps: 0 },
+            // Nothing has passed yet, so the knee is below where we started. Halve downward to
+            // bracket it: `--bps` is the operator's opening guess, and guessing high must still
+            // yield a measurement rather than an immediate no-knee verdict.
+            (None, Some(bad)) => {
+                if bad <= 1 {
+                    Decision::Converged { best_bps: 0 }
+                } else {
+                    self.target = bad / 2;
+                    Decision::Hold(self.target)
+                }
+            }
             (Some(good), Some(bad)) => {
                 // Adjacent integers cannot be subdivided: the midpoint would be `good` again
                 // and the search would re-test a rate it has already confirmed, forever. That
@@ -230,12 +245,34 @@ mod tests {
         );
     }
 
-    /// A network that cannot even serve the starting rate has no knee to report. Reporting the
-    /// start rate anyway would invent a result.
+    /// A network that cannot serve *any* rate has no knee to report. Reporting the start rate
+    /// anyway would invent a result.
     #[test]
     fn a_network_that_never_meets_the_budget_reports_no_knee() {
         let found = converge(RateSearchConfig::default(), |_| ms(9_000));
         assert_eq!(found, 0);
+    }
+
+    /// A knee below the opening guess must still be measured. `--bps` is a guess, and the
+    /// benchmark runbook opens well above what a cluster is likely to sustain, so a search that
+    /// only climbed would report no knee exactly when the number matters.
+    #[test]
+    fn it_searches_downward_when_the_start_rate_is_too_high() {
+        for knee in [1, 7, 140, 999] {
+            let config = RateSearchConfig {
+                start_bps: 4096,
+                ..RateSearchConfig::default()
+            };
+            let found = converge(config, |bps| if bps <= knee { ms(10) } else { ms(5_000) });
+            assert!(
+                found <= knee,
+                "reported {found} as sustainable but the knee is {knee}"
+            );
+            assert!(
+                found as f64 >= knee as f64 * 0.5,
+                "reported {found}, far below the real knee {knee}, from a start of 4096"
+            );
+        }
     }
 
     /// Latency inside budget is not enough on its own: if the generators cannot actually offer

--- a/linera-client/src/benchmark/rate.rs
+++ b/linera-client/src/benchmark/rate.rs
@@ -35,6 +35,24 @@ pub const MAX_WINDOW_SECS: u64 = 3;
 /// every later window down. A run of failures is that, not congestion.
 pub const MAX_CONSECUTIVE_COMMIT_FAILURES: u32 = 20;
 
+/// Warm-up held before the first observation, on top of the chain-start ramp.
+///
+/// `bad` is a one-way ratchet: the first window judged unsustainable caps every later target,
+/// and no rate above it can ever be reported. A cold cache or a half-started fleet therefore
+/// pins the knee below `--bps` permanently, and — since the search now halves downward rather
+/// than reporting nothing — it does so while still returning a plausible-looking number.
+pub const SETTLE_SECS: u64 = 5;
+
+/// How a rate search ended.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SearchOutcome {
+    /// The knee was bracketed to within the configured resolution.
+    Converged(usize),
+    /// A runtime limit or cancellation ended the run first; this is the best rate confirmed
+    /// so far, which is a lower bound on the knee rather than the knee itself.
+    CutShort(usize),
+}
+
 /// One control interval's worth of measurement.
 #[derive(Clone, Copy, Debug)]
 pub struct Observation {

--- a/linera-client/src/benchmark/rate.rs
+++ b/linera-client/src/benchmark/rate.rs
@@ -43,14 +43,28 @@ pub const MAX_CONSECUTIVE_COMMIT_FAILURES: u32 = 20;
 /// than reporting nothing — it does so while still returning a plausible-looking number.
 pub const SETTLE_SECS: u64 = 5;
 
+/// The highest sustainable rate, as offered and as actually delivered.
+///
+/// Both, because they differ: a level is confirmed while delivering as little as
+/// `min_achieved_fraction` of what was asked for, so the offered rate overstates throughput by
+/// up to 25% at the default 0.8. The offered figure is what the search brackets and bisects on;
+/// the delivered figure is the measurement.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Knee {
+    /// The rate that was asked for.
+    pub offered_bps: usize,
+    /// Blocks per second actually committed at that rate.
+    pub achieved_bps: f64,
+}
+
 /// How a rate search ended.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SearchOutcome {
     /// The knee was bracketed to within the configured resolution.
-    Converged(usize),
+    Converged(Knee),
     /// A runtime limit or cancellation ended the run first; this is the best rate confirmed
     /// so far, which is a lower bound on the knee rather than the knee itself.
-    CutShort(usize),
+    CutShort(Knee),
 }
 
 /// One control interval's worth of measurement.
@@ -120,6 +134,9 @@ pub struct RateSearch {
     target: usize,
     /// Highest rate confirmed inside the budget.
     good: Option<usize>,
+    /// Blocks per second actually delivered at `good`, which is the measurement the offered
+    /// rate only approximates.
+    good_achieved: f64,
     /// Lowest rate confirmed outside it.
     bad: Option<usize>,
     /// Consecutive intervals agreeing about the current target.
@@ -135,6 +152,7 @@ impl RateSearch {
             target: config.start_bps.max(1),
             config,
             good: None,
+            good_achieved: 0.0,
             bad: None,
             agreeing: 0,
             verdict: None,
@@ -175,6 +193,11 @@ impl RateSearch {
         self.verdict = None;
 
         if good {
+            // Record what was delivered only when this level actually raises the confirmed
+            // rate, so the pair stays consistent.
+            if self.good.is_none_or(|g| self.target > g) {
+                self.good_achieved = observation.achieved_bps;
+            }
             self.good = Some(self.good.map_or(self.target, |g| g.max(self.target)));
         } else {
             self.bad = Some(self.bad.map_or(self.target, |b| b.min(self.target)));
@@ -214,8 +237,15 @@ impl RateSearch {
     }
 
     /// The best confirmed rate so far, for a search cut short by a runtime limit.
-    pub fn best_so_far(&self) -> usize {
-        self.good.unwrap_or(0)
+    pub fn best_so_far(&self) -> Knee {
+        Knee {
+            offered_bps: self.good.unwrap_or(0),
+            achieved_bps: if self.good.is_some() {
+                self.good_achieved
+            } else {
+                0.0
+            },
+        }
     }
 }
 
@@ -324,7 +354,7 @@ mod tests {
             search.observe(observation);
         }
         assert_eq!(
-            search.best_so_far(),
+            search.best_so_far().offered_bps,
             0,
             "a target that was never actually offered was counted as sustained"
         );
@@ -359,7 +389,36 @@ mod tests {
             search.target_bps() > start,
             "the climb stalled at {start} because of one slow interval"
         );
-        assert_eq!(search.best_so_far(), start);
+        assert_eq!(search.best_so_far().offered_bps, start);
+    }
+
+    /// A level is confirmed while delivering as little as `min_achieved_fraction` of its
+    /// target, so the offered rate overstates throughput. Both must be carried, or the number
+    /// we publish is up to 25% above what the network actually committed.
+    #[test]
+    fn the_knee_reports_what_was_delivered_not_only_what_was_asked() {
+        let config = RateSearchConfig::default();
+        let mut search = RateSearch::new(config);
+        let target = search.target_bps();
+        // Inside the latency budget and inside the 80% floor, but short of the target.
+        let observation = Observation {
+            achieved_bps: target as f64 * 0.85,
+            p99: ms(10),
+        };
+        for _ in 0..config.confirmations {
+            search.observe(observation);
+        }
+        let knee = search.best_so_far();
+        assert_eq!(
+            knee.offered_bps, target,
+            "the confirmed level is the target"
+        );
+        assert!(
+            (knee.achieved_bps - target as f64 * 0.85).abs() < f64::EPSILON,
+            "reported {} delivered at an offered {target}, but only {} was committed",
+            knee.achieved_bps,
+            target as f64 * 0.85
+        );
     }
 
     /// Convergence is on the bracket, so a tighter resolution must not loop forever.

--- a/linera-client/src/benchmark/rate.rs
+++ b/linera-client/src/benchmark/rate.rs
@@ -28,12 +28,15 @@ pub const MIN_P99_SAMPLES: u64 = 200;
 /// At campaign rates the floor is met in well under a second, so this only binds on slow runs.
 pub const MAX_WINDOW_SECS: u64 = 3;
 
-/// Consecutive failed commits on one chain before the run is abandoned.
+/// How long one chain may fail every commit before the run is abandoned.
 ///
-/// An overshoot failure is a measurement — the rate is simply not sustainable — but a chain
-/// wedged by an uncertified proposal fails identically and never recovers, silently dragging
-/// every later window down. A run of failures is that, not congestion.
-pub const MAX_CONSECUTIVE_COMMIT_FAILURES: u32 = 20;
+/// A duration, not a count: an overshoot failure is a measurement — the rate is not sustainable
+/// — but at a hard overshoot commits are rejected immediately, so a chain racks up dozens of
+/// consecutive failures in a few hundred milliseconds, well before the controller's next tick
+/// can lower the target. Counting them aborts healthy runs. What actually separates an
+/// overshoot from a chain wedged by an uncertified proposal is that the wedge never recovers,
+/// so the bound has to outlast a back-off: one tick plus `confirmations` windows.
+pub const MAX_COMMIT_FAILURE_SECS: u64 = 30;
 
 /// Warm-up held before the first observation, on top of the chain-start ramp.
 ///
@@ -42,6 +45,33 @@ pub const MAX_CONSECUTIVE_COMMIT_FAILURES: u32 = 20;
 /// pins the knee below `--bps` permanently, and — since the search now halves downward rather
 /// than reporting nothing — it does so while still returning a plausible-looking number.
 pub const SETTLE_SECS: u64 = 5;
+
+/// Knobs for the code that DRIVES the search, as opposed to the search itself.
+///
+/// Separate from [`RateSearchConfig`] because these are consumed by the control task and the
+/// workers; the state machine never sees them, which is what keeps it clock-free and testable.
+#[derive(Clone, Copy, Debug)]
+pub struct RateControlConfig {
+    /// Blocks a window must hold before its p99 is believed.
+    pub min_p99_samples: u64,
+    /// How long a window may wait for `min_p99_samples` before being judged on what it has.
+    pub max_window_secs: u64,
+    /// Warm-up held before the first observation, on top of the chain-start ramp.
+    pub settle_secs: u64,
+    /// How long one chain may fail every commit before the run is abandoned.
+    pub max_commit_failure_secs: u64,
+}
+
+impl Default for RateControlConfig {
+    fn default() -> Self {
+        Self {
+            min_p99_samples: MIN_P99_SAMPLES,
+            max_window_secs: MAX_WINDOW_SECS,
+            settle_secs: SETTLE_SECS,
+            max_commit_failure_secs: MAX_COMMIT_FAILURE_SECS,
+        }
+    }
+}
 
 /// The highest sustainable rate, as offered and as actually delivered.
 ///
@@ -111,7 +141,7 @@ impl Default for RateSearchConfig {
     fn default() -> Self {
         Self {
             target_p99: Duration::from_secs(1),
-            start_bps: 10,
+            start_bps: 1,
             growth: 2.0,
             resolution: 0.1,
             confirmations: 2,
@@ -418,6 +448,31 @@ mod tests {
             "reported {} delivered at an offered {target}, but only {} was committed",
             knee.achieved_bps,
             target as f64 * 0.85
+        );
+    }
+
+    /// A window where every commit failed delivers nothing, and the search must treat that as
+    /// the rate being unservable and come down. Without it the controller holds an unservable
+    /// rate indefinitely, which is what a real run did: both chains failing to reach quorum for
+    /// 30 seconds while the search never observed a thing.
+    #[test]
+    fn a_window_that_delivered_nothing_forces_the_search_down() {
+        let config = RateSearchConfig {
+            start_bps: 512,
+            ..RateSearchConfig::default()
+        };
+        let mut search = RateSearch::new(config);
+        let start = search.target_bps();
+        let dead = Observation {
+            achieved_bps: 0.0,
+            p99: ms(3_000),
+        };
+        for _ in 0..config.confirmations {
+            search.observe(dead);
+        }
+        assert!(
+            search.target_bps() < start,
+            "the search stayed at {start} after a window that committed nothing"
         );
     }
 

--- a/linera-client/src/benchmark/rate.rs
+++ b/linera-client/src/benchmark/rate.rs
@@ -1,0 +1,305 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Finding the highest block rate a network sustains within a latency budget.
+//!
+//! The search is deliberately a pure state machine: it takes one observation per control
+//! interval and returns the next target rate, with no clock, network or task of its own. That
+//! is what lets the climb be unit-tested against synthetic networks — a saturating one, a
+//! linear one, one that is simply too slow — instead of only against a live cluster, and it is
+//! why this lives here rather than in the shell script it replaces.
+//!
+//! The shape of the search matters for what the numbers mean. It reports the **knee**: the
+//! highest rate whose tail latency stayed inside the budget. Peak throughput past that point is
+//! the number everyone quotes and nobody can use, because it is bought entirely with latency.
+
+use std::time::Duration;
+
+/// One control interval's worth of measurement.
+#[derive(Clone, Copy, Debug)]
+pub struct Observation {
+    /// Blocks committed per second over the interval.
+    pub achieved_bps: f64,
+    /// Tail latency over the interval.
+    pub p99: Duration,
+}
+
+/// What the controller wants to happen next.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Decision {
+    /// Keep running at this target.
+    Hold(usize),
+    /// The knee has been bracketed to within the configured resolution.
+    Converged {
+        /// The highest rate observed inside the latency budget.
+        best_bps: usize,
+    },
+}
+
+/// Tunables for the climb.
+#[derive(Clone, Copy, Debug)]
+pub struct RateSearchConfig {
+    /// The tail-latency budget. The knee is the last rate that stayed under it.
+    pub target_p99: Duration,
+    /// Where the climb starts.
+    pub start_bps: usize,
+    /// Multiplier applied while the network is keeping up.
+    pub growth: f64,
+    /// Stop once the bracket is this close, as a fraction of the lower bound.
+    pub resolution: f64,
+    /// A target is only believed once this many consecutive intervals agree, so a single
+    /// slow interval neither ends the search nor inflates the result.
+    pub confirmations: usize,
+    /// An interval delivering less than this fraction of the target counts as failing, even
+    /// with good latency: the rate is not actually being offered.
+    pub min_achieved_fraction: f64,
+}
+
+impl Default for RateSearchConfig {
+    fn default() -> Self {
+        Self {
+            target_p99: Duration::from_secs(1),
+            start_bps: 10,
+            growth: 2.0,
+            resolution: 0.1,
+            confirmations: 2,
+            min_achieved_fraction: 0.8,
+        }
+    }
+}
+
+/// Climbs toward the highest rate that holds `target_p99`.
+///
+/// Two phases. It first doubles (or `growth`s) until an interval misses the budget, which
+/// brackets the knee between the last good rate and the first bad one; then it bisects that
+/// bracket until the two are within `resolution`. Doubling first matters: an additive ramp puts
+/// its coarsest resolution exactly where the curve bends.
+#[derive(Debug)]
+pub struct RateSearch {
+    config: RateSearchConfig,
+    target: usize,
+    /// Highest rate confirmed inside the budget.
+    good: Option<usize>,
+    /// Lowest rate confirmed outside it.
+    bad: Option<usize>,
+    /// Consecutive intervals agreeing about the current target.
+    agreeing: usize,
+    /// What they agree on, if anything yet.
+    verdict: Option<bool>,
+}
+
+impl RateSearch {
+    /// Starts a search at `config.start_bps`.
+    pub fn new(config: RateSearchConfig) -> Self {
+        Self {
+            target: config.start_bps.max(1),
+            config,
+            good: None,
+            bad: None,
+            agreeing: 0,
+            verdict: None,
+        }
+    }
+
+    /// The rate the generators should currently be offering.
+    pub fn target_bps(&self) -> usize {
+        self.target
+    }
+
+    /// Whether `observation` is acceptable: inside the latency budget, and actually delivering
+    /// close to what was asked for. A run that quietly delivers a third of its target has found
+    /// a ceiling just as surely as one that blows the latency budget.
+    fn is_good(&self, observation: &Observation) -> bool {
+        let delivered =
+            observation.achieved_bps >= self.target as f64 * self.config.min_achieved_fraction;
+        observation.p99 <= self.config.target_p99 && delivered
+    }
+
+    /// Folds in one interval's measurement and returns the next move.
+    pub fn observe(&mut self, observation: Observation) -> Decision {
+        let good = self.is_good(&observation);
+
+        // Require agreement across intervals before acting. These runs are bimodal -- identical
+        // consecutive intervals have differed by more than an order of magnitude -- so a single
+        // reading is noise, not a verdict.
+        if self.verdict == Some(good) {
+            self.agreeing += 1;
+        } else {
+            self.verdict = Some(good);
+            self.agreeing = 1;
+        }
+        if self.agreeing < self.config.confirmations {
+            return Decision::Hold(self.target);
+        }
+        self.agreeing = 0;
+        self.verdict = None;
+
+        if good {
+            self.good = Some(self.good.map_or(self.target, |g| g.max(self.target)));
+        } else {
+            self.bad = Some(self.bad.map_or(self.target, |b| b.min(self.target)));
+        }
+
+        match (self.good, self.bad) {
+            // Still climbing: nothing has failed yet.
+            (_, None) => {
+                self.target = ((self.target as f64 * self.config.growth).round() as usize)
+                    .max(self.target + 1);
+                Decision::Hold(self.target)
+            }
+            // The very first target already failed. There is no knee to report: the network
+            // cannot sustain even the starting rate inside the budget.
+            (None, Some(_)) => Decision::Converged { best_bps: 0 },
+            (Some(good), Some(bad)) => {
+                // Adjacent integers cannot be subdivided: the midpoint would be `good` again
+                // and the search would re-test a rate it has already confirmed, forever. That
+                // is convergence regardless of what `resolution` asks for.
+                let exhausted = bad - good <= 1;
+                if exhausted || (bad - good) as f64 <= good as f64 * self.config.resolution {
+                    Decision::Converged { best_bps: good }
+                } else {
+                    self.target = good + (bad - good) / 2;
+                    Decision::Hold(self.target)
+                }
+            }
+        }
+    }
+
+    /// The best confirmed rate so far, for a search cut short by a runtime limit.
+    pub fn best_so_far(&self) -> usize {
+        self.good.unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ms(n: u64) -> Duration {
+        Duration::from_millis(n)
+    }
+
+    /// Drives a search against a synthetic network until it converges, and returns the knee.
+    /// `latency_at` is the network: it maps an offered rate to the p99 it produces.
+    fn converge(config: RateSearchConfig, latency_at: impl Fn(usize) -> Duration) -> usize {
+        let mut search = RateSearch::new(config);
+        for _ in 0..10_000 {
+            let target = search.target_bps();
+            let observation = Observation {
+                achieved_bps: target as f64,
+                p99: latency_at(target),
+            };
+            if let Decision::Converged { best_bps } = search.observe(observation) {
+                return best_bps;
+            }
+        }
+        panic!("search did not converge");
+    }
+
+    /// A network that is fine up to `knee` and falls off a cliff past it. The search should
+    /// land just under the knee, never above it.
+    #[test]
+    fn it_finds_a_hard_knee_without_overshooting() {
+        for knee in [37, 100, 512, 4096] {
+            let found = converge(RateSearchConfig::default(), |bps| {
+                if bps <= knee {
+                    ms(100)
+                } else {
+                    ms(5_000)
+                }
+            });
+            assert!(
+                found <= knee,
+                "reported {found} as sustainable but the knee is {knee}"
+            );
+            assert!(
+                found as f64 >= knee as f64 * 0.85,
+                "reported {found}, more than 15% below the real knee {knee}"
+            );
+        }
+    }
+
+    /// Latency that climbs smoothly with load: the knee is where it crosses the budget.
+    #[test]
+    fn it_finds_a_gradual_knee() {
+        // p99 = 1ms per bps, so the 1s budget is crossed at 1000 bps.
+        let found = converge(RateSearchConfig::default(), |bps| ms(bps as u64));
+        assert!(
+            (900..=1000).contains(&found),
+            "expected the knee near 1000 bps, got {found}"
+        );
+    }
+
+    /// A network that cannot even serve the starting rate has no knee to report. Reporting the
+    /// start rate anyway would invent a result.
+    #[test]
+    fn a_network_that_never_meets_the_budget_reports_no_knee() {
+        let found = converge(RateSearchConfig::default(), |_| ms(9_000));
+        assert_eq!(found, 0);
+    }
+
+    /// Latency inside budget is not enough on its own: if the generators cannot actually offer
+    /// the target, the rate is not sustainable at that target either.
+    #[test]
+    fn falling_short_of_the_target_counts_as_failure() {
+        let config = RateSearchConfig::default();
+        let mut search = RateSearch::new(config);
+        let target = search.target_bps();
+        // Great latency, but only a third of the requested rate is being delivered.
+        let observation = Observation {
+            achieved_bps: target as f64 / 3.0,
+            p99: ms(1),
+        };
+        for _ in 0..config.confirmations {
+            search.observe(observation);
+        }
+        assert_eq!(
+            search.best_so_far(),
+            0,
+            "a target that was never actually offered was counted as sustained"
+        );
+    }
+
+    /// One bad interval in a bimodal run must not end the climb: that is exactly the noise the
+    /// confirmation count exists to absorb.
+    #[test]
+    fn a_single_slow_interval_does_not_end_the_search() {
+        let mut search = RateSearch::new(RateSearchConfig::default());
+        let start = search.target_bps();
+
+        search.observe(Observation {
+            achieved_bps: start as f64,
+            p99: ms(50),
+        });
+        // A blip, immediately contradicted.
+        search.observe(Observation {
+            achieved_bps: start as f64,
+            p99: ms(9_000),
+        });
+        search.observe(Observation {
+            achieved_bps: start as f64,
+            p99: ms(50),
+        });
+        search.observe(Observation {
+            achieved_bps: start as f64,
+            p99: ms(50),
+        });
+
+        assert!(
+            search.target_bps() > start,
+            "the climb stalled at {start} because of one slow interval"
+        );
+        assert_eq!(search.best_so_far(), start);
+    }
+
+    /// Convergence is on the bracket, so a tighter resolution must not loop forever.
+    #[test]
+    fn a_tight_resolution_still_terminates() {
+        let config = RateSearchConfig {
+            resolution: 0.001,
+            ..RateSearchConfig::default()
+        };
+        let found = converge(config, |bps| if bps <= 777 { ms(10) } else { ms(3_000) });
+        assert!((770..=777).contains(&found), "got {found}");
+    }
+}

--- a/linera-client/src/benchmark/rate.rs
+++ b/linera-client/src/benchmark/rate.rs
@@ -20,6 +20,21 @@ use std::time::Duration;
 /// one slow block decides the verdict. 200 puts two samples above the 99th percentile.
 pub const MIN_P99_SAMPLES: u64 = 200;
 
+/// How long a window may wait for [`MIN_P99_SAMPLES`] before being judged on what it has.
+///
+/// A slow network never reaches the floor in useful time — 200 blocks at 2 bps is 100 seconds —
+/// so without a ceiling the search stalls instead of measuring. Past it the window is judged
+/// anyway and its `samples` count logged, making a thin tail visible rather than silently weak.
+/// At campaign rates the floor is met in well under a second, so this only binds on slow runs.
+pub const MAX_WINDOW_SECS: u64 = 3;
+
+/// Consecutive failed commits on one chain before the run is abandoned.
+///
+/// An overshoot failure is a measurement — the rate is simply not sustainable — but a chain
+/// wedged by an uncertified proposal fails identically and never recovers, silently dragging
+/// every later window down. A run of failures is that, not congestion.
+pub const MAX_CONSECUTIVE_COMMIT_FAILURES: u32 = 20;
+
 /// One control interval's worth of measurement.
 #[derive(Clone, Copy, Debug)]
 pub struct Observation {

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -163,8 +163,8 @@ pub struct BenchmarkOptions {
 
     /// Search for the highest rate the network sustains within `--target-p99-ms`, instead of
     /// holding `--bps` fixed. Reports the knee: the highest rate whose tail latency stayed
-    /// inside the budget, which is the number that means something. `--bps` becomes the
-    /// starting point for the climb.
+    /// inside the budget, which is the number that means something. The climb starts at
+    /// `--rate-start-bps`; `--bps` is ignored in this mode.
     #[arg(long)]
     pub rate_auto: bool,
 

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -172,6 +172,47 @@ pub struct BenchmarkOptions {
     #[arg(long, default_value_t = 1000)]
     pub target_p99_ms: u64,
 
+    /// Where the `--rate-auto` climb starts, in blocks per second. Defaults to 1: the climb
+    /// doubles, so starting low costs a handful of levels and avoids opening above the knee.
+    #[arg(long, default_value_t = 1)]
+    pub rate_start_bps: usize,
+
+    /// Multiplier applied to the target while the network keeps up.
+    #[arg(long, default_value_t = 2.0)]
+    pub rate_growth: f64,
+
+    /// Stop once the bracket is this close, as a fraction of its lower bound.
+    #[arg(long, default_value_t = 0.1)]
+    pub rate_resolution: f64,
+
+    /// Consecutive agreeing windows required before the search acts on a verdict.
+    #[arg(long, default_value_t = 2)]
+    pub rate_confirmations: usize,
+
+    /// A window delivering less than this fraction of its target counts as failing, even with
+    /// good latency.
+    #[arg(long, default_value_t = 0.8)]
+    pub rate_min_achieved_fraction: f64,
+
+    /// Blocks a window must hold before its p99 is believed. Below ~100 the reported tail is
+    /// really a maximum.
+    #[arg(long, default_value_t = linera_client::benchmark::rate::MIN_P99_SAMPLES)]
+    pub rate_min_p99_samples: u64,
+
+    /// How long a window may wait for `--rate-min-p99-samples` before being judged on what it
+    /// has. Bounds the search on networks too slow to ever reach the floor.
+    #[arg(long, default_value_t = linera_client::benchmark::rate::MAX_WINDOW_SECS)]
+    pub rate_max_window_secs: u64,
+
+    /// Warm-up held before the first judged window, on top of the chain-start ramp.
+    #[arg(long, default_value_t = linera_client::benchmark::rate::SETTLE_SECS)]
+    pub rate_settle_secs: u64,
+
+    /// How long one chain may fail every commit before the run is abandoned. Overshoot failures
+    /// are measurements; only a streak outlasting the controller's back-off is a wedged chain.
+    #[arg(long, default_value_t = linera_client::benchmark::rate::MAX_COMMIT_FAILURE_SECS)]
+    pub rate_max_commit_failure_secs: u64,
+
     /// Which client to drive the chains with.
     #[arg(long, value_enum, default_value_t = ClientMode::Full)]
     pub client_mode: ClientMode,
@@ -227,6 +268,15 @@ impl Default for BenchmarkOptions {
             config_path: None,
             single_destination_per_block: false,
             rate_auto: false,
+            rate_start_bps: 1,
+            rate_growth: 2.0,
+            rate_resolution: 0.1,
+            rate_confirmations: 2,
+            rate_min_achieved_fraction: 0.8,
+            rate_min_p99_samples: linera_client::benchmark::rate::MIN_P99_SAMPLES,
+            rate_max_window_secs: linera_client::benchmark::rate::MAX_WINDOW_SECS,
+            rate_settle_secs: linera_client::benchmark::rate::SETTLE_SECS,
+            rate_max_commit_failure_secs: linera_client::benchmark::rate::MAX_COMMIT_FAILURE_SECS,
             target_p99_ms: 1000,
             client_mode: ClientMode::default(),
             fan_out: None,

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -161,6 +161,17 @@ pub struct BenchmarkOptions {
     #[arg(long)]
     pub single_destination_per_block: bool,
 
+    /// Search for the highest rate the network sustains within `--target-p99-ms`, instead of
+    /// holding `--bps` fixed. Reports the knee: the highest rate whose tail latency stayed
+    /// inside the budget, which is the number that means something. `--bps` becomes the
+    /// starting point for the climb.
+    #[arg(long)]
+    pub rate_auto: bool,
+
+    /// The tail-latency budget for `--rate-auto`, in milliseconds.
+    #[arg(long, default_value_t = 1000)]
+    pub target_p99_ms: u64,
+
     /// Which client to drive the chains with.
     #[arg(long, value_enum, default_value_t = ClientMode::Full)]
     pub client_mode: ClientMode,
@@ -215,6 +226,8 @@ impl Default for BenchmarkOptions {
             delay_between_chains_ms: None,
             config_path: None,
             single_destination_per_block: false,
+            rate_auto: false,
+            target_p99_ms: 1000,
             client_mode: ClientMode::default(),
             fan_out: None,
             mixed_self_transfers: false,

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -809,6 +809,15 @@ impl Runnable for Job {
                         let BenchmarkOptions {
                             rate_auto,
                             target_p99_ms,
+                            rate_start_bps,
+                            rate_growth,
+                            rate_resolution,
+                            rate_confirmations,
+                            rate_min_achieved_fraction,
+                            rate_min_p99_samples,
+                            rate_max_window_secs,
+                            rate_settle_secs,
+                            rate_max_commit_failure_secs,
                             client_mode,
                             fan_out,
                             mixed_self_transfers,
@@ -1042,11 +1051,20 @@ impl Runnable for Job {
                                 linera_client::benchmark::rate::RateSearch::new(
                                     linera_client::benchmark::rate::RateSearchConfig {
                                         target_p99: std::time::Duration::from_millis(target_p99_ms),
-                                        start_bps: bps,
-                                        ..Default::default()
+                                        start_bps: rate_start_bps,
+                                        growth: rate_growth,
+                                        resolution: rate_resolution,
+                                        confirmations: rate_confirmations,
+                                        min_achieved_fraction: rate_min_achieved_fraction,
                                     },
                                 )
                             }),
+                            linera_client::benchmark::rate::RateControlConfig {
+                                min_p99_samples: rate_min_p99_samples,
+                                max_window_secs: rate_max_window_secs,
+                                settle_secs: rate_settle_secs,
+                                max_commit_failure_secs: rate_max_commit_failure_secs,
+                            },
                             &shutdown_notifier,
                         )
                         .await?;

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -807,6 +807,8 @@ impl Runnable for Job {
                         options: benchmark_options,
                     } => {
                         let BenchmarkOptions {
+                            rate_auto,
+                            target_p99_ms,
                             client_mode,
                             fan_out,
                             mixed_self_transfers,
@@ -1036,6 +1038,15 @@ impl Runnable for Job {
                             runtime_in_seconds,
                             delay_between_chains_ms,
                             chain_listener,
+                            rate_auto.then(|| {
+                                linera_client::benchmark::rate::RateSearch::new(
+                                    linera_client::benchmark::rate::RateSearchConfig {
+                                        target_p99: std::time::Duration::from_millis(target_p99_ms),
+                                        start_bps: bps,
+                                        ..Default::default()
+                                    },
+                                )
+                            }),
                             &shutdown_notifier,
                         )
                         .await?;

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -904,6 +904,25 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera benchmark` to completion and returns its stderr, for tests that must assert
+    /// on what the run reported rather than only on a zero exit status.
+    pub async fn benchmark_capturing_stderr(&self, args: BenchmarkCommand) -> Result<String> {
+        let output = self
+            .benchmark_command_with_envs(args, &[("RUST_LOG", "linera=info")])
+            .await?
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await?;
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        anyhow::ensure!(
+            output.status.success(),
+            "benchmark exited with {}; stderr:\n{stderr}",
+            output.status
+        );
+        Ok(stderr)
+    }
+
     /// Runs `linera benchmark`, but detached: don't wait for the command to finish, just spawn it
     /// and return the child process, and the handles to the stdout and stderr.
     pub async fn benchmark_detached(

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -915,9 +915,15 @@ impl ClientWrapper {
             .output()
             .await?;
         let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        // Echoed, not just captured: piping the child's stderr into this String is what lets
+        // the caller assert on it, but it also means a PASSING run shows none of the evidence
+        // behind the pass -- no search trace, no window sample counts -- in the CI log.
+        for line in stderr.lines() {
+            println!("benchmark| {line}");
+        }
         anyhow::ensure!(
             output.status.success(),
-            "benchmark exited with {}; stderr:\n{stderr}",
+            "benchmark exited with {}",
             output.status
         );
         Ok(stderr)

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -1121,6 +1121,7 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
                 transactions_per_block: 10,
                 bps: 2,
                 rate_auto: true,
+                rate_start_bps: 1,
                 target_p99_ms: 2_000,
                 runtime_in_seconds: Some(120),
                 client_mode: ClientMode::Lite,
@@ -1137,9 +1138,9 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
         .and_then(|value| value.parse::<usize>().ok())
         .context("the rate search never reported a converged knee")?;
     assert!(
-        knee > 2,
-        "the search converged at {knee} bps, no better than its start rate: it found a ceiling \
-         rather than measuring one"
+        knee > 1,
+        "the search converged at {knee} bps, no better than its start rate of 1: it found a \
+         ceiling rather than measuring one"
     );
     // Printed so a CI log carries the measured knee, not just a pass.
     println!("rate search converged at {knee} bps");

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -1111,6 +1111,26 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
         })
         .await?;
 
+    // --rate-auto: the search must actually converge against a real network and report a knee,
+    // not just compile. A local net is fast enough that the climb terminates quickly, and the
+    // point of the assertion is that the controller reaches a decision at all rather than
+    // climbing forever or stalling at its start rate.
+    client
+        .benchmark(BenchmarkCommand::Single {
+            options: BenchmarkOptions {
+                num_chains: 2,
+                transactions_per_block: 10,
+                bps: 2,
+                rate_auto: true,
+                target_p99_ms: 2_000,
+                runtime_in_seconds: Some(30),
+                client_mode: ClientMode::Lite,
+                close_chains: true,
+                ..Default::default()
+            },
+        })
+        .await?;
+
     net.ensure_is_running().await?;
     net.terminate().await?;
 

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -1130,13 +1130,28 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
             },
         })
         .await?;
+    // Either outcome is a real measurement. Whether the local net wedges before the search
+    // finishes bracketing is timing-dependent -- overshooting can leave a chain unable to
+    // commit again -- so requiring convergence specifically would make this case flaky for a
+    // reason that has nothing to do with the search.
     let knee = stderr
         .lines()
-        .find(|line| line.contains("rate search converged"))
-        .and_then(|line| line.split("knee_bps=").nth(1))
-        .and_then(|rest| rest.split_whitespace().next())
-        .and_then(|value| value.parse::<usize>().ok())
-        .context("the rate search never reported a converged knee")?;
+        .find_map(|line| {
+            let field = if line.contains("rate search converged") {
+                "knee_bps="
+            } else if line.contains("rate search cut short") {
+                "best_bps="
+            } else {
+                return None;
+            };
+            line.split(field)
+                .nth(1)?
+                .split_whitespace()
+                .next()?
+                .parse::<usize>()
+                .ok()
+        })
+        .context("the rate search reported neither a converged knee nor a lower bound")?;
     assert!(
         knee > 1,
         "the search converged at {knee} bps, no better than its start rate of 1: it found a \

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -1111,25 +1111,38 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
         })
         .await?;
 
-    // --rate-auto: the search must actually converge against a real network and report a knee,
-    // not just compile. A local net is fast enough that the climb terminates quickly, and the
-    // point of the assertion is that the controller reaches a decision at all rather than
-    // climbing forever or stalling at its start rate.
-    client
-        .benchmark(BenchmarkCommand::Single {
+    // --rate-auto: assert the search reached a knee above its own start rate. A clean exit
+    // proves nothing here — a run that never converged, and one that converged at zero, both
+    // exit zero too, which is exactly what this case existed to rule out and did not.
+    let stderr = client
+        .benchmark_capturing_stderr(BenchmarkCommand::Single {
             options: BenchmarkOptions {
                 num_chains: 2,
                 transactions_per_block: 10,
                 bps: 2,
                 rate_auto: true,
                 target_p99_ms: 2_000,
-                runtime_in_seconds: Some(30),
+                runtime_in_seconds: Some(120),
                 client_mode: ClientMode::Lite,
                 close_chains: true,
                 ..Default::default()
             },
         })
         .await?;
+    let knee = stderr
+        .lines()
+        .find(|line| line.contains("rate search converged"))
+        .and_then(|line| line.split("knee_bps=").nth(1))
+        .and_then(|rest| rest.split_whitespace().next())
+        .and_then(|value| value.parse::<usize>().ok())
+        .context("the rate search never reported a converged knee")?;
+    assert!(
+        knee > 2,
+        "the search converged at {knee} bps, no better than its start rate: it found a ceiling \
+         rather than measuring one"
+    );
+    // Printed so a CI log carries the measured knee, not just a pass.
+    println!("rate search converged at {knee} bps");
 
     net.ensure_is_running().await?;
     net.terminate().await?;


### PR DESCRIPTION
## Motivation

The rate search that produces our benchmark numbers is a bash script embedded in a terraform
template (`linera-infra:terraform/templates/client-env-gcp/startup.sh.tftpl`). It carries real
logic — geometric ramp, warm-up convergence, degradation thresholds, plateau detection,
re-measurement before accepting a ceiling — and none of it can be run by anyone outside our VMs,
unit-tested, or reviewed as code.

That is a problem beyond tidiness. The benchmark report we are preparing has to ship a harness
third parties can run; a shell script inside a terraform template cannot be that harness. And a
search whose only test is "we ran it and the number looked plausible" is exactly the kind of
result a hostile reader should discount.

It also reports the wrong thing by default. `--bps` holds a fixed rate, so the operator picks the
answer in advance. What a benchmark should find is the **knee**: maximum throughput subject to a
latency ceiling.

## Proposal

`--rate-auto` searches for the knee in-process, with `--target-p99-ms` (default 1000) as the
budget, starting from `--rate-start-bps` (default 1).

The search is a **pure state machine** in `linera-client/src/benchmark/rate.rs`: one observation
per window in, the next target out, with no clock, network or task of its own. That is what lets
the climb be tested against synthetic networks rather than only against a live cluster.

It brackets the knee geometrically — multiplying while the network keeps up, halving while it
does not — then bisects. Both directions matter: an additive ramp puts its coarsest resolution
exactly where the curve bends, and a search that gave up when its opening guess was too high
would report no knee precisely when the operator most needs one.

**Both figures are reported.** A level is confirmed while delivering as little as
`--rate-min-achieved-fraction` (0.8) of its target, so the offered rate overstates committed
throughput by up to 25%. The search brackets on the offered rate — the bracket and bisection
midpoint are in target units — but the log carries `knee_bps` beside `knee_achieved_bps` /
`knee_achieved_tps`, and the delivered figure is the measurement.

**Overshoot is data, not failure.** The search has to exceed the knee to bracket it, so a commit
that fails at an overshoot rate is counted as unsustained rather than aborting the run. Two
consequences fall out of that, both found by running it:

- A window in which *every* commit failed produces no latencies at all. Skipping such a window
  leaves the search blind to the one condition it must react to — it holds the unservable rate
  indefinitely. An aged-out empty window is now observed as zero throughput, which fails the
  delivery check and drives the search down.
- The bound separating an overshoot from a genuinely wedged chain is a **duration**, not a
  count. At a hard overshoot commits are rejected immediately, so a chain accumulates dozens of
  consecutive failures in a few hundred milliseconds — long before the controller's next tick
  can lower the target. A count aborts healthy runs; only a streak outlasting the back-off is a
  wedge.

Everything is a flag. Nine knobs that were hardcoded constants are now CLI options — the search's
shape (`--rate-growth`, `--rate-resolution`, `--rate-confirmations`,
`--rate-min-achieved-fraction`) and the driver's guards (`--rate-min-p99-samples`,
`--rate-max-window-secs`, `--rate-settle-secs`, `--rate-max-commit-failure-secs`), split across
`RateSearchConfig` and `RateControlConfig` so the state machine stays clock-free and testable.

Two of those guards exist because of specific failures. A window must hold
`--rate-min-p99-samples` (200) blocks before its p99 is believed — `value_at_quantile(0.99)`
returns the largest sample whenever n < 100, so a one-second window at 20 bps reports its
slowest block and calls it a tail — bounded by `--rate-max-window-secs` so a slow network cannot
stall the search, with each window's `samples` count logged so a thin tail is visible rather than
silently weak. And `--rate-settle-secs` holds a warm-up before the first judged window, because
`bad` is a one-way ratchet: one cold-cache window would cap every later target and pin the
reported knee below the start rate permanently.

Supporting changes: per-chain shares become atomics so the controller can retarget the fleet
mid-run, seeded from the search's own starting target rather than `--bps`; a `LatencyRecorder`
(hdrhistogram) drains per window rather than accumulating, since a cumulative histogram could
never recover its tail after an overshoot; and `runtime_control_task` races its sleep against the
cancellation token, since convergence makes early exit the normal ending and a bare sleep held
the run open — chains and all — for the remainder of `--runtime-in-seconds`.

A run cut short before convergence reports `CutShort`, logged as a LOWER BOUND. A search that
brackets all the way down without any rate holding the budget reports no sustainable rate rather
than a knee of zero.

## Test Plan

**Unit — the search against synthetic networks.** Nine tests, all passing:

- a hard knee at 37/100/512/4096 bps: never overshoots, lands within 15%
- a knee *below* the opening guess (1/7/140/999 from a start of 4096), found by halving down
- a gradual knee (p99 rising 1ms per bps): found within 900–1000 where the 1s budget crosses
- a network too slow to serve any rate: reports no knee rather than inventing one
- latency inside budget but a third of the rate delivered: counted as failure
- delivered vs offered: a level confirmed at 85% delivery reports both figures
- a window that committed nothing forces the search down
- one slow window in an otherwise healthy run: the climb continues
- a tight resolution still terminates

Four came from real bugs. Adjacent integers made the bisection midpoint the known-good rate, so
the search re-tested a confirmed rate forever. The original "never meets the budget" test failed
at *every* rate, so it could not distinguish "no knee exists" from "the knee is below where you
started". `converge()` fed `achieved == target`, so no test could see the offered/delivered gap.
And nothing covered a window that delivered nothing, which is how the total-failure stall
survived five review rounds.

**End to end.** `test_end_to_end_benchmark` gains a `--rate-auto` case across four `test_case`
variants. It parses `knee_bps=` from the child's stderr and requires a knee above the start rate
— a clean exit alone also passes for a run that never converged and for one that converged at
zero. The child's stderr is echoed into the test output, so a passing run shows the search trace
rather than swallowing it. Verified locally on the storage-service variants: converged at 32 bps
on both grpc and tcp.

`cargo clippy` clean; `cargo fmt --check` clean; `CLI.md` regenerated.

## Known gaps

`benchmark-test` is `if:`-gated to `merge_group`/`push`, so it does not run on this PR. With the
merge queue disabled it runs only on push to `main` — after merge. It has been run locally
against this branch instead, which is where the figures above come from.

Not attempted here, worth follow-ups: searching `--transactions-per-block` alongside the block
rate (TPS is the product, and the two axes trade off differently against latency), and a mode
that holds the knee for a fixed period to report sustained throughput rather than the search's
own final window.

## Release Plan

- Nothing to do / These changes follow the usual deployment cycle.

`--rate-auto` is opt-in; without it `--bps` behaves exactly as before.

## Links

Replaces the search half of the sweep script in linera-infra. The collection half is
linera-io/linera-infra#1930 (merged).
