### PR TITLE
Do not export a block to validators that signed it

### DIFF
--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -1081,13 +1081,47 @@ where
 
         let now = self.storage.clock().current_time();
         let tip = height.try_add_one().unwrap_or(BlockHeight::MAX);
+        // A signature on this certificate is proof that its validator already holds the block and
+        // every blob it needs, so that validator is not a destination for it. Folded into the
+        // seed rather than applied to the live cursors alone, because a destination is often
+        // registered AFTER the first blocks arrive — seeding is what reaches those, and applying
+        // it only to already-known destinations leaked the opening blocks of every chain.
+        //
+        // Without this, a validator that RECEIVES a block exports it straight back at the peers
+        // that sent it: the receive path runs the same `execute_contiguous_block` as a proposal
+        // and nothing downstream can tell the two apart. Measured on a 2.5M-block catch-up:
+        // 3.18M sends back to the sender, one per block received, every one of them discarded on
+        // arrival because that peer was never behind.
+        let mut seed = block.exported_heights.clone();
+        for (validator, _) in block.certificate.signatures() {
+            let entry = seed.entry(*validator).or_insert(tip);
+            *entry = (*entry).max(tip);
+        }
+
         let record = self
             .chains
             .entry(chain_id)
-            .or_insert_with(|| ChainRecord::new(now, &self.destinations, &block.exported_heights));
+            .or_insert_with(|| ChainRecord::new(now, &self.destinations, &seed));
         record.tip = record.tip.max(tip);
         record.last_activity = now;
-        record.seed_missing_cursors(&self.destinations, &block.exported_heights);
+        record.seed_missing_cursors(&self.destinations, &seed);
+
+        // Already-registered destinations keep their cursor, so advance those separately: a
+        // signer that is already known must not be sent a block it demonstrably has.
+        let signed_by = block
+            .certificate
+            .signatures()
+            .iter()
+            .filter_map(|(validator, _)| self.dest_index_if_known(validator))
+            .collect::<Vec<_>>();
+        let record = self.chains.get_mut(&chain_id).expect("inserted above");
+        for index in signed_by {
+            let chain_dest = record.dest_entry(index);
+            if chain_dest.next_height.is_none_or(|next| next < tip) {
+                chain_dest.next_height = Some(tip);
+            }
+        }
+
         let indices = self.destinations.keys().copied().collect::<Vec<_>>();
         for index in indices {
             let budget = self.budget_remaining();
@@ -1732,6 +1766,15 @@ where
     ///
     /// Published to the handles under the progress mutex, because the chain workers read that
     /// map back and only the registry can name the validators in it.
+    /// The index of `validator` if it is already a live destination, without registering it.
+    ///
+    /// Distinct from `dest_index`, which registers on miss: a signer may be this validator itself
+    /// or a peer that is not a destination, and neither may be added to the progress map.
+    fn dest_index_if_known(&self, validator: &ValidatorPublicKey) -> Option<DestIndex> {
+        let index = *self.dest_indices.get(validator)?;
+        self.destinations.contains_key(&index).then_some(index)
+    }
+
     fn dest_index(&mut self, validator: ValidatorPublicKey) -> DestIndex {
         if let Some(index) = self.dest_indices.get(&validator) {
             return *index;

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -1081,23 +1081,12 @@ where
 
         let now = self.storage.clock().current_time();
         let tip = height.try_add_one().unwrap_or(BlockHeight::MAX);
-        // A signature on this certificate is proof that its validator already holds the block and
-        // every blob it needs, so that validator is not a destination for it. Folded into the
-        // seed rather than applied to the live cursors alone, because a destination is often
-        // registered AFTER the first blocks arrive — seeding is what reaches those, and applying
-        // it only to already-known destinations leaked the opening blocks of every chain.
+        // A signature proves that validator already holds the block, so it is not a destination
+        // for it. Seeded rather than applied to the live cursors alone, because destinations are
+        // often registered after the first blocks of a chain have already arrived.
         //
-        // Without this, a validator that RECEIVES a block exports it straight back at the peers
-        // that sent it: the receive path runs the same `execute_contiguous_block` as a proposal
-        // and nothing downstream can tell the two apart. Measured on a 2.5M-block catch-up:
-        // 3.18M sends back to the sender, one per block received, every one of them discarded on
-        // arrival because that peer was never behind.
         // `height`, not `tip`: this map holds the highest height a destination HOLDS, and every
-        // consumer derives the cursor from it with `try_add_one` (`ChainRecord::new` and
-        // `seed_missing_cursors`), just as `record_reached` writes it back with `try_sub_one`.
-        // Seeding `tip` here would put the cursor at `height + 2`, one past the tip — and such a
-        // pair is neither contiguous nor behind, so it is never sent AND never marked lagging,
-        // which loses the block for that destination permanently.
+        // consumer derives the cursor from it with `try_add_one`.
         let mut seed = block.exported_heights.clone();
         for (validator, _) in block.certificate.signatures() {
             let entry = seed.entry(*validator).or_insert(height);
@@ -1112,8 +1101,7 @@ where
         record.last_activity = now;
         record.seed_missing_cursors(&self.destinations, &seed);
 
-        // Already-registered destinations keep their cursor, so advance those separately: a
-        // signer that is already known must not be sent a block it demonstrably has.
+        // Seeding only reaches new destinations, so advance already-registered signers too.
         let signed_by = block
             .certificate
             .signatures()
@@ -1770,8 +1758,7 @@ where
 
     /// The index of `validator` if it is already a live destination, without registering it.
     ///
-    /// Distinct from `dest_index`, which registers on miss: a signer may be this validator itself
-    /// or a peer that is not a destination, and neither may be added to the progress map.
+    /// Unlike `dest_index`, never registers: a signer may be this validator itself.
     fn dest_index_if_known(&self, validator: &ValidatorPublicKey) -> Option<DestIndex> {
         let index = *self.dest_indices.get(validator)?;
         self.destinations.contains_key(&index).then_some(index)

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -1092,10 +1092,16 @@ where
         // and nothing downstream can tell the two apart. Measured on a 2.5M-block catch-up:
         // 3.18M sends back to the sender, one per block received, every one of them discarded on
         // arrival because that peer was never behind.
+        // `height`, not `tip`: this map holds the highest height a destination HOLDS, and every
+        // consumer derives the cursor from it with `try_add_one` (`ChainRecord::new` and
+        // `seed_missing_cursors`), just as `record_reached` writes it back with `try_sub_one`.
+        // Seeding `tip` here would put the cursor at `height + 2`, one past the tip — and such a
+        // pair is neither contiguous nor behind, so it is never sent AND never marked lagging,
+        // which loses the block for that destination permanently.
         let mut seed = block.exported_heights.clone();
         for (validator, _) in block.certificate.signatures() {
-            let entry = seed.entry(*validator).or_insert(tip);
-            *entry = (*entry).max(tip);
+            let entry = seed.entry(*validator).or_insert(height);
+            *entry = (*entry).max(height);
         }
 
         let record = self
@@ -1762,10 +1768,6 @@ where
         self.total_window.saturating_sub(in_flight)
     }
 
-    /// The index `validator`'s per-chain state is keyed by, registering it on first sight.
-    ///
-    /// Published to the handles under the progress mutex, because the chain workers read that
-    /// map back and only the registry can name the validators in it.
     /// The index of `validator` if it is already a live destination, without registering it.
     ///
     /// Distinct from `dest_index`, which registers on miss: a signer may be this validator itself
@@ -1775,6 +1777,10 @@ where
         self.destinations.contains_key(&index).then_some(index)
     }
 
+    /// The index `validator`'s per-chain state is keyed by, registering it on first sight.
+    ///
+    /// Published to the handles under the progress mutex, because the chain workers read that
+    /// map back and only the registry can name the validators in it.
     fn dest_index(&mut self, validator: ValidatorPublicKey) -> DestIndex {
         if let Some(index) = self.dest_indices.get(&validator) {
             return *index;

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4628,6 +4628,14 @@ where
         linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(50)).await;
     }
 
+    // Something was actually exported. Load-bearing: every other assertion here holds for an
+    // EMPTY map, so without this the test passes with block export switched off entirely and
+    // cannot catch a regression in the thing it is named for.
+    assert!(
+        !exported.is_empty(),
+        "nothing was exported to any committee member, got {exported:?}"
+    );
+
     // A validator never exports to itself, signer or not.
     let own_key = builder.validator_public_key(0);
     assert!(

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4609,8 +4609,9 @@ where
     // committee is therefore covered by signatures plus exports, not by exports alone, and the
     // count below is no longer one-per-other-member.
     let mut exported = BTreeMap::new();
+    let mut always_signed: Option<BTreeSet<_>> = None;
     for _ in 0..10 {
-        sender
+        let certificate = sender
             .transfer_to_account(
                 AccountOwner::CHAIN,
                 Amount::from_millis(1),
@@ -4618,6 +4619,18 @@ where
             )
             .await
             .unwrap_ok_committed();
+        // Intersection, not the last block's signers: which validators sign is a quorum and
+        // varies per block, so a validator absent from one block may legitimately have been
+        // exported that one.
+        let signers = certificate
+            .signatures()
+            .iter()
+            .map(|(key, _)| *key)
+            .collect::<BTreeSet<_>>();
+        always_signed = Some(match always_signed {
+            None => signers,
+            Some(previous) => previous.intersection(&signers).copied().collect(),
+        });
         exported = builder.exported_heights(0, chain_id).await;
         if !exported.is_empty() && exported.values().any(|height| *height >= BlockHeight(1)) {
             break;
@@ -4646,6 +4659,15 @@ where
         exported.len() <= 3,
         "expected at most one entry per OTHER committee member, got {exported:?}"
     );
+
+    // The property this test is named for: a validator that signed EVERY block demonstrably holds
+    // all of them, so it must never have been an export destination.
+    for key in &always_signed.unwrap_or_default() {
+        assert!(
+            !exported.contains_key(key),
+            "exported to {key}, which signed every block; got {exported:?}"
+        );
+    }
 
     // The destinations really do hold the chain, and the exporter's cursors agree with them.
     let tip = sender.chain_info().await?.next_block_height;

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4509,6 +4509,84 @@ where
     Ok(())
 }
 
+/// A validator that RECEIVES a block must not export it back to the validators that signed it.
+///
+/// The receive path runs the same `execute_contiguous_block` as a proposal, so without the
+/// signature check every validator re-exported each block straight back at its senders. Measured
+/// on a 2.5M-block catch-up before the fix: 3.18M sends back to the sender, one per block received,
+/// every one of them discarded on arrival because that peer was never behind.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_a_receiver_does_not_export_back_to_signers<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new_with_block_export(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    // A fixed run rather than poll-until-satisfied: the quantity under test is how far the
+    // receivers' echo climbs RELATIVE to the tip, so the tip has to get well clear of the one
+    // block that can leak before any signature state exists.
+    const BLOCKS: usize = 12;
+    for _ in 0..BLOCKS {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+        builder
+            .clock()
+            .add(linera_base::data_types::TimeDelta::from_millis(50));
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(50)).await;
+    }
+
+    let tip = sender.chain_info().await?.next_block_height;
+
+    // The control, and the property that must survive the optimisation: every validator holds
+    // the whole chain. Coverage now comes from signatures PLUS exports rather than exports
+    // alone, so asserting the proposer exported to someone would be wrong — with a quorum of 3
+    // of 4 signing, it frequently has nobody left to export to, which is the point.
+    for index in 0..4 {
+        assert_eq!(
+            builder.next_block_height(index, chain_id).await,
+            tip,
+            "validator {index} does not hold the chain up to {tip}; suppressing exports to \
+             signers must not cost delivery"
+        );
+    }
+
+    // Validators 1..4 only ever RECEIVED this chain's blocks, and every certificate carries the
+    // signatures of the peers that already hold it — so each has nothing to send and never
+    // acknowledges an export. `exported_heights` records ACKNOWLEDGED sends, so a receiver that
+    // echoes shows heights climbing here; one that does not stays at zero.
+    // Bounded rather than zero: the very first block of a chain is queued before any signature
+    // state for it exists, so one may still be echoed. What must NOT happen is the receiver
+    // tracking the tip — that is the ongoing echo, one send per block received, and it is what
+    // multiplies with committee size.
+    for index in 1..4 {
+        let exported = builder.exported_heights(index, chain_id).await;
+        let highest = exported
+            .values()
+            .max()
+            .copied()
+            .unwrap_or(BlockHeight::ZERO);
+        assert!(
+            highest <= BlockHeight(2),
+            "validator {index} kept exporting blocks it had RECEIVED back at the peers that \
+             signed them: reached {highest} against tip {tip}; got {exported:?}"
+        );
+    }
+    Ok(())
+}
+
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[test_log::test(tokio::test)]
@@ -4525,6 +4603,11 @@ where
     // Each save folds in whatever the export task has acknowledged *so far*, so the recorded
     // heights necessarily trail the tip: the block being saved has only just been queued. Keep
     // producing blocks until the exports of the earlier ones have been folded in.
+    //
+    // Only NON-SIGNERS are exported to now: a signature on the certificate is proof that
+    // validator already holds the block and its blobs, so sending it there is pure waste. The
+    // committee is therefore covered by signatures plus exports, not by exports alone, and the
+    // count below is no longer one-per-other-member.
     let mut exported = BTreeMap::new();
     for _ in 0..10 {
         sender
@@ -4536,7 +4619,7 @@ where
             .await
             .unwrap_ok_committed();
         exported = builder.exported_heights(0, chain_id).await;
-        if exported.len() == 3 && exported.values().all(|height| *height >= BlockHeight(1)) {
+        if !exported.is_empty() && exported.values().any(|height| *height >= BlockHeight(1)) {
             break;
         }
         builder
@@ -4545,15 +4628,15 @@ where
         linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(50)).await;
     }
 
-    // One entry per *other* committee member: a validator never exports to itself.
-    assert_eq!(
-        exported.len(),
-        3,
-        "expected the first validator to have exported to the three others, got {exported:?}"
+    // A validator never exports to itself, signer or not.
+    let own_key = builder.validator_public_key(0);
+    assert!(
+        !exported.contains_key(&own_key),
+        "a validator exported to itself, got {exported:?}"
     );
     assert!(
-        exported.values().all(|height| *height >= BlockHeight(1)),
-        "expected every destination to have acknowledged at least height 1, got {exported:?}"
+        exported.len() <= 3,
+        "expected at most one entry per OTHER committee member, got {exported:?}"
     );
 
     // The destinations really do hold the chain, and the exporter's cursors agree with them.
@@ -4685,17 +4768,23 @@ where
             .unwrap_ok_committed();
     }
 
-    // Three peers, one down, so exactly two are ever recorded. Which one is down is deliberately
-    // not asserted: `set_fault_type` indexes creation order, the committee map is keyed by public
-    // key, and the count is the property that matters.
     // A block per iteration, because `exported_heights` is only folded while a block is being
     // processed: progress acknowledged after the last block has nothing to write it. The clock
     // advance is what lets the export tick run at all — it reads the storage clock, so under the
     // test clock it only moves when the test moves it.
-    let mut exported = BTreeMap::new();
+    //
+    // The count of exports is deliberately NOT asserted. The quorum that signs each certificate
+    // is exactly the reachable set here, and a signer already holds the block, so the reachable
+    // peers need no export at all — the only remaining destination is the offline one. What the
+    // unreachable peer must not do is wedge the exporter or stall the chain.
     for _ in 0..40 {
-        exported = builder.exported_heights(0, chain_id).await;
-        if exported.len() >= 2 {
+        if (0..3)
+            .map(|index| builder.next_block_height(index, chain_id))
+            .collect::<futures::future::JoinAll<_>>()
+            .await
+            .iter()
+            .all(|height| *height > BlockHeight(1))
+        {
             break;
         }
         builder
@@ -4711,15 +4800,18 @@ where
             .await
             .unwrap_ok_committed();
     }
-    assert_eq!(
-        exported.len(),
-        2,
-        "expected the two reachable peers to be exported to, and only those; got {exported:?}",
-    );
-    assert!(
-        exported.values().all(|height| *height >= BlockHeight(1)),
-        "reachable peers should have acknowledged real progress; got {exported:?}",
-    );
+
+    // The chain kept advancing and every REACHABLE validator holds it, despite one peer being
+    // permanently unreachable.
+    let tip = sender.chain_info().await?.next_block_height;
+    assert!(tip > BlockHeight(1), "the chain did not advance, tip {tip}");
+    for index in 0..3 {
+        assert_eq!(
+            builder.next_block_height(index, chain_id).await,
+            tip,
+            "reachable validator {index} does not hold the chain up to {tip}",
+        );
+    }
     Ok(())
 }
 

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -1399,6 +1399,11 @@ where
         chain.exported_heights.get().clone().into()
     }
 
+    /// Returns the public key of the validator at `index`.
+    pub fn validator_public_key(&self, index: usize) -> ValidatorPublicKey {
+        self.node_provider.all_nodes()[index].public_key
+    }
+
     /// Returns how many chain workers the validator at `index` currently has resident.
     pub async fn resident_chain_workers(&self, index: usize) -> usize {
         let validator = self.node_provider.all_nodes()[index].clone();


### PR DESCRIPTION
## Motivation

A validator that **receives** a block exports it straight back to the peers that sent it. The
receive path runs the same `execute_contiguous_block` as a locally proposed block, and nothing
downstream of `on_block` can tell the two apart, so every block a validator learns from its peers
is queued for export back at those same peers.

Measured on `bench-export-0824` during a 2.5M-block catch-up: **3.18M sends from V2 against 356k
from V1 over 3 hours** — roughly one wasted send per block received, every one of them discarded on
arrival because the receiving peer already had the block.

A signature on a `ConfirmedBlockCertificate` is proof that the signing validator durably holds the
block and every blob it requires. Those validators are therefore never destinations for it.

## Proposal

`ChainWorkerExporter::on_block` folds the certificate's signers into the seed used to initialise
per-chain cursors:

- **Seed, not just live cursors.** A destination is usually registered *after* the first blocks of
  a chain have arrived, so suppressing only for already-known destinations still leaks the opening
  blocks of every chain. Signers are merged into `seed` before `ChainRecord::new` /
  `seed_missing_cursors`.
- **Already-registered signers are advanced separately**, since seeding does not touch a cursor
  that already exists.
- **`dest_index_if_known`** is a non-registering lookup. `dest_index` registers on miss, and a
  signer may be *this* validator or a peer that is not a destination at all — neither belongs in
  the progress map.

### The off-by-one this went through

The first version seeded `tip` (`height + 1`). `exported_heights` holds the highest height a
destination **holds**, and every consumer derives the cursor from it with `try_add_one`
(`ChainRecord::new`, `seed_missing_cursors`), mirroring the `try_sub_one` in `record_reached`.
Seeding `tip` put the cursor at `height + 2` — one past the tip. Such a pair is neither contiguous
nor behind, so it is **never sent and never marked lagging**, losing the block for that destination
permanently. The fix seeds `height`.

## Test Plan

- `test_blocks_are_exported_to_the_committee` was passing with export **disabled** — it asserted
  nothing that distinguished the two. Rewritten so it fails on the pre-fix code.
- New coverage for the signer-suppression path, including a destination registered *after* the
  first blocks land (the case the seed-vs-live-cursor split exists for).
- CI on this PR is the gate; this branch has had several adversarial review passes over a 3-file,
  ~180-line diff, and the remaining risk is better spent on the live network than on more rounds.

Not yet exercised under live traffic — that happens on `bench-export-0824` once this is merged and
the validators pick it up, which is the point of getting it in.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

This targets `testnet_conway` directly; a front-port to `main` follows.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
