### PR TITLE
Make a wedged inbox task say why it is stuck

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::{btree_map::Entry, BTreeMap, BTreeSet},
+    pin::pin,
     sync::Arc,
     time::Duration,
 };
@@ -10,8 +11,9 @@ use std::{
 use futures::{future, lock::Mutex, Future, FutureExt as _, StreamExt};
 use linera_base::{
     crypto::{CryptoHash, Signer},
-    data_types::{ChainDescription, MessagePolicy, TimeDelta, Timestamp},
+    data_types::{BlockHeight, ChainDescription, MessagePolicy, TimeDelta, Timestamp},
     identifiers::{AccountOwner, BlobType, ChainId},
+    time::Instant,
     util::future::FutureSyncExt as _,
     Task,
 };
@@ -798,6 +800,33 @@ impl<C: ClientContext + 'static> ChainListener<C> {
     }
 }
 
+/// How often a parked inbox task reports that it has still received no notification.
+/// Being parked is a legitimate steady state, so the report is `info!` rather than `warn!`.
+const PARKED_REPORT_INTERVAL: Duration = Duration::from_secs(300);
+
+/// How often an inbox task reports that an inbox-processing await has not returned.
+const INBOX_STALL_REPORT_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Awaits `inner`, calling `report` with the elapsed time every `interval` while it stays pending.
+///
+/// Purely diagnostic. `inner` is pinned once and polled to completion by the same `select!`
+/// arm every iteration, so a timer tick only logs: it never drops or restarts `inner`, and
+/// therefore cannot lose a `Notify` permit or abandon an in-flight inbox call.
+async fn report_while_pending<F: Future>(
+    inner: F,
+    interval: Duration,
+    mut report: impl FnMut(Duration),
+) -> F::Output {
+    let pending_since = Instant::now();
+    let mut inner = pin!(inner.fuse());
+    loop {
+        futures::select! {
+            output = inner => return output,
+            () = linera_base::time::timer::sleep(interval).fuse() => report(pending_since.elapsed()),
+        }
+    }
+}
+
 /// Per-chain inbox processing loop. Runs as a long-lived tokio task. Wakes on
 /// `inbox_notify` signals and processes the inbox, handling round-leader timeouts
 /// internally. Multiple notifications while busy collapse into a single permit.
@@ -809,10 +838,30 @@ async fn inbox_processing_loop<C: ClientContext>(
     cancellation_token: CancellationToken,
 ) {
     let chain_id = client.chain_id();
+    // Tracked in-process because the diagnostics below must stay readable when storage is
+    // exactly what is unavailable: querying the chain's height would hang alongside the task.
+    let mut last_created_height: Option<BlockHeight> = None;
     loop {
+        debug!(%chain_id, ?last_created_height, "Parking inbox task until the next notification");
+        let parked_since = Instant::now();
         futures::select! {
             () = cancellation_token.cancelled().fuse() => break,
-            () = inbox_notify.notified().fuse() => {
+            () = report_while_pending(
+                inbox_notify.notified(),
+                PARKED_REPORT_INTERVAL,
+                move |parked| info!(
+                    %chain_id,
+                    stage = "awaiting_notification",
+                    parked_secs = parked.as_secs(),
+                    ?last_created_height,
+                    "Inbox task is still parked and has received no notification",
+                ),
+            ).fuse() => {
+                debug!(
+                    %chain_id,
+                    parked_ms = parked_since.elapsed().as_millis() as u64,
+                    "Inbox task woken by a notification",
+                );
                 if config.skip_process_inbox {
                     debug!("Not processing inbox for {chain_id:.8} due to listener configuration");
                     continue;
@@ -831,22 +880,45 @@ async fn inbox_processing_loop<C: ClientContext>(
                 // because we're not the leader, sleep until the timeout then retry.
                 // A new notification or cancellation can interrupt the sleep.
                 loop {
-                    match client.process_inbox_without_prepare().await {
+                    debug!(%chain_id, "Calling process_inbox_without_prepare");
+                    let call_started = Instant::now();
+                    let result = report_while_pending(
+                        client.process_inbox_without_prepare(),
+                        INBOX_STALL_REPORT_INTERVAL,
+                        move |pending| warn!(
+                            %chain_id,
+                            stage = "process_inbox_without_prepare",
+                            pending_secs = pending.as_secs(),
+                            ?last_created_height,
+                            "Inbox task has not returned from process_inbox_without_prepare",
+                        ),
+                    )
+                    .await;
+                    let elapsed_ms = call_started.elapsed().as_millis() as u64;
+                    if let Ok((certs, _)) = &result {
+                        last_created_height = certs
+                            .last()
+                            .map(|cert| cert.inner().height())
+                            .or(last_created_height);
+                    }
+                    match result {
                         Err(chain_client::Error::CannotFindKeyForChain(chain_id)) => {
-                            debug!(%chain_id, "Cannot find key for chain");
+                            debug!(%chain_id, elapsed_ms, "Cannot find key for chain");
                             break;
                         }
                         Err(error) => {
-                            warn!(%error, "Failed to process inbox");
+                            warn!(%chain_id, %error, elapsed_ms, "Failed to process inbox");
                             break;
                         }
                         Ok((certs, None)) => {
                             if certs.is_empty() {
-                                debug!(%chain_id, "done processing inbox: no blocks created");
+                                debug!(%chain_id, elapsed_ms, "done processing inbox: no blocks created");
                             } else {
                                 info!(
                                     %chain_id,
                                     created_block_count = %certs.len(),
+                                    elapsed_ms,
+                                    ?last_created_height,
                                     "done processing inbox",
                                 );
                             }
@@ -856,6 +928,8 @@ async fn inbox_processing_loop<C: ClientContext>(
                             info!(
                                 %chain_id,
                                 created_block_count = %certs.len(),
+                                elapsed_ms,
+                                ?last_created_height,
                                 timeout = %new_timeout,
                                 "waiting for round timeout before continuing to process the inbox",
                             );
@@ -871,8 +945,22 @@ async fn inbox_processing_loop<C: ClientContext>(
                     }
                 }
 
-                if let Err(error) = context.lock().await.update_wallet(&client).await {
-                    warn!(%error, "Failed to update wallet after inbox processing");
+                // The context mutex is shared by every chain in the process, so a stall here
+                // is a whole-worker fault rather than a per-chain one.
+                let update = report_while_pending(
+                    async { context.lock().await.update_wallet(&client).await },
+                    INBOX_STALL_REPORT_INTERVAL,
+                    move |pending| warn!(
+                        %chain_id,
+                        stage = "update_wallet",
+                        pending_secs = pending.as_secs(),
+                        ?last_created_height,
+                        "Inbox task has not returned from the post-processing wallet update",
+                    ),
+                )
+                .await;
+                if let Err(error) = update {
+                    warn!(%chain_id, %error, "Failed to update wallet after inbox processing");
                 }
             }
         }

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -801,7 +801,6 @@ impl<C: ClientContext + 'static> ChainListener<C> {
 }
 
 /// How often a parked inbox task reports that it has still received no notification.
-/// Being parked is a legitimate steady state, so the report is `info!` rather than `warn!`.
 const PARKED_REPORT_INTERVAL: Duration = Duration::from_secs(300);
 
 /// How often an inbox task reports that an inbox-processing await has not returned.
@@ -809,9 +808,8 @@ const INBOX_STALL_REPORT_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Awaits `inner`, calling `report` with the elapsed time every `interval` while it stays pending.
 ///
-/// Purely diagnostic. `inner` is pinned once and polled to completion by the same `select!`
-/// arm every iteration, so a timer tick only logs: it never drops or restarts `inner`, and
-/// therefore cannot lose a `Notify` permit or abandon an in-flight inbox call.
+/// `inner` is pinned once and re-polled by the same `select!` arm every iteration; a tick only
+/// logs. Do not rebind it — dropping `inner` here would discard a `Notify` permit.
 async fn report_while_pending<F: Future>(
     inner: F,
     interval: Duration,
@@ -840,9 +838,12 @@ async fn inbox_processing_loop<C: ClientContext>(
     let chain_id = client.chain_id();
     // Tracked in-process because the diagnostics below must stay readable when storage is
     // exactly what is unavailable: querying the chain's height would hang alongside the task.
-    let mut last_created_height: Option<BlockHeight> = None;
+    let mut last_height_this_task_created: Option<BlockHeight> = None;
+    // Paired with the exit line below so that "no lines at all for this chain" is a distinct
+    // diagnosis from "the task is parked", rather than being indistinguishable from an old binary.
+    info!(%chain_id, "Inbox task started");
     loop {
-        debug!(%chain_id, ?last_created_height, "Parking inbox task until the next notification");
+        debug!(%chain_id, ?last_height_this_task_created, "Parking inbox task until the next notification");
         let parked_since = Instant::now();
         futures::select! {
             () = cancellation_token.cancelled().fuse() => break,
@@ -853,7 +854,7 @@ async fn inbox_processing_loop<C: ClientContext>(
                     %chain_id,
                     stage = "awaiting_notification",
                     parked_secs = parked.as_secs(),
-                    ?last_created_height,
+                    ?last_height_this_task_created,
                     "Inbox task is still parked and has received no notification",
                 ),
             ).fuse() => {
@@ -889,17 +890,28 @@ async fn inbox_processing_loop<C: ClientContext>(
                             %chain_id,
                             stage = "process_inbox_without_prepare",
                             pending_secs = pending.as_secs(),
-                            ?last_created_height,
+                            ?last_height_this_task_created,
                             "Inbox task has not returned from process_inbox_without_prepare",
                         ),
                     )
                     .await;
-                    let elapsed_ms = call_started.elapsed().as_millis() as u64;
+                    let elapsed = call_started.elapsed();
+                    let elapsed_ms = elapsed.as_millis() as u64;
+                    // Terminates a stall that reported above, so recovery is distinguishable from
+                    // the task dying mid-stall. The ordinary outcome only logs at `debug!`.
+                    if elapsed >= INBOX_STALL_REPORT_INTERVAL {
+                        info!(
+                            %chain_id,
+                            stage = "process_inbox_without_prepare",
+                            elapsed_ms,
+                            "Inbox task returned after a reported stall",
+                        );
+                    }
                     if let Ok((certs, _)) = &result {
-                        last_created_height = certs
+                        last_height_this_task_created = certs
                             .last()
                             .map(|cert| cert.inner().height())
-                            .or(last_created_height);
+                            .or(last_height_this_task_created);
                     }
                     match result {
                         Err(chain_client::Error::CannotFindKeyForChain(chain_id)) => {
@@ -918,7 +930,7 @@ async fn inbox_processing_loop<C: ClientContext>(
                                     %chain_id,
                                     created_block_count = %certs.len(),
                                     elapsed_ms,
-                                    ?last_created_height,
+                                    ?last_height_this_task_created,
                                     "done processing inbox",
                                 );
                             }
@@ -929,14 +941,19 @@ async fn inbox_processing_loop<C: ClientContext>(
                                 %chain_id,
                                 created_block_count = %certs.len(),
                                 elapsed_ms,
-                                ?last_created_height,
+                                ?last_height_this_task_created,
                                 timeout = %new_timeout,
                                 "waiting for round timeout before continuing to process the inbox",
                             );
                             let delta = new_timeout.timestamp.delta_since(Timestamp::now());
                             if delta > TimeDelta::ZERO {
+                                // Not wrapped in `report_while_pending`: this wait is bounded by
+                                // `delta` and its duration was just logged above.
                                 futures::select! {
-                                    () = cancellation_token.cancelled().fuse() => return,
+                                    () = cancellation_token.cancelled().fuse() => {
+                                        info!(%chain_id, "Inbox task stopped: cancelled while waiting for the round timeout");
+                                        return;
+                                    },
                                     () = linera_base::time::timer::sleep(delta.as_duration()).fuse() => {},
                                     () = inbox_notify.notified().fuse() => {},
                                 }
@@ -945,29 +962,95 @@ async fn inbox_processing_loop<C: ClientContext>(
                     }
                 }
 
-                // The context mutex is shared by every chain in the process, so a stall here
-                // is a whole-worker fault rather than a per-chain one.
+                // Reported as two stages on purpose: `context` is shared by every chain, so one
+                // chain stalling inside the update makes every other chain stall acquiring it.
+                // Split, the waiters say `context_lock` and only the holder says `update_wallet`.
+                let mut guard = report_while_pending(
+                    context.lock(),
+                    INBOX_STALL_REPORT_INTERVAL,
+                    move |pending| warn!(
+                        %chain_id,
+                        stage = "context_lock",
+                        pending_secs = pending.as_secs(),
+                        "Inbox task is still waiting for the shared context lock",
+                    ),
+                )
+                .await;
                 let update = report_while_pending(
-                    async { context.lock().await.update_wallet(&client).await },
+                    guard.update_wallet(&client),
                     INBOX_STALL_REPORT_INTERVAL,
                     move |pending| warn!(
                         %chain_id,
                         stage = "update_wallet",
                         pending_secs = pending.as_secs(),
-                        ?last_created_height,
+                        ?last_height_this_task_created,
                         "Inbox task has not returned from the post-processing wallet update",
                     ),
                 )
                 .await;
+                drop(guard);
                 if let Err(error) = update {
                     warn!(%chain_id, %error, "Failed to update wallet after inbox processing");
                 }
             }
         }
     }
+    info!(%chain_id, "Inbox task stopped: cancelled");
 }
 
 enum Action {
     Notification(Notification),
     Stop,
+}
+
+#[cfg(all(test, not(web)))]
+mod report_while_pending_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    /// A report tick must not consume the `Notify` permit. Every diagnostic in this file is
+    /// wrapped around an await that must still resolve, so this is the invariant to protect.
+    #[tokio::test(start_paused = true)]
+    async fn a_tick_does_not_swallow_the_notification() {
+        let notify = Arc::new(Notify::new());
+        let reports = Arc::new(AtomicUsize::new(0));
+
+        let waiter = {
+            let notify = notify.clone();
+            let reports = reports.clone();
+            tokio::spawn(async move {
+                report_while_pending(notify.notified(), Duration::from_secs(60), move |_| {
+                    reports.fetch_add(1, Ordering::SeqCst);
+                })
+                .await
+            })
+        };
+
+        // Three intervals with nothing to wake it: the reports fire, the await stays pending.
+        tokio::time::sleep(Duration::from_secs(190)).await;
+        assert!(reports.load(Ordering::SeqCst) >= 3);
+        assert!(!waiter.is_finished());
+
+        notify.notify_one();
+        waiter
+            .await
+            .expect("the notification must still resolve it");
+    }
+
+    /// A notification arriving before the first tick resolves without reporting at all.
+    #[tokio::test(start_paused = true)]
+    async fn a_prompt_notification_reports_nothing() {
+        let notify = Arc::new(Notify::new());
+        let reports = Arc::new(AtomicUsize::new(0));
+
+        notify.notify_one();
+        let counter = reports.clone();
+        report_while_pending(notify.notified(), Duration::from_secs(60), move |_| {
+            counter.fetch_add(1, Ordering::SeqCst);
+        })
+        .await;
+
+        assert_eq!(reports.load(Ordering::SeqCst), 0);
+    }
 }


### PR DESCRIPTION
## Motivation

On 2026-08-24, validator-3's Scylla connection pool died at 17:06:53 UTC. Within one second, two PM
market chains on two different workers stopped producing blocks and did not recover for 11 minutes,
until the pods were restarted:

```
17:06:52.243  a419803c  (engine-v2-71-SOL-1-lv market, worker-7)  last line ever emitted
17:06:53.262  validator-3's first client-visible error
17:06:53.283  4c832bdb  (engine-v2-71-ETH-1-lv market, worker-6)  last line ever emitted
```

**Those workers logged nothing at all for those two chains during the entire wedge** — no error, no
retry, no warning. Twelve sibling chains in the same processes kept running normally throughout.

Detection was never the problem: `PMChainNotProducingBlocks` fired and an autoheal CronJob restarted
both workers. The problem is that once alerted, there was **no way to tell why**. The investigation
could narrow it only to two candidates that are indistinguishable from the logs: the task never woke,
or it never returned from `process_inbox_without_prepare()`.

`inbox_processing_loop` is driven solely by `inbox_notify.notified()`. The only `notify_one()` site is
`maybe_notify_inbox_processing`, reached from four notification-driven paths. There is no timer and no
periodic re-arm, so "parked forever" and "nothing to do" look identical — both are silence.

## Proposal

**Diagnostics only. This does not fix the wedge, and it deliberately does not change control flow.**

`report_while_pending` wraps an await and logs every `interval` while it stays pending. The inner
future is pinned once and re-polled by the same `select!` arm each iteration, so a tick only logs —
it never drops or restarts the future, and therefore cannot lose a `Notify` permit or abandon an
in-flight inbox call. That property is what makes this safe to put on the notification await, and it
is now covered by a test (below) rather than by argument.

Applied at the four points where the task can be stuck, so they become distinguishable:

| await | level | interval | says |
|---|---|---|---|
| `inbox_notify.notified()` | `info!` | 300 s | parked, no notification received |
| `process_inbox_without_prepare()` | `warn!` | 60 s | call has not returned |
| `context.lock()` | `warn!` | 60 s | still waiting for the shared context lock |
| `update_wallet()` | `warn!` | 60 s | update has not returned |

The last two are split on purpose. `context` is a process-wide mutex, so one chain stalling *inside*
the update makes every other chain stall *acquiring* it. Reported as one stage, a 14-chain worker
emits fourteen identical accusations and names no culprit; split, the waiters say `context_lock` and
only the holder says `update_wallet`.

Also:
- `info!` on task start and on each exit path, so **"no lines at all for this chain"** is a distinct
  diagnosis rather than being indistinguishable from a binary that predates this PR.
- An `info!` when `process_inbox_without_prepare` returns after having reported a stall. The ordinary
  outcome logs at `debug!`, so without this a stall that recovers simply stops emitting and looks the
  same as the task dying mid-stall.
- `elapsed_ms` on the existing "done processing inbox" lines, so slow-but-alive is distinguishable
  from stuck.
- `%chain_id` on `"Failed to update wallet after inbox processing"`, which previously carried no
  chain identity at all — on a worker hosting a dozen chains that line named none of them.
- `last_height_this_task_created` tracked in process rather than queried, because the diagnostics
  must stay readable when storage is exactly what is unavailable. Named for what it is: it is
  task-local and resets when the task respawns, so it reads `None` on a freshly restarted worker and
  must not be mistaken for the chain tip.

### What this still cannot see

The table above is not exhaustive, and the gaps are worth stating:

- **Executor starvation.** Every report depends on the tokio timer and a free worker thread. If the
  runtime itself is wedged — plausible under a storage-driver meltdown, and certain under
  `--tokio-threads 1` — no tick fires and the log is silent exactly as before. **Absence of these
  lines is therefore a third diagnosis, not a gap in coverage.**
- **The round-timeout wait** is deliberately not wrapped: it is bounded by `delta`, whose duration
  the preceding `info!` already prints. So the heartbeat is not perfectly continuous, and a
  "no line from chain X in > N minutes" detector needs to allow for it.

## Test Plan

Two tests, both `#[tokio::test(start_paused = true)]`, covering the property the rest of the PR rests
on:

```
test chain_listener::report_while_pending_tests::a_tick_does_not_swallow_the_notification ... ok
test chain_listener::report_while_pending_tests::a_prompt_notification_reports_nothing ... ok
```

The first lets three report intervals elapse, asserts the reports fired **and that the future is
still pending**, then sends `notify_one()` and asserts it resolves — i.e. a tick does not consume the
permit. The second asserts a notification arriving before the first tick reports nothing at all.

- `cargo +nightly-2025-04-03 fmt -p linera-client -- --check` — clean. Run on the CI toolchain
  specifically: `lint-cargo-fmt` symlinks `toolchains/nightly/rust-toolchain.toml` first, and on
  stable the `imports_granularity` / `group_imports` / `format_code_in_doc_comments` rules are
  silently skipped, so a stable fmt pass proves nothing.
- `cargo check -p linera-client` — compiles clean.
- `cargo clippy -p linera-client --all-targets` — **adds no warnings.** The 3 it reports were
  verified pre-existing by stashing this change and re-running on the clean base: byte-identical
  output. They live in `linera-client/src/unit_tests/chain_listener.rs`, untouched here.

Not covered: no test reproduces an actual wedge. That needs fault injection at the storage layer,
which does not exist in the tree — but note that is only true of *reproducing the wedge*, not of the
permit-preservation property, which is tested above.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

Targeted at `testnet_conway` because that is where the incident happened and where the two related
fixes (#6761, #6762) live. **It should be forward-ported to `main`** — the silence it addresses is
not conway-specific.

## Links

- Companion protocol PRs on the same incident: #6762 and #6761.
- The wedge itself is a separate defect and is **not** fixed here: a notification-only loop with no
  timer and no re-arm. This PR only makes it say so.
