### PR TITLE
Report a missing block height instead of panicking

### DIFF
--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2023,10 +2023,15 @@ impl Runnable for Job {
                     .load_chain(chain_id)
                     .await
                     .context("Failed to load chain")?;
+                // `block_hashes_for_heights` skips heights it does not hold, so an unknown
+                // height yields an empty vector rather than an error.
                 let block_hash = chain_state_view
                     .block_hashes_for_heights([height])
                     .await
-                    .context("Failed to find a block hash for the given height")?[0];
+                    .context("Failed to find a block hash for the given height")?
+                    .into_iter()
+                    .next()
+                    .with_context(|| format!("Chain {chain_id} has no block at height {height}"))?;
                 let block = context
                     .storage()
                     .read_confirmed_block(block_hash)


### PR DESCRIPTION
## Motivation

`linera chain show-block --height <height>` panics with index-out-of-bounds for any height the local
storage does not hold.

`linera-service/src/cli/main.rs` indexes the result directly:

```rust
let block_hash = chain_state_view
    .block_hashes_for_heights([height])
    .await
    .context("Failed to find a block hash for the given height")?[0];
```

and the function it calls documents that it skips what it does not have
(`linera-chain/src/chain.rs`):

```rust
/// Returns the hashes of all blocks we have at the given heights, in input order.
/// Unknown heights are skipped.
```

`multi_get` returns `Vec<Option<CryptoHash>>` and `.flatten()` drops the misses, so an unknown height
yields an **empty** `Vec` and `[0]` panics. The `?` never fires — this is a successful `Ok` carrying
zero elements, which is exactly why the existing `.context(...)` does not catch it.

Reaching it needs no unusual state: a height above the tip, a height on a chain this node only
partially tracks, or a typo.

## Proposal

Take the first element if there is one, and turn its absence into the error the caller already
expects:

```rust
    .context("Failed to find a block hash for the given height")?
    .into_iter()
    .next()
    .with_context(|| format!("Chain {chain_id} has no block at height {height}"))?;
```

A panic becomes a CLI error naming both the chain and the height. `anyhow::Context` is already in
scope at the top of the file, so no new import.

## Test Plan

- `cargo check -p linera-service --bin linera` — compiles clean.
- `cargo +nightly-2025-04-03 fmt -p linera-service -- --check` — clean. Run on the CI toolchain
  specifically, since `lint-cargo-fmt` symlinks `toolchains/nightly/rust-toolchain.toml` first and on
  stable the `imports_granularity` / `group_imports` rules are silently skipped.
- Clippy is left to CI's `lint-cargo-clippy` rather than run locally; the change adds no new
  construct beyond an `Iterator::next` and a second `Context` call already used throughout the file.

The failure mode was verified by reading, not by running the binary: `block_hashes_for_heights`
→ `multi_get` → `.flatten()` → `collect()` cannot preserve a slot for a missing height, so the
returned `Vec` is shorter than the requested list and empty for a single unknown height.

## Release Plan

- Nothing to do / These changes follow the usual deployment cycle.

`main` only. `testnet_conway` is already covered by #6761, which reworks this call site as part of a
larger change; this is the minimal standalone fix for the branch that does not have it.

## Links

Found while adversarially reviewing #6761, which touches the same call site on `testnet_conway`.
Deliberately kept out of that PR: different branch, different scope, and this one stands alone.
