### PR TITLE
Backport #6743 to testnet_conway: isolate task groups from one another

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -839,6 +839,9 @@ Run a GraphQL service to explore and extend the chains of the wallet
 * `--task-retry-delay-secs <TASK_RETRY_DELAY_SECS>` — Delay in seconds before retrying a failed operator task batch. Only relevant when operators are configured via `--operator-application-ids` or `--controller-id`
 
   Default value: `5`
+* `--slow-task-group-secs <SLOW_TASK_GROUP_SECS>` — Number of seconds after which a still-running operator task group is logged and counted as slow. The group is not interrupted and runs to completion. Only relevant when operators are configured via `--operator-application-ids` or `--controller-id`
+
+  Default value: `300`
 * `--read-only` — Run in read-only mode: disallow mutations and prevent queries from scheduling operations. Use this when exposing the service to untrusted clients
 * `--query-cache-size <QUERY_CACHE_SIZE>` — Enable the application query response cache with the given per-chain capacity. Each entry stores a serialized GraphQL response keyed by (application_id, request_bytes). Incompatible with `--long-lived-services`
 * `--allow-subscription <ALLOWED_SUBSCRIPTIONS>` — Allow a named GraphQL subscription query. The operation name is extracted from the query string. Repeatable. Example: `--allow-subscription 'query CounterValue { getCounter { value } }'`

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -879,6 +879,13 @@ pub enum ClientCommand {
         #[arg(long, default_value = "5")]
         task_retry_delay_secs: u64,
 
+        /// Number of seconds after which a still-running operator task group is logged and
+        /// counted as slow. The group is not interrupted and runs to completion.
+        /// Only relevant when operators are configured via `--operator-application-ids`
+        /// or `--controller-id`.
+        #[arg(long, default_value = "300")]
+        slow_task_group_secs: u64,
+
         /// Run in read-only mode: disallow mutations and prevent queries from scheduling
         /// operations. Use this when exposing the service to untrusted clients.
         #[arg(long)]

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -78,7 +78,7 @@ use linera_service::{
     node_service::NodeService,
     project::{self, Project},
     storage::{AssertStorageV1, Runnable, RunnableWithStore, StorageCacheConfig, StorageMigration},
-    task_processor::TaskProcessor,
+    task_processor::{TaskProcessor, TaskProcessorConfig},
     util,
 };
 use linera_storage::{DbStorage, Storage};
@@ -1300,6 +1300,7 @@ impl Runnable for Job {
                 operators,
                 controller_application_id,
                 task_retry_delay_secs,
+                slow_task_group_secs,
                 read_only,
                 query_cache_size,
                 allowed_subscriptions,
@@ -1329,7 +1330,10 @@ impl Runnable for Job {
                 let operators = Arc::new(operators);
 
                 // Start the task processor if operator applications are specified.
-                let retry_delay = TimeDelta::from_secs(task_retry_delay_secs);
+                let task_config = TaskProcessorConfig {
+                    retry_delay: TimeDelta::from_secs(task_retry_delay_secs),
+                    slow_group_threshold: TimeDelta::from_secs(slow_task_group_secs),
+                };
 
                 if !operator_application_ids.is_empty() {
                     let chain_client = context.make_chain_client(chain_id).await?;
@@ -1339,7 +1343,7 @@ impl Runnable for Job {
                         chain_client,
                         cancellation_token.clone(),
                         operators.clone(),
-                        retry_delay,
+                        task_config,
                         None,
                     );
                     tokio::spawn(processor.run());
@@ -1360,7 +1364,7 @@ impl Runnable for Job {
                         chain_client,
                         cancellation_token.clone(),
                         operators,
-                        retry_delay,
+                        task_config,
                         command_sender,
                     );
 

--- a/linera-service/src/controller.rs
+++ b/linera-service/src/controller.rs
@@ -7,10 +7,7 @@ use std::{
 };
 
 use futures::{lock::Mutex, stream::StreamExt, FutureExt};
-use linera_base::{
-    data_types::TimeDelta,
-    identifiers::{ApplicationId, ChainId},
-};
+use linera_base::identifiers::{ApplicationId, ChainId};
 use linera_client::chain_listener::{ClientContext, ListenerCommand};
 use linera_core::{client::ChainClient, node::NotificationStream, worker::Reason};
 use linera_sdk::abis::controller::{LocalWorkerState, Operation, WorkerCommand};
@@ -22,7 +19,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
-use crate::task_processor::{OperatorMap, TaskProcessor};
+use crate::task_processor::{OperatorMap, TaskProcessor, TaskProcessorConfig};
 
 /// An update message sent to a TaskProcessor to change its set of applications.
 #[derive(Debug)]
@@ -44,7 +41,7 @@ pub struct Controller<Ctx: ClientContext> {
     cancellation_token: CancellationToken,
     notifications: NotificationStream,
     operators: OperatorMap,
-    retry_delay: TimeDelta,
+    config: TaskProcessorConfig,
     processors: BTreeMap<ChainId, ProcessorHandle>,
     listened_local_chains: BTreeSet<ChainId>,
     command_sender: UnboundedSender<ListenerCommand>,
@@ -65,7 +62,7 @@ where
         chain_client: ChainClient<Ctx::Environment>,
         cancellation_token: CancellationToken,
         operators: OperatorMap,
-        retry_delay: TimeDelta,
+        config: TaskProcessorConfig,
         command_sender: UnboundedSender<ListenerCommand>,
     ) -> Self {
         let notifications = chain_client.subscribe().expect("client subscription");
@@ -77,7 +74,7 @@ where
             cancellation_token,
             notifications,
             operators,
-            retry_delay,
+            config,
             processors: BTreeMap::new(),
             listened_local_chains: BTreeSet::new(),
             command_sender,
@@ -297,7 +294,7 @@ where
             chain_client,
             self.cancellation_token.child_token(),
             self.operators.clone(),
-            self.retry_delay,
+            self.config,
             Some(update_receiver),
         );
 

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -45,4 +45,5 @@ pub fn init_metrics() {
     linera_storage::init_metrics();
     linera_views::init_metrics();
     node_service::query_cache_metrics::init_metrics();
+    task_processor::metrics::init_metrics();
 }

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -8,7 +8,7 @@
 
 use std::{
     cmp::Reverse,
-    collections::{BTreeMap, BTreeSet, BinaryHeap},
+    collections::{BTreeMap, BTreeSet, BinaryHeap, HashSet},
     path::PathBuf,
     sync::Arc,
 };
@@ -26,9 +26,27 @@ use linera_core::{
 use serde_json::json;
 use tokio::{io::AsyncWriteExt, process::Command, select, sync::mpsc};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::controller::Update;
+
+#[cfg(with_metrics)]
+pub(crate) mod metrics {
+    use linera_base::prometheus_util::register_int_counter;
+    use prometheus::IntCounter;
+
+    linera_base::declare_metrics! {
+        /// Task groups that have outlived [`TaskProcessorConfig::slow_group_threshold`].
+        ///
+        /// A group counted here is still running and may still succeed. It is worth alerting on
+        /// because nothing else reports it: the process stays healthy while the chain the group
+        /// serves stops advancing, so a group that never returns is otherwise silent.
+        pub static SLOW_TASK_GROUPS: IntCounter = register_int_counter(
+            "slow_task_groups_total",
+            "Number of task groups that outlived the slow-group threshold"
+        );
+    }
+}
 
 /// A map from operator names to their binary paths.
 pub type OperatorMap = Arc<BTreeMap<String, PathBuf>>;
@@ -45,10 +63,21 @@ pub fn parse_operator(s: &str) -> Result<(String, PathBuf), String> {
 
 type Deadline = Reverse<(Timestamp, Option<ApplicationId>)>;
 
-/// Message sent from a background batch task to the main loop on completion.
-struct BatchResult {
+/// Timing limits applied to operator tasks.
+#[derive(Clone, Copy, Debug)]
+pub struct TaskProcessorConfig {
+    /// How long to wait before retrying a task group that failed.
+    pub retry_delay: TimeDelta,
+    /// How long a task group may run before it is reported as slow. The group keeps running.
+    pub slow_group_threshold: TimeDelta,
+}
+
+/// Message sent from a background task group to the main loop on completion.
+struct GroupResult {
     application_id: ApplicationId,
-    /// If set, the batch failed and should be retried at this timestamp.
+    /// The group's id, as returned by [`group_tasks`].
+    group: Option<String>,
+    /// If set, the group failed and should be retried at this timestamp.
     retry_at: Option<Timestamp>,
 }
 
@@ -60,13 +89,15 @@ pub struct TaskProcessor<Env: linera_core::Environment> {
     chain_client: ChainClient<Env>,
     cancellation_token: CancellationToken,
     notifications: NotificationStream,
-    batch_sender: mpsc::UnboundedSender<BatchResult>,
-    batch_receiver: mpsc::UnboundedReceiver<BatchResult>,
+    result_sender: mpsc::UnboundedSender<GroupResult>,
+    result_receiver: mpsc::UnboundedReceiver<GroupResult>,
     update_receiver: mpsc::UnboundedReceiver<Update>,
     deadlines: BinaryHeap<Deadline>,
     operators: OperatorMap,
-    retry_delay: TimeDelta,
-    in_flight_apps: BTreeSet<ApplicationId>,
+    config: TaskProcessorConfig,
+    /// The groups currently running, so that a second copy is never started while one is in
+    /// flight.
+    in_flight_groups: BTreeSet<(ApplicationId, Option<String>)>,
 }
 
 impl<Env: linera_core::Environment> TaskProcessor<Env> {
@@ -77,11 +108,11 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         chain_client: ChainClient<Env>,
         cancellation_token: CancellationToken,
         operators: OperatorMap,
-        retry_delay: TimeDelta,
+        config: TaskProcessorConfig,
         update_receiver: Option<mpsc::UnboundedReceiver<Update>>,
     ) -> Self {
         let notifications = chain_client.subscribe().expect("client subscription");
-        let (batch_sender, batch_receiver) = mpsc::unbounded_channel();
+        let (result_sender, result_receiver) = mpsc::unbounded_channel();
         let update_receiver = update_receiver.unwrap_or_else(|| mpsc::unbounded_channel().1);
         Self {
             chain_id,
@@ -90,13 +121,13 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
             chain_client,
             cancellation_token,
             notifications,
-            batch_sender,
-            batch_receiver,
+            result_sender,
+            result_receiver,
             update_receiver,
             deadlines: BinaryHeap::new(),
             operators,
-            retry_delay,
-            in_flight_apps: BTreeSet::new(),
+            config,
+            in_flight_groups: BTreeSet::new(),
         }
     }
 
@@ -117,8 +148,8 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                     let application_ids = self.process_events();
                     self.process_actions(application_ids).await;
                 }
-                Some(result) = self.batch_receiver.recv() => {
-                    self.in_flight_apps.remove(&result.application_id);
+                Some(result) = self.result_receiver.recv() => {
+                    self.in_flight_groups.remove(&(result.application_id, result.group));
                     // The application could have been unassigned from this processor
                     // in the meantime - do not retry if that is the case.
                     if self.application_ids.contains(&result.application_id) {
@@ -163,8 +194,8 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
 
         self.cursors
             .retain(|app_id, _| new_app_set.contains(app_id));
-        self.in_flight_apps
-            .retain(|app_id| new_app_set.contains(app_id));
+        self.in_flight_groups
+            .retain(|(app_id, _)| new_app_set.contains(app_id));
 
         // Update the application_ids
         self.application_ids = update.application_ids;
@@ -181,12 +212,17 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         }
     }
 
+    /// Returns the applications whose deadlines have come, ordered by deadline and without
+    /// repetitions.
     fn process_events(&mut self) -> Vec<ApplicationId> {
         let now = Timestamp::now();
         let mut application_ids = Vec::new();
+        let mut seen = HashSet::new();
         while let Some(deadline) = self.deadlines.pop() {
             if let Reverse((_, Some(id))) = deadline {
-                application_ids.push(id);
+                if seen.insert(id) {
+                    application_ids.push(id);
+                }
             }
             let Some(Reverse((ts, _))) = self.deadlines.peek() else {
                 break;
@@ -202,10 +238,6 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         for application_id in application_ids {
             if !self.application_ids.contains(&application_id) {
                 debug!("Skipping {application_id}: it's no longer assigned to this processor");
-                continue;
-            }
-            if self.in_flight_apps.contains(&application_id) {
-                debug!("Skipping {application_id}: tasks already in flight");
                 continue;
             }
             debug!("Processing actions for {application_id}");
@@ -230,47 +262,43 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
             if let Some(cursor) = actions.set_cursor {
                 self.cursors.insert(application_id, cursor);
             }
-            if !actions.execute_tasks.is_empty() {
-                self.in_flight_apps.insert(application_id);
+            // Start each group that is not already running. Group outcomes commute, so a group
+            // that is slow, stuck or failing neither delays the others nor keeps this application
+            // from being polled again for their sake.
+            for (group, tasks) in group_tasks(actions.execute_tasks) {
+                if !self
+                    .in_flight_groups
+                    .insert((application_id, group.clone()))
+                {
+                    debug!(%application_id, ?group, "Skipping group: tasks already in flight");
+                    continue;
+                }
                 let chain_client = self.chain_client.clone();
-                let batch_sender = self.batch_sender.clone();
-                let retry_delay = self.retry_delay;
+                let result_sender = self.result_sender.clone();
+                let config = self.config;
                 let operators = self.operators.clone();
                 tokio::spawn(async move {
-                    // Run each group concurrently, so that a slow or failing group never
-                    // delays the outcomes of the others.
-                    let mut handles = Vec::new();
-                    for (group, tasks) in group_tasks(actions.execute_tasks) {
-                        handles.push((
-                            group.clone(),
-                            tokio::spawn(Self::process_group(
-                                application_id,
-                                group,
-                                tasks,
-                                chain_client.clone(),
-                                operators.clone(),
-                                retry_delay,
-                            )),
-                        ));
-                    }
-                    // `None` sorts before any timestamp, so the maximum is the latest retry
-                    // any group asked for: a task failing on every attempt cannot shorten the
-                    // delay protecting the operator.
-                    let mut retry_at = None;
-                    for (group, handle) in handles {
-                        retry_at = retry_at.max(handle.await.unwrap_or_else(|error| {
-                            error!(%application_id, ?group, %error, "Task group panicked");
-                            Some(Timestamp::now().saturating_add(retry_delay))
-                        }));
-                    }
-                    if batch_sender
-                        .send(BatchResult {
+                    // Run the group on its own task: a panic inside it must surface here and
+                    // become a retry. An unreported panic sends no result message, and the group
+                    // then stays marked in flight forever.
+                    let handle = tokio::spawn(Self::process_group(
+                        application_id,
+                        group.clone(),
+                        tasks,
+                        chain_client,
+                        operators,
+                        config,
+                    ));
+                    let retry_at = await_group(application_id, &group, handle, config).await;
+                    if result_sender
+                        .send(GroupResult {
                             application_id,
+                            group,
                             retry_at,
                         })
                         .is_err()
                     {
-                        error!(%application_id, "Batch receiver dropped");
+                        error!(%application_id, "Result receiver dropped");
                     }
                 });
             }
@@ -293,11 +321,11 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         tasks: Vec<Task>,
         chain_client: ChainClient<Env>,
         operators: OperatorMap,
-        retry_delay: TimeDelta,
+        config: TaskProcessorConfig,
     ) -> Option<Timestamp> {
         let mut handles = Vec::with_capacity(tasks.len());
         for task in tasks {
-            handles.push(tokio::spawn(Self::execute_task(
+            handles.push(tokio::spawn(execute_task(
                 application_id,
                 task,
                 operators.clone(),
@@ -308,60 +336,25 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 Ok(Ok(outcome)) => outcome,
                 Ok(Err(error)) => {
                     error!(%application_id, ?group, %error, "Error executing task");
-                    return Some(Timestamp::now().saturating_add(retry_delay));
+                    return Some(Timestamp::now().saturating_add(config.retry_delay));
                 }
                 Err(error) => {
                     error!(%application_id, ?group, %error, "Task panicked");
-                    return Some(Timestamp::now().saturating_add(retry_delay));
+                    return Some(Timestamp::now().saturating_add(config.retry_delay));
                 }
             };
-            if let Err(timestamp) =
-                Self::submit_task_outcome(&chain_client, application_id, &outcome, retry_delay)
-                    .await
+            if let Err(timestamp) = Self::submit_task_outcome(
+                &chain_client,
+                application_id,
+                &outcome,
+                config.retry_delay,
+            )
+            .await
             {
                 return Some(timestamp);
             }
         }
         None
-    }
-
-    async fn execute_task(
-        application_id: ApplicationId,
-        task: Task,
-        operators: OperatorMap,
-    ) -> Result<TaskOutcome, anyhow::Error> {
-        let Task {
-            id,
-            operator,
-            input,
-        } = task;
-        let binary_path = operators
-            .get(&operator)
-            .ok_or_else(|| anyhow::anyhow!("unsupported operator: {operator}"))?;
-        debug!("Executing task {operator} ({binary_path:?}) for {application_id}");
-        let mut child = Command::new(binary_path)
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .spawn()?;
-
-        let mut stdin = child.stdin.take().expect("stdin should be configured");
-        stdin.write_all(input.as_bytes()).await?;
-        drop(stdin);
-
-        let output = child.wait_with_output().await?;
-        anyhow::ensure!(
-            output.status.success(),
-            "operator {} exited with status: {}",
-            operator,
-            output.status
-        );
-        let outcome = TaskOutcome {
-            id,
-            operator,
-            output: String::from_utf8_lossy(&output.stdout).into(),
-        };
-        debug!("Done executing task for {application_id}");
-        Ok(outcome)
     }
 
     // Keeping `&mut self` avoids borrowing `TaskProcessor` through `&self` across `.await`,
@@ -453,6 +446,73 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
             }
         }
         Ok(())
+    }
+}
+
+/// Runs one task's operator binary to completion.
+async fn execute_task(
+    application_id: ApplicationId,
+    task: Task,
+    operators: OperatorMap,
+) -> Result<TaskOutcome, anyhow::Error> {
+    let Task {
+        id,
+        operator,
+        input,
+    } = task;
+    let binary_path = operators
+        .get(&operator)
+        .ok_or_else(|| anyhow::anyhow!("unsupported operator: {operator}"))?;
+    debug!("Executing task {operator} ({binary_path:?}) for {application_id}");
+    let mut child = Command::new(binary_path)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()?;
+
+    let mut stdin = child.stdin.take().expect("stdin should be configured");
+    stdin.write_all(input.as_bytes()).await?;
+    drop(stdin);
+
+    let output = child.wait_with_output().await?;
+    anyhow::ensure!(
+        output.status.success(),
+        "operator {} exited with status: {}",
+        operator,
+        output.status
+    );
+    let outcome = TaskOutcome {
+        id,
+        operator,
+        output: String::from_utf8_lossy(&output.stdout).into(),
+    };
+    debug!("Done executing task for {application_id}");
+    Ok(outcome)
+}
+
+/// Awaits a task group, reporting it once if it outlives `slow_group_threshold` and then
+/// continuing to wait for it.
+async fn await_group(
+    application_id: ApplicationId,
+    group: &Option<String>,
+    mut handle: tokio::task::JoinHandle<Option<Timestamp>>,
+    config: TaskProcessorConfig,
+) -> Option<Timestamp> {
+    let on_panic = |error| {
+        error!(%application_id, ?group, %error, "Task group panicked");
+        Some(Timestamp::now().saturating_add(config.retry_delay))
+    };
+    let threshold = config.slow_group_threshold.as_duration();
+    match tokio::time::timeout(threshold, &mut handle).await {
+        Ok(result) => result.unwrap_or_else(on_panic),
+        Err(_) => {
+            warn!(
+                %application_id, ?group,
+                "Task group still running after {threshold:?}; leaving it to finish"
+            );
+            #[cfg(with_metrics)]
+            metrics::SLOW_TASK_GROUPS.inc();
+            handle.await.unwrap_or_else(on_panic)
+        }
     }
 }
 
@@ -550,6 +610,58 @@ mod tests {
                 group(Some("other"), &["second"])
             ]
         );
+    }
+
+    /// Writes an executable shell script and returns an operator map pointing at it.
+    fn operator_running(script: &str, dir: &tempfile::TempDir) -> OperatorMap {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let path = dir.path().join("operator");
+        std::fs::write(&path, format!("#!/bin/sh\n{script}\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        Arc::new(BTreeMap::from([("op".to_string(), path)]))
+    }
+
+    /// A syntactically valid application id. `CryptoHash`'s `FromStr` is hex over 32 bytes and,
+    /// unlike `test_hash`, is not gated behind `with_testing`.
+    fn app_id() -> ApplicationId {
+        ApplicationId::new("00".repeat(32).parse().unwrap())
+    }
+
+    fn timed_task() -> Task {
+        Task {
+            id: None,
+            operator: "op".to_string(),
+            input: String::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_task_returns_the_operator_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let operators = operator_running("echo done", &dir);
+        let outcome = execute_task(app_id(), timed_task(), operators)
+            .await
+            .unwrap();
+        assert_eq!(outcome.output.trim(), "done");
+    }
+
+    #[tokio::test]
+    async fn a_group_that_outlives_the_threshold_is_reported_but_still_awaited() {
+        let expected = Some(Timestamp::from(4_242));
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+            expected
+        });
+        let config = TaskProcessorConfig {
+            retry_delay: TimeDelta::from_secs(5),
+            // Far below what the group takes, so the slow path is the one exercised.
+            slow_group_threshold: TimeDelta::from_millis(10),
+        };
+        // Crossing the threshold reports the group without cutting it short, so the value it
+        // produces still comes back.
+        let retry_at = await_group(app_id(), &Some("group".to_string()), handle, config).await;
+        assert_eq!(retry_at, expected);
     }
 
     #[test]


### PR DESCRIPTION
Backport of #6743.

> **Opened before #6743 has merged**, so that review can run in parallel and this does not go the way
> of #5518 — the backport of #5484, open since 2026-02-25 and now conflicting, which is why
> `testnet_conway`'s controller still lacks that change. **Do not merge this before #6743**, or the
> branches diverge in the opposite direction.

## Motivation

`ProcessorActions::execute_tasks` documents that the outcomes of distinct groups commute and that
"a task that fails is retried **without holding the other groups back**". That holds for a group
that fails quickly, not for one that is merely slow, because the in-flight bookkeeping is per
*application*: `in_flight_apps` made `process_actions` skip the whole application while any batch
ran, and the batch awaited *every* group before reporting.

Observed on `oracle-v2-71-1`, 2026-08-18 — two consumers of one oracle application:

```
21:29:01  ETH   submits ts 1787088540
          HYPE  group still running
21:30-21:43  no log line mentioning the chain at all
21:42:03  HYPE  returns ts 1787088540 — the same timestamp — successfully
21:42:04  ETH   catches up 13 points (21:30 -> 21:42)
```

`ETH-1-lv` is a dense, healthy symbol; it lost 13 minutes of block production behind an unrelated
group. Note that the HYPE group **succeeded** at 21:42:03 — it was slow, not stuck, which is why
this fixes the coupling rather than adding a timeout. The full reasoning, including why a task
timeout is the wrong instrument, is in #6743.

This is the branch the incident happened on, so the fix matters here at least as much as on `main`.

## Proposal

Same change as #6743:

- `in_flight_groups: BTreeSet<(ApplicationId, Option<String>)>` replaces `in_flight_apps`, with each
  group reporting its own `GroupResult`.
- A group outliving `--slow-task-group-secs` (default 300) is logged and counted in
  `linera_slow_task_groups_total`, then awaited to completion. Reported, never interrupted.
- `process_events` returns each due application once.

## Test Plan

Applied as the net diff of #6743 rather than a cherry-pick of its commits, since #6743 has not been
squashed yet and its history contains a timeout that was added and then removed.

**`linera-service/src/task_processor.rs` — the whole substance of the change — applied cleanly and
is byte-identical to the version in #6743** (`git diff origin/ma2bd/task-processor-group-isolation --
linera-service/src/task_processor.rs` is empty). Two import hunks conflicted and were resolved
against this branch's own state:

- `controller.rs` — `main` imports `MessagePolicy` and `GenericApplicationId` here because of #5484,
  which is not on this branch (see #5518). Kept this branch's imports, minus `TimeDelta`, which the
  move to `TaskProcessorConfig` leaves unused.
- `cli/main.rs` — this branch's `storage` import carries `AssertStorageV1` and `StorageMigration`.
  Kept those and took only the added `TaskProcessorConfig`.

Verified with this branch's own toolchains, not `main`'s:

- `cargo check -p linera-service --all-targets` on the pinned **1.86.0** — clean. Nothing in the
  change needs a newer `std`: `is_some_and` (1.70), `last_key_value` (1.66), let-else (1.65).
- `cargo test -p linera-service --lib task_processor` — 6 passed.
- `cargo clippy --locked --all-targets --all-features -p linera-service` — clean.
- `cargo fmt --all -- --check` under this branch's pinned **nightly-2025-04-03** — clean.
- `scripts/check_metrics_registration.sh` — clean.
- `CLI.md` regenerated **on this branch**, since its CLI differs from `main`'s: the new flag lands at
  line 842 here versus 832 there.
