### PR TITLE
Correct the misleading claim that must_reload_view indicates a journal resolution failure

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -421,7 +421,7 @@ pub enum WorkerError {
     MissingNetworkDescription,
     #[error("thread error: {0}")]
     Thread(#[from] web_thread_pool::Error),
-    #[error("Chain worker was poisoned by a journal resolution failure")]
+    #[error("Chain worker was poisoned by a failed save that may have left storage in an undetermined state")]
     PoisonedWorker,
     #[error("Cross-chain batch was rolled back due to an error in another request")]
     BatchRolledBack,

--- a/linera-views/src/error.rs
+++ b/linera-views/src/error.rs
@@ -34,7 +34,8 @@ pub enum ViewError {
         /// The inner error
         #[source]
         error: Box<dyn std::error::Error + Send + Sync>,
-        /// Whether this error was caused by a journal resolution failure.
+        /// Whether this error may have left storage in an undetermined state,
+        /// so the view must be reloaded before being used again.
         must_reload_view: bool,
     },
 
@@ -69,8 +70,8 @@ pub enum ViewError {
 }
 
 impl ViewError {
-    /// Returns `true` if this error was caused by a journal resolution failure,
-    /// which may leave storage in an inconsistent state requiring a view reload.
+    /// Returns `true` if this error may have left storage in an undetermined state,
+    /// so the view must be reloaded before being used again.
     pub fn must_reload_view(&self) -> bool {
         matches!(
             self,

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -22,8 +22,8 @@ pub trait KeyValueStoreError:
     /// The name of the backend.
     const BACKEND: &'static str;
 
-    /// Returns `true` if this error represents a journal resolution failure,
-    /// which may leave storage in an inconsistent state requiring a view reload.
+    /// Returns `true` if this error may have left storage in an undetermined state,
+    /// so the view must be reloaded before being used again.
     fn must_reload_view(&self) -> bool {
         false
     }


### PR DESCRIPTION
## Motivation

`WorkerError::PoisonedWorker` renders as **"Chain worker was poisoned by a journal resolution failure"**, and the docs on `ViewError::must_reload_view`, its `StoreError` field, and the `KeyValueStoreError::must_reload_view` trait method all repeat the same claim.

That claim is wrong. Nothing in the poison path inspects the journal — `ChainWorkerState::save` sets `poisoned` for *any* error where `must_reload_view()` is true, and the flag is contributed by every backend. The dominant contributor is ScyllaDB, whose implementation says so directly:

```rust
fn must_reload_view(&self) -> bool {
    // Errors (notably timeouts) during a `write_batch` may leave the view in a
    // undetermined state where the batch may or may not have happened.
    matches!(self, Self::WriteBatchExecutionError(_))
}
```

`JournalingError::JournalResolutionFailed` is one contributor among several, and in practice a rare one. While debugging a corrupted chain on a `testnet_conway` validator, the wording actively sent the investigation down the wrong path: it named a cause that had not occurred. On those validators the journal slow path has never executed at all — `linera_journal_slowpath_count`, `linera_journal_resolution_failures` and `linera_value_split_count` have no series (they are `LazyLock` counters, registered only on first increment), while `linera_journal_fastpath_count` is in the 10^8 range. Every poison event observed there came from a Scylla `WriteTimeout`.

## Proposal

Reword the error message and the three doc comments to describe the actual condition — the operation may or may not have been applied, so the view must be reloaded — without naming a specific backend or cause:

- `linera-core/src/worker.rs` — `PoisonedWorker` message
- `linera-views/src/error.rs` — `StoreError::must_reload_view` field doc
- `linera-views/src/error.rs` — `ViewError::must_reload_view()` doc
- `linera-views/src/store.rs` — `KeyValueStoreError::must_reload_view()` trait doc

No behaviour, signature or name changes. The `JOURNAL_RESOLUTION_FAILURES` metric descriptions are deliberately left alone: those genuinely are about journal resolution.

## Test Plan

Text-only change (one `#[error]` string and three doc comments), so correctness rests on it still compiling and on the wording matching the code paths that set the flag.

- `cargo check -p linera-views -p linera-core --all-features` — clean
- `cargo clippy -p linera-views -p linera-core --all-features -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean (nightly because `rustfmt.toml` sets `unstable_features`, `imports_granularity` and `group_imports`)
- Verified by inspection that every `must_reload_view` implementation reaching this message is accounted for: `scylla_db.rs` (any `WriteBatchExecutionError`), `journaling.rs` (`JournalResolutionFailed`, plus delegation to the inner error), `value_splitting.rs` and `dual.rs` (both pure delegation), and the trait default (`false`).

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

Message and documentation only — no protocol or storage format change, so no new deployment is required. The `testnet_conway` companion is linked below.

## Links

- `testnet_conway` backport: #6775
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
