### PR TITLE
Backport #6774 to testnet_conway: correct the misleading journal-resolution-failure wording

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -428,7 +428,7 @@ pub enum WorkerError {
 
     #[error("Fallback mode is not available on this network")]
     NoFallbackMode,
-    #[error("Chain worker was poisoned by a journal resolution failure")]
+    #[error("Chain worker was poisoned by a failed save that may have left storage in an undetermined state")]
     PoisonedWorker,
     #[error("Cross-chain batch was rolled back due to an error in another request")]
     BatchRolledBack,

--- a/linera-views/src/error.rs
+++ b/linera-views/src/error.rs
@@ -34,7 +34,8 @@ pub enum ViewError {
         /// The inner error
         #[source]
         error: Box<dyn std::error::Error + Send + Sync>,
-        /// Whether this error was caused by a journal resolution failure.
+        /// Whether this error may have left storage in an undetermined state,
+        /// so the view must be reloaded before being used again.
         must_reload_view: bool,
     },
 
@@ -61,8 +62,8 @@ pub enum ViewError {
 }
 
 impl ViewError {
-    /// Returns `true` if this error was caused by a journal resolution failure,
-    /// which may leave storage in an inconsistent state requiring a view reload.
+    /// Returns `true` if this error may have left storage in an undetermined state,
+    /// so the view must be reloaded before being used again.
     pub fn must_reload_view(&self) -> bool {
         matches!(
             self,

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -22,8 +22,8 @@ pub trait KeyValueStoreError:
     /// The name of the backend.
     const BACKEND: &'static str;
 
-    /// Returns `true` if this error represents a journal resolution failure,
-    /// which may leave storage in an inconsistent state requiring a view reload.
+    /// Returns `true` if this error may have left storage in an undetermined state,
+    /// so the view must be reloaded before being used again.
     fn must_reload_view(&self) -> bool {
         false
     }


### PR DESCRIPTION
## Motivation

Backport of #6774 to `testnet_conway`.

`WorkerError::PoisonedWorker` renders as **"Chain worker was poisoned by a journal resolution failure"**, and the docs on `ViewError::must_reload_view`, its `StoreError` field, and the `KeyValueStoreError::must_reload_view` trait method all repeat the same claim.

That claim is wrong. Nothing in the poison path inspects the journal — `ChainWorkerState::save` sets `poisoned` for *any* error where `must_reload_view()` is true, and the flag is contributed by every backend. The dominant contributor is ScyllaDB, whose implementation says so directly:

```rust
fn must_reload_view(&self) -> bool {
    // Errors (notably timeouts) during a `write_batch` may leave the view in a
    // undetermined state where the batch may or may not have happened.
    matches!(self, Self::WriteBatchExecutionError(_))
}
```

This branch is where the wording actually costs us. Investigating a corrupted chain on validator-2 of `testnet-conway`, the message named a cause that had not occurred and sent the investigation down the wrong path. On these validators the journal slow path has **never** executed: `linera_journal_slowpath_count`, `linera_journal_resolution_failures` and `linera_value_split_count` have no series at all (they are `LazyLock` counters, registered only on first increment), while `linera_journal_fastpath_count` is in the 10^8 range. Every one of the ~500 poison events across the fleet in the last 14 days came from a Scylla `WriteTimeout { consistency: LocalQuorum, received: 0, required: 1 }` on `kv.table_linera`.

## Proposal

Reword the error message and the three doc comments to describe the actual condition — the operation may or may not have been applied, so the view must be reloaded — without naming a specific backend or cause:

- `linera-core/src/worker.rs` — `PoisonedWorker` message
- `linera-views/src/error.rs` — `StoreError::must_reload_view` field doc
- `linera-views/src/error.rs` — `ViewError::must_reload_view()` doc
- `linera-views/src/store.rs` — `KeyValueStoreError::must_reload_view()` trait doc

No behaviour, signature or name changes. The `JOURNAL_RESOLUTION_FAILURES` metric descriptions in `journaling.rs` are deliberately left alone: those genuinely are about journal resolution.

Committed directly on `testnet_conway` rather than cherry-picked, because `worker.rs` differs around the variant between the branches (`NoFallbackMode` sits immediately above it here). The resulting diff is identical to #6774: 3 files, +7/-6.

## Test Plan

Text-only change (one `#[error]` string and three doc comments), so correctness rests on it still compiling and on the wording matching the code paths that set the flag.

- `cargo clippy -p linera-views -p linera-core --all-features -- -D warnings` — clean, on this branch's pinned toolchain
- `cargo +nightly fmt --all -- --check` — clean (nightly because `rustfmt.toml` sets `unstable_features`, `imports_granularity` and `group_imports`)
- Verified by inspection that every `must_reload_view` implementation reaching this message is accounted for: `scylla_db.rs` (any `WriteBatchExecutionError`), `journaling.rs` (`JournalResolutionFailed`, plus delegation to the inner error), `value_splitting.rs` and `dual.rs` (both pure delegation), and the trait default (`false`).

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

Message and documentation only — no protocol or storage format change, so no new deployment is required.

## Links

- Backport of #6774
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
