### PR TITLE
Do not report shared-mode write batch errors as view-invalidating

### DIFF
--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -495,7 +495,7 @@ impl ScyllaDbClient {
 
     /// Issues an unlogged batch that contains only prefix-delete statements,
     /// letting the coordinator assign the write timestamp. Shared mode only.
-    async fn write_shared_batch_prefix_deletes(
+    async fn write_batch_prefix_deletes_shared(
         &self,
         root_key: &[u8],
         key_prefix_deletions: Vec<Vec<u8>>,
@@ -530,7 +530,7 @@ impl ScyllaDbClient {
 
     /// Issues an unlogged batch containing the single-key deletions and the
     /// insertions, letting the coordinator assign the write timestamp. Shared mode only.
-    async fn write_shared_simple_batch(
+    async fn write_simple_batch_shared(
         &self,
         root_key: &[u8],
         batch: SimpleUnorderedBatch,
@@ -785,18 +785,18 @@ pub enum ScyllaDbStoreInternalError {
     PrepareError(#[from] PrepareError),
 
     /// An execution error during a query (except write-batch).
-    #[error(transparent)]
-    ExecutionError(ExecutionError),
+    #[error("query execution error: {0}")]
+    ExecutionError(#[source] ExecutionError),
 
     /// An execution error during a write-batch operation on a store opened in
     /// exclusive mode, which backs a view.
-    #[error(transparent)]
-    ExclusiveWriteBatchExecutionError(ExecutionError),
+    #[error("write batch execution error (exclusive mode): {0}")]
+    ExclusiveWriteBatchExecutionError(#[source] ExecutionError),
 
     /// An execution error during a write-batch operation on a store opened in
     /// shared mode, which backs no view.
-    #[error(transparent)]
-    SharedWriteBatchExecutionError(ExecutionError),
+    #[error("write batch execution error (shared mode): {0}")]
+    SharedWriteBatchExecutionError(#[source] ExecutionError),
 
     /// A session creation error
     #[error(transparent)]
@@ -953,10 +953,10 @@ impl DirectWritableKeyValueStore for ScyllaDbStoreInternal {
             store.write_batch_exclusive(&self.root_key, batch, t).await
         } else {
             store
-                .write_shared_batch_prefix_deletes(&self.root_key, batch.key_prefix_deletions)
+                .write_batch_prefix_deletes_shared(&self.root_key, batch.key_prefix_deletions)
                 .await?;
             store
-                .write_shared_simple_batch(&self.root_key, batch.simple_unordered_batch)
+                .write_simple_batch_shared(&self.root_key, batch.simple_unordered_batch)
                 .await?;
             Ok(())
         }

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -788,9 +788,15 @@ pub enum ScyllaDbStoreInternalError {
     #[error(transparent)]
     ExecutionError(ExecutionError),
 
-    /// An execution error during a write-batch operation.
+    /// An execution error during a write-batch operation on a store opened in
+    /// exclusive mode, which backs a view.
     #[error(transparent)]
     WriteBatchExecutionError(ExecutionError),
+
+    /// An execution error during a write-batch operation on a store opened in
+    /// shared mode, which backs no view.
+    #[error(transparent)]
+    SharedWriteBatchExecutionError(ExecutionError),
 
     /// A session creation error
     #[error(transparent)]
@@ -822,12 +828,24 @@ pub enum ScyllaDbStoreInternalError {
     ZeroLengthKey,
 }
 
+impl ScyllaDbStoreInternalError {
+    /// Reclassifies a write-batch error as having been raised on a shared store.
+    fn into_shared(self) -> Self {
+        match self {
+            Self::WriteBatchExecutionError(error) => Self::SharedWriteBatchExecutionError(error),
+            other => other,
+        }
+    }
+}
+
 impl KeyValueStoreError for ScyllaDbStoreInternalError {
     const BACKEND: &'static str = "scylla_db";
 
     fn must_reload_view(&self) -> bool {
-        // Errors (notably timeouts) during a `write_batch` may leave the view in a
-        // undetermined state where the batch may or may not have happened.
+        // Errors (notably timeouts) during a `write_batch` leave it undetermined whether
+        // the batch was applied. That only invalidates in-memory state when the store
+        // backs a view, which is the case in exclusive mode; a shared store backs none,
+        // so the same ambiguity is reported as an ordinary, retryable error.
         matches!(self, Self::WriteBatchExecutionError(_))
     }
 }
@@ -946,10 +964,12 @@ impl DirectWritableKeyValueStore for ScyllaDbStoreInternal {
         } else {
             store
                 .write_batch_prefix_deletes(&self.root_key, batch.key_prefix_deletions)
-                .await?;
+                .await
+                .map_err(ScyllaDbStoreInternalError::into_shared)?;
             store
                 .write_simple_batch(&self.root_key, batch.simple_unordered_batch)
-                .await?;
+                .await
+                .map_err(ScyllaDbStoreInternalError::into_shared)?;
             Ok(())
         }
     }
@@ -1325,3 +1345,34 @@ pub type ScyllaDbStoreConfig = LruCachingConfig<ScyllaDbStoreInternalConfig>;
 
 /// The combined error type for the `ScyllaDbDatabase`.
 pub type ScyllaDbStoreError = JournalingError<ScyllaDbStoreInternalError>;
+
+#[cfg(test)]
+mod tests {
+    use scylla::errors::ExecutionError;
+
+    use super::*;
+
+    /// A write batch whose outcome is undetermined invalidates in-memory state only when
+    /// the store backs a view, which is the case in exclusive mode.
+    #[test]
+    fn write_batch_error_reloads_the_view_only_in_exclusive_mode() {
+        let exclusive =
+            ScyllaDbStoreInternalError::WriteBatchExecutionError(ExecutionError::EmptyPlan);
+        assert!(exclusive.must_reload_view());
+        assert!(!exclusive.into_shared().must_reload_view());
+    }
+
+    /// Reclassifying for a shared store leaves every other error untouched.
+    #[test]
+    fn into_shared_only_reclassifies_write_batch_errors() {
+        assert!(matches!(
+            ScyllaDbStoreInternalError::ZeroLengthKey.into_shared(),
+            ScyllaDbStoreInternalError::ZeroLengthKey
+        ));
+        assert!(matches!(
+            ScyllaDbStoreInternalError::ExecutionError(ExecutionError::EmptyPlan).into_shared(),
+            ScyllaDbStoreInternalError::ExecutionError(_)
+        ));
+        assert!(!ScyllaDbStoreInternalError::ZeroLengthKey.must_reload_view());
+    }
+}

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -494,8 +494,8 @@ impl ScyllaDbClient {
     }
 
     /// Issues an unlogged batch that contains only prefix-delete statements,
-    /// letting the coordinator assign the write timestamp.
-    async fn write_batch_prefix_deletes(
+    /// letting the coordinator assign the write timestamp. Shared mode only.
+    async fn write_shared_batch_prefix_deletes(
         &self,
         root_key: &[u8],
         key_prefix_deletions: Vec<Vec<u8>>,
@@ -524,13 +524,13 @@ impl ScyllaDbClient {
         session
             .batch(&batch_query, batch_values)
             .await
-            .map_err(ScyllaDbStoreInternalError::WriteBatchExecutionError)?;
+            .map_err(ScyllaDbStoreInternalError::SharedWriteBatchExecutionError)?;
         Ok(())
     }
 
     /// Issues an unlogged batch containing the single-key deletions and the
-    /// insertions, letting the coordinator assign the write timestamp.
-    async fn write_simple_batch(
+    /// insertions, letting the coordinator assign the write timestamp. Shared mode only.
+    async fn write_shared_simple_batch(
         &self,
         root_key: &[u8],
         batch: SimpleUnorderedBatch,
@@ -557,7 +557,7 @@ impl ScyllaDbClient {
         session
             .batch(&batch_query, batch_values)
             .await
-            .map_err(ScyllaDbStoreInternalError::WriteBatchExecutionError)?;
+            .map_err(ScyllaDbStoreInternalError::SharedWriteBatchExecutionError)?;
         Ok(())
     }
 
@@ -648,7 +648,7 @@ impl ScyllaDbClient {
         session
             .batch(&batch_query, batch_values)
             .await
-            .map_err(ScyllaDbStoreInternalError::WriteBatchExecutionError)?;
+            .map_err(ScyllaDbStoreInternalError::ExclusiveWriteBatchExecutionError)?;
         Ok(())
     }
 
@@ -791,7 +791,7 @@ pub enum ScyllaDbStoreInternalError {
     /// An execution error during a write-batch operation on a store opened in
     /// exclusive mode, which backs a view.
     #[error(transparent)]
-    WriteBatchExecutionError(ExecutionError),
+    ExclusiveWriteBatchExecutionError(ExecutionError),
 
     /// An execution error during a write-batch operation on a store opened in
     /// shared mode, which backs no view.
@@ -828,16 +828,6 @@ pub enum ScyllaDbStoreInternalError {
     ZeroLengthKey,
 }
 
-impl ScyllaDbStoreInternalError {
-    /// Reclassifies a write-batch error as having been raised on a shared store.
-    fn into_shared(self) -> Self {
-        match self {
-            Self::WriteBatchExecutionError(error) => Self::SharedWriteBatchExecutionError(error),
-            other => other,
-        }
-    }
-}
-
 impl KeyValueStoreError for ScyllaDbStoreInternalError {
     const BACKEND: &'static str = "scylla_db";
 
@@ -846,7 +836,7 @@ impl KeyValueStoreError for ScyllaDbStoreInternalError {
         // the batch was applied. That only invalidates in-memory state when the store
         // backs a view, which is the case in exclusive mode; a shared store backs none,
         // so the same ambiguity is reported as an ordinary, retryable error.
-        matches!(self, Self::WriteBatchExecutionError(_))
+        matches!(self, Self::ExclusiveWriteBatchExecutionError(_))
     }
 }
 
@@ -963,13 +953,11 @@ impl DirectWritableKeyValueStore for ScyllaDbStoreInternal {
             store.write_batch_exclusive(&self.root_key, batch, t).await
         } else {
             store
-                .write_batch_prefix_deletes(&self.root_key, batch.key_prefix_deletions)
-                .await
-                .map_err(ScyllaDbStoreInternalError::into_shared)?;
+                .write_shared_batch_prefix_deletes(&self.root_key, batch.key_prefix_deletions)
+                .await?;
             store
-                .write_simple_batch(&self.root_key, batch.simple_unordered_batch)
-                .await
-                .map_err(ScyllaDbStoreInternalError::into_shared)?;
+                .write_shared_simple_batch(&self.root_key, batch.simple_unordered_batch)
+                .await?;
             Ok(())
         }
     }
@@ -1356,23 +1344,25 @@ mod tests {
     /// the store backs a view, which is the case in exclusive mode.
     #[test]
     fn write_batch_error_reloads_the_view_only_in_exclusive_mode() {
-        let exclusive =
-            ScyllaDbStoreInternalError::WriteBatchExecutionError(ExecutionError::EmptyPlan);
-        assert!(exclusive.must_reload_view());
-        assert!(!exclusive.into_shared().must_reload_view());
+        assert!(
+            ScyllaDbStoreInternalError::ExclusiveWriteBatchExecutionError(
+                ExecutionError::EmptyPlan
+            )
+            .must_reload_view()
+        );
+        assert!(!ScyllaDbStoreInternalError::SharedWriteBatchExecutionError(
+            ExecutionError::EmptyPlan
+        )
+        .must_reload_view());
     }
 
-    /// Reclassifying for a shared store leaves every other error untouched.
+    /// No other error asks for a view reload.
     #[test]
-    fn into_shared_only_reclassifies_write_batch_errors() {
-        assert!(matches!(
-            ScyllaDbStoreInternalError::ZeroLengthKey.into_shared(),
-            ScyllaDbStoreInternalError::ZeroLengthKey
-        ));
-        assert!(matches!(
-            ScyllaDbStoreInternalError::ExecutionError(ExecutionError::EmptyPlan).into_shared(),
-            ScyllaDbStoreInternalError::ExecutionError(_)
-        ));
+    fn other_errors_do_not_reload_the_view() {
         assert!(!ScyllaDbStoreInternalError::ZeroLengthKey.must_reload_view());
+        assert!(
+            !ScyllaDbStoreInternalError::ExecutionError(ExecutionError::EmptyPlan)
+                .must_reload_view()
+        );
     }
 }


### PR DESCRIPTION
## Motivation

`must_reload_view` means "this write's outcome is undetermined, so the in-memory **view** may no longer match storage — discard it and reload". ScyllaDB sets it on any write-batch error:

```rust
fn must_reload_view(&self) -> bool {
    matches!(self, Self::WriteBatchExecutionError(_))
}
```

That is a truthful statement about the write, but the store has two modes and only one of them backs a view:

| mode | backs | `must_reload_view` |
|---|---|---|
| exclusive | `ChainStateView`, block-exporter state | meaningful |
| **shared** | raw content-addressed key/value | **there is no view to reload** |

The correspondence is exact today, not approximate. In `linera-storage` there are two non-test `open_exclusive` call sites, and both construct a view immediately (`db_storage.rs`, `RootKey::ChainState` → `ChainStateView::load`, and `RootKey::BlockExporterState` → `ViewContext::create_root_context`). There are ~21 `open_shared` call sites and **not one** builds a `ViewContext` — they are raw `put_key_value_bytes` batches against content-addressed partitions (`RootKey::Blob`, `ConfirmedBlock`, `Event`, `BlockByHeight`).

Every consumer of the flag is a worker-level decision about the chain view: `chain_read`/`chain_write` evict the chain worker (`worker.rs`), `ChainWorkerState::save` poisons it, and `classify_processing_error` routes for recovery.

So a timeout writing a blob or an event — a different partition, through a store that backs no view — currently evicts a chain worker whose in-memory state is perfectly valid.

### Why it is like this

Landing order, not design:

| date | change |
|---|---|
| 2025-06-02 | `open_exclusive`/`open_shared` split (#4036) |
| 2026-04-01 | `must_reload_view` introduced, in a journaling fix (#5892) — journal-specific at the time |
| 2026-05-19 | #6333 generalises it to ambiguous/partially-applied writes; ScyllaDB's `WriteBatchExecutionError` becomes a producer |
| 2026-05-19/21 | `is_exclusive` / `write_batch_exclusive` added (#6334/#6344), for performance — to eliminate a per-batch read |

The flag's producer set widened and the exclusive/shared write split appeared within days of each other, and which modes should produce the flag was never revisited.

### This is not hypothetical

`testnet_conway` validator-2 has a chain that has been logging `Corrupted chain state: message counter should be present` continuously since 2026-08-20. Reading that chain's state out of ScyllaDB: seven outbox queue heads have no entry in `outbox_counters`, so `mark_messages_as_received` aborts on the first height it drains and rolls the batch back, and those seven outboxes have not advanced in six days.

`WRITETIME` on the seven bad rows places all of them in a 182 ms window that ends 110-290 ms **after** the chain worker was evicted — i.e. the evicted instance was still writing while its replacement loaded. The durable state then split by write granularity, exactly as expected when two views race: `outbox_counters` is a `RegisterView` whose `pre_save` rewrites the whole value, so it regressed to the replacement's copy, while `outboxes` writes only the sub-views it loaded, so the queue entries survived. That asymmetry is measurable in storage today — counters are a strict subset of queued heights, short by precisely those seven.

No `Chain save failed` line was logged for that chain, so the eviction did not come from `save()`. It came from a `must_reload_view` error on one of the three shared-store writes in the certificate path.

## Proposal

Report the ambiguity of a shared-mode write batch as an ordinary error rather than as a view-invalidating one.

`WriteBatchExecutionError` is constructed in exactly three places, and each one belongs to exactly one mode: `write_batch_exclusive` is reached only from the exclusive branch of `write_batch`, and the other two only from the shared branch. So each site now constructs the variant that fits — `ExclusiveWriteBatchExecutionError` or `SharedWriteBatchExecutionError` — and `must_reload_view()` matches only the former. Nothing downstream changes.

The two shared-only helpers are renamed to `write_shared_batch_prefix_deletes` and `write_shared_simple_batch`, so the mode assumption is visible at the definition rather than only at the call site, and a later caller cannot reach them from the exclusive path without noticing.

Effect: `must_reload_view` can now only originate from a store that actually backs a view. A blob/event/certificate write timing out no longer evicts a healthy chain worker, so no replacement instance is loaded and the two-live-views race cannot occur. Retry is safe on that path without any reconciliation, because those partitions are content-addressed and the caller's `?` has already rolled the chain view back.

## Test Plan

```
cargo test  -p linera-views --features scylladb --lib scylla   # 2 new tests pass
cargo clippy -p linera-views --features scylladb --all-targets -- -D warnings
cargo +nightly fmt --all -- --check
```

Two unit tests, following the existing precedent in `journaling.rs`
(`journaling_error_inner_delegates_must_reload_view`):

- `write_batch_error_reloads_the_view_only_in_exclusive_mode` — the exclusive variant sets the flag, the shared one does not
- `other_errors_do_not_reload_the_view` — no other variant asks for a reload

Note `views::tests::test_queue_operations_with_scylla_db_context` fails locally without a live ScyllaDB (`Connection refused`); it is unrelated to this change.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

The `testnet_conway` backport matters: that is where the corruption above is live.

No protocol or storage format change.

## Links

- Alternative to #6762, which addresses the same failure by poisoning the three shared-store write sites so the evicted worker stops writing. This PR removes the eviction instead, so there is nothing to poison; if it lands, those three sites and `check_chain_worker_writes.sh` are no longer needed. Discussion on that PR.
- #6778 — `testnet_conway` backport, where the corruption described above is live.
- #6777 — follow-up: this PR relies on "views exist only on exclusive stores", which currently holds by convention. That issue proposes making it structural by requiring an exclusive store to build a root view.
- #6333 defined `must_reload_view`; #5892 introduced it; #6334/#6344 added the exclusive/shared write split.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
