### PR TITLE
Delegate the formation of confirmation certificates (client-side seam)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -178,6 +178,7 @@ Client implementation and command-line tool for the Linera blockchain
   Default value: `3600000`
 * `--wait-for-outgoing-messages` — Whether to wait until a quorum of validators has confirmed that all sent cross-chain messages have been delivered
 * `--allow-fast-blocks` — Whether to allow creating blocks in the fast round. Fast blocks have lower latency but must be used carefully so that there are never any conflicting fast block proposals
+* `--delegate-validator-updates` — Whether a proposer delegate also broadcasts the confirmed certificate to the validators, rather than our broadcasting it ourselves once the delegate returns it
 * `--long-lived-services` — (EXPERIMENTAL) Whether application services can persist in some cases between queries
 * `--blanket-message-policy <BLANKET_MESSAGE_POLICY>` — The policy for handling incoming messages
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -153,6 +153,11 @@ pub struct Options {
     #[arg(long)]
     pub allow_fast_blocks: bool,
 
+    /// Whether a proposer delegate also delivers a block's outgoing cross-chain messages,
+    /// rather than our delivering them ourselves once the delegate returns the certificate.
+    #[arg(long)]
+    pub delegate_message_delivery: bool,
+
     /// (EXPERIMENTAL) Whether application services can persist in some cases between queries.
     #[arg(long)]
     pub long_lived_services: bool,
@@ -377,6 +382,7 @@ impl Options {
             notification_circuit_breaker_max_probe_interval: self
                 .notification_circuit_breaker_max_probe_interval,
             max_event_stream_queries: self.max_event_stream_queries,
+            delegate_message_delivery: self.delegate_message_delivery,
         }
     }
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -153,10 +153,10 @@ pub struct Options {
     #[arg(long)]
     pub allow_fast_blocks: bool,
 
-    /// Whether a proposer delegate also delivers a block's outgoing cross-chain messages,
-    /// rather than our delivering them ourselves once the delegate returns the certificate.
+    /// Whether a proposer delegate also broadcasts the confirmed certificate to the validators,
+    /// rather than our broadcasting it ourselves once the delegate returns it.
     #[arg(long)]
-    pub delegate_message_delivery: bool,
+    pub delegate_validator_updates: bool,
 
     /// (EXPERIMENTAL) Whether application services can persist in some cases between queries.
     #[arg(long)]
@@ -382,7 +382,7 @@ impl Options {
             notification_circuit_breaker_max_probe_interval: self
                 .notification_circuit_breaker_max_probe_interval,
             max_event_stream_queries: self.max_event_stream_queries,
-            delegate_message_delivery: self.delegate_message_delivery,
+            delegate_validator_updates: self.delegate_validator_updates,
         }
     }
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -68,6 +68,7 @@ use super::{
 };
 use crate::{
     data_types::{ChainInfo, ChainInfoQuery, ClientOutcome, RoundTimeout},
+    delegate::DelegatedOutcome,
     environment::Environment,
     local_node::{LocalNodeClient, LocalNodeError},
     node::{
@@ -2299,7 +2300,7 @@ impl<Env: Environment> ChainClient<Env> {
                 match err {
                     LocalNodeError::BlobsNotFound(_) => {
                         local_node
-                            .handle_pending_blobs(self.chain_id, blobs)
+                            .handle_pending_blobs(self.chain_id, blobs.clone())
                             .await?;
                         local_node.handle_block_proposal(*proposal.clone()).await?;
                     }
@@ -2316,33 +2317,118 @@ impl<Env: Environment> ChainClient<Env> {
         let block = Block::new(proposed_block, outcome);
         // Send the query to validators.
         let submit_block_proposal_start = linera_base::time::Instant::now();
-        let certificate = if round.is_fast() {
-            let hashed_value = ConfirmedBlock::new(block);
-            self.client
-                .submit_block_proposal(committee.clone(), proposal, hashed_value)
-                .await?
-        } else {
-            let hashed_value = ValidatedBlock::new(block);
-            let certificate = self
-                .client
-                .submit_block_proposal(committee.clone(), proposal, hashed_value.clone())
-                .await?;
-            self.client.finalize_block(&committee, certificate).await?
+        // A delegate collects the votes for us, finalizes a validated certificate, and delivers
+        // the block's cross-chain messages, all from close to the validators. It cannot open a
+        // round, so whenever it stops short we form the certificate here from the same signed
+        // proposal.
+        let delegated = self
+            .try_delegated_submission(&proposal, &block, &blobs, &committee)
+            .await;
+        let (certificate, delivered) = match delegated {
+            Some(certificate) => (certificate, true),
+            None if round.is_fast() => {
+                let hashed_value = ConfirmedBlock::new(block);
+                let certificate = self
+                    .client
+                    .submit_block_proposal(committee.clone(), proposal, hashed_value)
+                    .await?;
+                (certificate, false)
+            }
+            None => {
+                let hashed_value = ValidatedBlock::new(block);
+                let certificate = self
+                    .client
+                    .submit_block_proposal(committee.clone(), proposal, hashed_value.clone())
+                    .await?;
+                let certificate = self.client.finalize_block(&committee, certificate).await?;
+                (certificate, false)
+            }
         };
         self.send_timing(submit_block_proposal_start, TimingType::SubmitBlockProposal);
         tracing::debug!(
             total_process_ms = process_start.elapsed().as_millis(),
             "process_pending_block_without_prepare completing"
         );
-        debug!(round = %certificate.round, "Sending confirmed block to validators");
         let certificate = self.client.storage_client().cache_certificate(certificate);
-        self.update_validators(Some(&committee), Some(certificate.clone()))
-            .await?;
+        if !delivered {
+            debug!(round = %certificate.round, "Sending confirmed block to validators");
+            self.update_validators(Some(&committee), Some(certificate.clone()))
+                .await?;
+        }
         // Clear the pending proposal now that the block has been committed.
         *proposal_guard = None;
         Ok(ClientOutcome::Committed(Some(CacheArc::unwrap_or_clone(
             certificate,
         ))))
+    }
+
+    /// Asks the configured delegate, if any, to carry `proposal` through the rest of the round
+    /// it was signed for, and returns the confirmation certificate it formed.
+    ///
+    /// Returns `None` when there is no delegate, when the delegate could not be reached, or
+    /// when it stopped at something that needs a new owner signature. The caller then forms the
+    /// certificate itself from the very same signed proposal: a super owner that proposes two
+    /// different blocks for one round can wedge its chain until the round times out, so a
+    /// fallback must re-submit the existing proposal rather than build another.
+    ///
+    /// The delegate is not trusted. The certificate it returns is accepted only if it carries a
+    /// quorum of this committee's signatures over the block we proposed, which is the same
+    /// check the certificate would have to pass had we collected the votes ourselves.
+    #[instrument(level = "trace", skip_all)]
+    async fn try_delegated_submission(
+        &self,
+        proposal: &BlockProposal,
+        block: &Block,
+        blobs: &[Blob],
+        committee: &Committee,
+    ) -> Option<ConfirmedBlockCertificate> {
+        let delegate = self.client.confirmation_delegate()?;
+        let address = delegate.address();
+        let outcome = delegate
+            .submit_and_confirm(
+                proposal.clone(),
+                block.clone(),
+                blobs.to_vec(),
+                self.options.cross_chain_message_delivery,
+            )
+            .await;
+        let certificate = match outcome {
+            Ok(DelegatedOutcome::Confirmed(certificate)) => *certificate,
+            Ok(DelegatedOutcome::NeedsOwner(info)) => {
+                debug!(
+                    delegate = address,
+                    round = %info.manager.current_round,
+                    "Delegate handed the proposal back; submitting it to the validators",
+                );
+                return None;
+            }
+            Err(error) => {
+                warn!(
+                    delegate = address,
+                    %error,
+                    "Delegate failed; submitting the proposal to the validators",
+                );
+                return None;
+            }
+        };
+        if certificate.block() != block {
+            warn!(
+                delegate = address,
+                "Delegate returned a certificate for a different block; \
+                 submitting the proposal to the validators",
+            );
+            return None;
+        }
+        if let Err(error) = certificate.check(committee) {
+            warn!(
+                delegate = address,
+                %error,
+                "Delegate returned an unverifiable certificate; \
+                 submitting the proposal to the validators",
+            );
+            return None;
+        }
+        Some(certificate)
     }
 
     #[expect(

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2382,7 +2382,7 @@ impl<Env: Environment> ChainClient<Env> {
         blobs: &[Blob],
         committee: &Committee,
     ) -> Option<ConfirmedBlockCertificate> {
-        let delegate = self.client.confirmation_delegate()?;
+        let delegate = self.client.proposer_delegate()?;
         let address = delegate.address();
         let outcome = delegate
             .submit_and_confirm(

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -78,6 +78,7 @@ use crate::{
     remote_node::RemoteNode,
     updater::{communicate_with_quorum, CommunicateAction, CommunicationError},
     worker::{Notification, Reason, WorkerError},
+    ProcessConfirmedBlockMode,
 };
 
 /// Options that configure the behavior of a [`ChainClient`].
@@ -2370,6 +2371,11 @@ impl<Env: Environment> ChainClient<Env> {
         ))))
     }
 
+    /// Returns the client this chain client belongs to.
+    pub fn client(&self) -> &Arc<Client<Env>> {
+        &self.client
+    }
+
     /// Returns the cross-chain message delivery mode to ask a delegate for.
     ///
     /// A delegate that does not broadcast for us is asked not to wait on delivery either, since
@@ -2388,7 +2394,7 @@ impl<Env: Environment> ChainClient<Env> {
     /// this committee's signatures over `block`, which is the same check the certificate would
     /// have to pass had we collected the votes ourselves. Handing the work back is an ordinary
     /// answer rather than a failure, and is reported as such.
-    fn accept_delegated_outcome(
+    async fn accept_delegated_outcome(
         &self,
         outcome: Result<DelegatedOutcome, NodeError>,
         block: &Block,
@@ -2431,6 +2437,24 @@ impl<Env: Environment> ChainClient<Env> {
             );
             return None;
         }
+        // Nothing has told our own node about this block yet: the round we skipped is where that
+        // normally happens. Execute it here, so that the certificate we return leaves the chain
+        // in the state it would have been in had we collected the votes ourselves.
+        if let Err(error) = self
+            .client
+            .receive_certificate_with_checked_signatures(
+                certificate.clone(),
+                ProcessConfirmedBlockMode::Execute,
+            )
+            .await
+        {
+            warn!(
+                delegate = address,
+                %error,
+                "Could not execute the delegate's certificate; going to the validators ourselves",
+            );
+            return None;
+        }
         Some(certificate)
     }
 
@@ -2461,6 +2485,7 @@ impl<Env: Environment> ChainClient<Env> {
             )
             .await;
         self.accept_delegated_outcome(outcome, block, committee, &address)
+            .await
     }
 
     /// Asks the configured delegate, if any, to carry an already validated block to a
@@ -2481,6 +2506,7 @@ impl<Env: Environment> ChainClient<Env> {
             .finalize(certificate.clone(), self.delegated_delivery())
             .await;
         self.accept_delegated_outcome(outcome, certificate.block(), committee, &address)
+            .await
     }
 
     #[expect(

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -132,12 +132,13 @@ pub struct Options {
     /// Maximum number of event stream IDs to include in a single `PreviousEventBlocks`
     /// request. Larger sets are split into multiple requests.
     pub max_event_stream_queries: usize,
-    /// Whether a proposer delegate also delivers the block's outgoing cross-chain messages.
+    /// Whether a proposer delegate also broadcasts the confirmed certificate to the validators,
+    /// in place of our own [`ChainClient::update_validators`].
     ///
-    /// Delivery is the one part of the delegated work whose result is not a certificate we can
-    /// check, so with this off we deliver the messages ourselves and the delegate saves us only
-    /// the round trips it can prove it made.
-    pub delegate_message_delivery: bool,
+    /// That broadcast is the one part of the delegated work whose result is not a certificate we
+    /// can check, so with this off we make it ourselves and the delegate saves us only the round
+    /// trips it can prove it made.
+    pub delegate_validator_updates: bool,
 }
 
 struct CircuitBreakerState {
@@ -185,7 +186,7 @@ impl Options {
             notification_circuit_breaker_initial_probe_interval: Duration::from_secs(300),
             notification_circuit_breaker_max_probe_interval: Duration::from_secs(3600),
             max_event_stream_queries: DEFAULT_MAX_EVENT_STREAM_QUERIES,
-            delegate_message_delivery: false,
+            delegate_validator_updates: false,
         }
     }
 }
@@ -2331,8 +2332,8 @@ impl<Env: Environment> ChainClient<Env> {
         let delegated = self
             .try_delegated_submission(&proposal, &block, &blobs, &committee)
             .await;
-        let (certificate, delivered) = match delegated {
-            Some(certificate) => (certificate, self.options.delegate_message_delivery),
+        let (certificate, updated_validators) = match delegated {
+            Some(certificate) => (certificate, self.options.delegate_validator_updates),
             None if round.is_fast() => {
                 let hashed_value = ConfirmedBlock::new(block);
                 let certificate = self
@@ -2357,7 +2358,7 @@ impl<Env: Environment> ChainClient<Env> {
             "process_pending_block_without_prepare completing"
         );
         let certificate = self.client.storage_client().cache_certificate(certificate);
-        if !delivered {
+        if !updated_validators {
             debug!(round = %certificate.round, "Sending confirmed block to validators");
             self.update_validators(Some(&committee), Some(certificate.clone()))
                 .await?;
@@ -2369,12 +2370,12 @@ impl<Env: Environment> ChainClient<Env> {
         ))))
     }
 
-    /// Returns the delivery mode to ask a delegate for.
+    /// Returns the cross-chain message delivery mode to ask a delegate for.
     ///
-    /// When the delegate is not trusted with delivery we ask it not to wait for one, since we
-    /// deliver the messages ourselves once it hands the certificate back.
+    /// A delegate that does not broadcast for us is asked not to wait on delivery either, since
+    /// the broadcast we make once it hands the certificate back does that waiting.
     fn delegated_delivery(&self) -> CrossChainMessageDelivery {
-        if self.options.delegate_message_delivery {
+        if self.options.delegate_validator_updates {
             self.options.cross_chain_message_delivery
         } else {
             CrossChainMessageDelivery::NonBlocking
@@ -2534,11 +2535,11 @@ impl<Env: Environment> ChainClient<Env> {
         let committee = self.local_committee().await?;
         // Finalizing needs no signature of ours, so a delegate can take the lock straight to a
         // confirmation certificate without our going to the validators at all.
-        let (certificate, delivered) = match self
+        let (certificate, updated_validators) = match self
             .try_delegated_finalization(&certificate, &committee)
             .await
         {
-            Some(certificate) => (certificate, self.options.delegate_message_delivery),
+            Some(certificate) => (certificate, self.options.delegate_validator_updates),
             None => {
                 let certificate = self
                     .client
@@ -2548,7 +2549,7 @@ impl<Env: Environment> ChainClient<Env> {
             }
         };
         let certificate = self.client.storage_client().cache_certificate(certificate);
-        if !delivered {
+        if !updated_validators {
             self.update_validators(Some(&committee), Some(certificate.clone()))
                 .await?;
         }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -41,7 +41,7 @@ use linera_chain::{
     manager::LockingBlock,
     types::{
         Block, ConfirmedBlock, ConfirmedBlockCertificate, Timeout, TimeoutCertificate,
-        ValidatedBlock,
+        ValidatedBlock, ValidatedBlockCertificate,
     },
     ChainError, ChainExecutionContext,
 };
@@ -132,6 +132,12 @@ pub struct Options {
     /// Maximum number of event stream IDs to include in a single `PreviousEventBlocks`
     /// request. Larger sets are split into multiple requests.
     pub max_event_stream_queries: usize,
+    /// Whether a proposer delegate also delivers the block's outgoing cross-chain messages.
+    ///
+    /// Delivery is the one part of the delegated work whose result is not a certificate we can
+    /// check, so with this off we deliver the messages ourselves and the delegate saves us only
+    /// the round trips it can prove it made.
+    pub delegate_message_delivery: bool,
 }
 
 struct CircuitBreakerState {
@@ -179,6 +185,7 @@ impl Options {
             notification_circuit_breaker_initial_probe_interval: Duration::from_secs(300),
             notification_circuit_breaker_max_probe_interval: Duration::from_secs(3600),
             max_event_stream_queries: DEFAULT_MAX_EVENT_STREAM_QUERIES,
+            delegate_message_delivery: false,
         }
     }
 }
@@ -2325,7 +2332,7 @@ impl<Env: Environment> ChainClient<Env> {
             .try_delegated_submission(&proposal, &block, &blobs, &committee)
             .await;
         let (certificate, delivered) = match delegated {
-            Some(certificate) => (certificate, true),
+            Some(certificate) => (certificate, self.options.delegate_message_delivery),
             None if round.is_fast() => {
                 let hashed_value = ConfirmedBlock::new(block);
                 let certificate = self
@@ -2362,18 +2369,78 @@ impl<Env: Environment> ChainClient<Env> {
         ))))
     }
 
-    /// Asks the configured delegate, if any, to carry `proposal` through the rest of the round
-    /// it was signed for, and returns the confirmation certificate it formed.
+    /// Returns the delivery mode to ask a delegate for.
     ///
-    /// Returns `None` when there is no delegate, when the delegate could not be reached, or
-    /// when it stopped at something that needs a new owner signature. The caller then forms the
+    /// When the delegate is not trusted with delivery we ask it not to wait for one, since we
+    /// deliver the messages ourselves once it hands the certificate back.
+    fn delegated_delivery(&self) -> CrossChainMessageDelivery {
+        if self.options.delegate_message_delivery {
+            self.options.cross_chain_message_delivery
+        } else {
+            CrossChainMessageDelivery::NonBlocking
+        }
+    }
+
+    /// Accepts a delegate's answer, or returns `None` so that the caller does the work itself.
+    ///
+    /// The delegate is not trusted, so its certificate is accepted only if it carries a quorum of
+    /// this committee's signatures over `block`, which is the same check the certificate would
+    /// have to pass had we collected the votes ourselves. Handing the work back is an ordinary
+    /// answer rather than a failure, and is reported as such.
+    fn accept_delegated_outcome(
+        &self,
+        outcome: Result<DelegatedOutcome, NodeError>,
+        block: &Block,
+        committee: &Committee,
+        address: &str,
+    ) -> Option<ConfirmedBlockCertificate> {
+        let certificate = match outcome {
+            Ok(DelegatedOutcome::Confirmed(certificate)) => *certificate,
+            Ok(DelegatedOutcome::NeedsOwner(info)) => {
+                debug!(
+                    delegate = address,
+                    round = %info.manager.current_round,
+                    "Delegate handed the block back; going to the validators ourselves",
+                );
+                return None;
+            }
+            Err(error) => {
+                warn!(
+                    delegate = address,
+                    %error,
+                    "Delegate failed; going to the validators ourselves",
+                );
+                return None;
+            }
+        };
+        if certificate.block() != block {
+            warn!(
+                delegate = address,
+                "Delegate returned a certificate for a different block; \
+                 going to the validators ourselves",
+            );
+            return None;
+        }
+        if let Err(error) = certificate.check(committee) {
+            warn!(
+                delegate = address,
+                %error,
+                "Delegate returned an unverifiable certificate; \
+                 going to the validators ourselves",
+            );
+            return None;
+        }
+        Some(certificate)
+    }
+
+    /// Asks the configured delegate, if any, to carry `proposal` through the rest of the round it
+    /// was signed for, and returns the confirmation certificate it formed.
+    ///
+    /// Returns `None` when there is no delegate, when the delegate could not be reached, or when
+    /// it stopped at something that needs a new owner signature. The caller then forms the
     /// certificate itself from the very same signed proposal: a super owner that proposes two
     /// different blocks for one round can wedge its chain until the round times out, so a
     /// fallback must re-submit the existing proposal rather than build another.
-    ///
-    /// The delegate is not trusted. The certificate it returns is accepted only if it carries a
-    /// quorum of this committee's signatures over the block we proposed, which is the same
-    /// check the certificate would have to pass had we collected the votes ourselves.
     #[instrument(level = "trace", skip_all)]
     async fn try_delegated_submission(
         &self,
@@ -2389,46 +2456,30 @@ impl<Env: Environment> ChainClient<Env> {
                 proposal.clone(),
                 block.clone(),
                 blobs.to_vec(),
-                self.options.cross_chain_message_delivery,
+                self.delegated_delivery(),
             )
             .await;
-        let certificate = match outcome {
-            Ok(DelegatedOutcome::Confirmed(certificate)) => *certificate,
-            Ok(DelegatedOutcome::NeedsOwner(info)) => {
-                debug!(
-                    delegate = address,
-                    round = %info.manager.current_round,
-                    "Delegate handed the proposal back; submitting it to the validators",
-                );
-                return None;
-            }
-            Err(error) => {
-                warn!(
-                    delegate = address,
-                    %error,
-                    "Delegate failed; submitting the proposal to the validators",
-                );
-                return None;
-            }
-        };
-        if certificate.block() != block {
-            warn!(
-                delegate = address,
-                "Delegate returned a certificate for a different block; \
-                 submitting the proposal to the validators",
-            );
-            return None;
-        }
-        if let Err(error) = certificate.check(committee) {
-            warn!(
-                delegate = address,
-                %error,
-                "Delegate returned an unverifiable certificate; \
-                 submitting the proposal to the validators",
-            );
-            return None;
-        }
-        Some(certificate)
+        self.accept_delegated_outcome(outcome, block, committee, &address)
+    }
+
+    /// Asks the configured delegate, if any, to carry an already validated block to a
+    /// confirmation certificate.
+    ///
+    /// This is the entry point for a caller that holds a lock rather than a fresh proposal, after
+    /// an interrupted attempt or after finding the lock on the validators. Finalization carries no
+    /// owner signature, so the delegate needs nothing from us beyond the certificate itself.
+    #[instrument(level = "trace", skip_all)]
+    async fn try_delegated_finalization(
+        &self,
+        certificate: &ValidatedBlockCertificate,
+        committee: &Committee,
+    ) -> Option<ConfirmedBlockCertificate> {
+        let delegate = self.client.proposer_delegate()?;
+        let address = delegate.address();
+        let outcome = delegate
+            .finalize(certificate.clone(), self.delegated_delivery())
+            .await;
+        self.accept_delegated_outcome(outcome, certificate.block(), committee, &address)
     }
 
     #[expect(
@@ -2481,13 +2532,26 @@ impl<Env: Environment> ChainClient<Env> {
             "Finalizing locking block"
         );
         let committee = self.local_committee().await?;
-        let certificate = self
-            .client
-            .finalize_block(&committee, certificate.clone())
-            .await?;
+        // Finalizing needs no signature of ours, so a delegate can take the lock straight to a
+        // confirmation certificate without our going to the validators at all.
+        let (certificate, delivered) = match self
+            .try_delegated_finalization(&certificate, &committee)
+            .await
+        {
+            Some(certificate) => (certificate, self.options.delegate_message_delivery),
+            None => {
+                let certificate = self
+                    .client
+                    .finalize_block(&committee, certificate.clone())
+                    .await?;
+                (certificate, false)
+            }
+        };
         let certificate = self.client.storage_client().cache_certificate(certificate);
-        self.update_validators(Some(&committee), Some(certificate.clone()))
-            .await?;
+        if !delivered {
+            self.update_validators(Some(&committee), Some(certificate.clone()))
+                .await?;
+        }
         Ok(ClientOutcome::Committed(Some(CacheArc::unwrap_or_clone(
             certificate,
         ))))

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -52,6 +52,7 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::{
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse},
+    delegate::ConfirmationDelegate,
     environment::Environment,
     local_node::{LocalNodeClient, LocalNodeError},
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode as _, ValidatorNodeProvider as _},
@@ -386,6 +387,11 @@ pub struct Client<Env: Environment> {
     chains: papaya::HashMap<ChainId, chain_client::State>,
     /// Configuration options.
     options: chain_client::Options,
+    /// A node that forms confirmation certificates on this client's behalf, if one is
+    /// configured. Everything it returns is checked here against our own committee, so a
+    /// delegate that fails or withholds costs us the fallback to forming certificates
+    /// ourselves and nothing more.
+    confirmation_delegate: Option<Arc<dyn ConfirmationDelegate>>,
 }
 
 /// Boxed future returned by `receive_sender_certificate`. It is `Send` off the `web`
@@ -458,7 +464,22 @@ impl<Env: Environment> Client<Env> {
             chain_modes,
             notifier: Arc::new(ChannelNotifier::default()),
             options,
+            confirmation_delegate: None,
         }
+    }
+
+    /// Delegates the formation of confirmation certificates to the given node.
+    ///
+    /// The client keeps forming certificates itself whenever the delegate cannot finish the
+    /// round it was given, so this only ever changes how a block is committed, never whether
+    /// the result is trusted.
+    pub fn set_confirmation_delegate(&mut self, delegate: Arc<dyn ConfirmationDelegate>) {
+        self.confirmation_delegate = Some(delegate);
+    }
+
+    /// Returns the node that forms confirmation certificates on this client's behalf, if any.
+    pub fn confirmation_delegate(&self) -> Option<&Arc<dyn ConfirmationDelegate>> {
+        self.confirmation_delegate.as_ref()
     }
 
     /// Returns the chain ID of the admin chain.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -52,7 +52,7 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use crate::{
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse},
-    delegate::ConfirmationDelegate,
+    delegate::ProposerDelegate,
     environment::Environment,
     local_node::{LocalNodeClient, LocalNodeError},
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode as _, ValidatorNodeProvider as _},
@@ -391,7 +391,7 @@ pub struct Client<Env: Environment> {
     /// configured. Everything it returns is checked here against our own committee, so a
     /// delegate that fails or withholds costs us the fallback to forming certificates
     /// ourselves and nothing more.
-    confirmation_delegate: Option<Arc<dyn ConfirmationDelegate>>,
+    proposer_delegate: Option<Arc<dyn ProposerDelegate>>,
 }
 
 /// Boxed future returned by `receive_sender_certificate`. It is `Send` off the `web`
@@ -464,7 +464,7 @@ impl<Env: Environment> Client<Env> {
             chain_modes,
             notifier: Arc::new(ChannelNotifier::default()),
             options,
-            confirmation_delegate: None,
+            proposer_delegate: None,
         }
     }
 
@@ -473,13 +473,13 @@ impl<Env: Environment> Client<Env> {
     /// The client keeps forming certificates itself whenever the delegate cannot finish the
     /// round it was given, so this only ever changes how a block is committed, never whether
     /// the result is trusted.
-    pub fn set_confirmation_delegate(&mut self, delegate: Arc<dyn ConfirmationDelegate>) {
-        self.confirmation_delegate = Some(delegate);
+    pub fn set_proposer_delegate(&mut self, delegate: Arc<dyn ProposerDelegate>) {
+        self.proposer_delegate = Some(delegate);
     }
 
     /// Returns the node that forms confirmation certificates on this client's behalf, if any.
-    pub fn confirmation_delegate(&self) -> Option<&Arc<dyn ConfirmationDelegate>> {
-        self.confirmation_delegate.as_ref()
+    pub fn proposer_delegate(&self) -> Option<&Arc<dyn ProposerDelegate>> {
+        self.proposer_delegate.as_ref()
     }
 
     /// Returns the chain ID of the admin chain.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -391,7 +391,7 @@ pub struct Client<Env: Environment> {
     /// configured. Everything it returns is checked here against our own committee, so a
     /// delegate that fails or withholds costs us the fallback to forming certificates
     /// ourselves and nothing more.
-    proposer_delegate: Option<Arc<dyn ProposerDelegate>>,
+    proposer_delegate: RwLock<Option<Arc<dyn ProposerDelegate>>>,
 }
 
 /// Boxed future returned by `receive_sender_certificate`. It is `Send` off the `web`
@@ -464,7 +464,7 @@ impl<Env: Environment> Client<Env> {
             chain_modes,
             notifier: Arc::new(ChannelNotifier::default()),
             options,
-            proposer_delegate: None,
+            proposer_delegate: RwLock::new(None),
         }
     }
 
@@ -473,13 +473,20 @@ impl<Env: Environment> Client<Env> {
     /// The client keeps forming certificates itself whenever the delegate cannot finish the
     /// round it was given, so this only ever changes how a block is committed, never whether
     /// the result is trusted.
-    pub fn set_proposer_delegate(&mut self, delegate: Arc<dyn ProposerDelegate>) {
-        self.proposer_delegate = Some(delegate);
+    pub fn set_proposer_delegate(&self, delegate: Option<Arc<dyn ProposerDelegate>>) {
+        *self
+            .proposer_delegate
+            .write()
+            .expect("Panics should not happen while holding a lock to `proposer_delegate`") =
+            delegate;
     }
 
     /// Returns the node that forms confirmation certificates on this client's behalf, if any.
-    pub fn proposer_delegate(&self) -> Option<&Arc<dyn ProposerDelegate>> {
-        self.proposer_delegate.as_ref()
+    pub fn proposer_delegate(&self) -> Option<Arc<dyn ProposerDelegate>> {
+        self.proposer_delegate
+            .read()
+            .expect("Panics should not happen while holding a lock to `proposer_delegate`")
+            .clone()
     }
 
     /// Returns the chain ID of the admin chain.
@@ -1373,7 +1380,7 @@ impl<Env: Environment> Client<Env> {
 
     /// Submits a block proposal to the validators.
     #[instrument(level = "trace", skip_all)]
-    async fn submit_block_proposal<T: ProcessableCertificate>(
+    pub(crate) async fn submit_block_proposal<T: ProcessableCertificate>(
         self: &Arc<Self>,
         committee: Arc<Committee>,
         proposal: Box<BlockProposal>,
@@ -1518,7 +1525,7 @@ impl<Env: Environment> Client<Env> {
 
     /// Broadcasts certified blocks to validators.
     #[instrument(level = "trace", skip_all, fields(chain_id, block_height, delivery))]
-    async fn communicate_chain_updates(
+    pub(crate) async fn communicate_chain_updates(
         self: &Arc<Self>,
         committee: &Committee,
         chain_id: ChainId,
@@ -1640,7 +1647,7 @@ impl<Env: Environment> Client<Env> {
     /// Processes the confirmed block certificate in the local node without checking signatures.
     /// Also downloads and processes all ancestors that are still missing.
     #[instrument(level = "trace", skip_all)]
-    async fn receive_certificate_with_checked_signatures(
+    pub(crate) async fn receive_certificate_with_checked_signatures(
         &self,
         certificate: ConfirmedBlockCertificate,
         mode: ProcessConfirmedBlockMode,
@@ -2189,7 +2196,7 @@ impl<Env: Environment> Client<Env> {
     ///
     /// Whether manager values are fetched depends on the chain's follow-only state.
     #[instrument(level = "trace", skip_all)]
-    async fn synchronize_chain_state(
+    pub(crate) async fn synchronize_chain_state(
         &self,
         chain_id: ChainId,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {

--- a/linera-core/src/delegate.rs
+++ b/linera-core/src/delegate.rs
@@ -36,21 +36,32 @@
 //! [`ProposalContent`]: linera_chain::data_types::ProposalContent
 //! [`ValidatedBlockCertificate`]: linera_chain::types::ValidatedBlockCertificate
 
+use std::sync::Arc;
+
 #[cfg(not(web))]
 use futures::future::BoxFuture;
 #[cfg(web)]
 use futures::future::LocalBoxFuture as BoxFuture;
 use linera_base::{
     data_types::Blob,
+    identifiers::ChainId,
     task::{MaybeSend, MaybeSync},
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{Block, ConfirmedBlockCertificate, ValidatedBlockCertificate},
+    types::{
+        Block, ConfirmedBlock, ConfirmedBlockCertificate, ValidatedBlock, ValidatedBlockCertificate,
+    },
 };
+use linera_execution::committee::Committee;
+use linera_storage::Storage as _;
+use tracing::{debug, warn};
 
 use crate::{
+    client::{chain_client, Client, ListeningMode},
     data_types::ChainInfo,
+    environment::Environment,
+    local_node::LocalNodeError,
     node::{CrossChainMessageDelivery, NodeError},
 };
 
@@ -118,4 +129,236 @@ pub trait ProposerDelegate: std::fmt::Debug + MaybeSend + MaybeSync {
         certificate: ValidatedBlockCertificate,
         delivery: CrossChainMessageDelivery,
     ) -> BoxFuture<'a, Result<DelegatedOutcome, NodeError>>;
+}
+
+#[cfg(test)]
+#[path = "unit_tests/delegate_tests.rs"]
+mod delegate_tests;
+
+/// Reports a failure of the delegate's own machinery, as opposed to one of the chain's rounds.
+fn internal_error(error: impl std::fmt::Display) -> NodeError {
+    NodeError::WorkerError {
+        error: error.to_string(),
+    }
+}
+
+/// A [`ProposerDelegate`] that does the work in this process, against a local [`Client`].
+///
+/// This is the delegate proper, not a handle to a remote one: a node that offers delegation over
+/// the network serves it from one of these, and a client reaching that node holds an
+/// implementation that forwards to it instead.
+///
+/// The [`Client`] it drives needs no key for the chains it serves, since nothing the delegate
+/// does is signed by an owner. It does need to be close to the validators and to hold, or be able
+/// to fetch, the blocks and blobs they turn out to be missing, because that is the work being
+/// moved off the caller.
+pub struct LocalProposerDelegate<Env: Environment> {
+    client: Arc<Client<Env>>,
+    address: String,
+}
+
+impl<Env: Environment> std::fmt::Debug for LocalProposerDelegate<Env> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalProposerDelegate")
+            .field("address", &self.address)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<Env: Environment> LocalProposerDelegate<Env> {
+    /// Creates a delegate that serves proposals from the given client, reporting `address` as
+    /// its own.
+    pub fn new(client: Arc<Client<Env>>, address: impl Into<String>) -> Self {
+        Self {
+            client,
+            address: address.into(),
+        }
+    }
+
+    /// Returns the committee of the chain's current epoch, as our local node sees it.
+    async fn committee(&self, chain_id: ChainId) -> Result<Arc<Committee>, chain_client::Error> {
+        let info = self.client.local_node.chain_info(chain_id).await?;
+        let hash = info
+            .committee_hash
+            .ok_or(LocalNodeError::InactiveChain(chain_id))?;
+        Ok(self
+            .client
+            .storage_client()
+            .get_or_load_committee_by_hash(hash)
+            .await
+            .map_err(LocalNodeError::from)?)
+    }
+
+    /// Starts following the chain and brings our view of it level with the validators.
+    ///
+    /// We serve chains we were never configured for, so the mode is extended on demand. The
+    /// chain has to be followed in full: repairing a validator that is behind can mean pushing
+    /// blocks from the chains that sent it messages, not just from this one.
+    async fn prepare(&self, chain_id: ChainId) -> Result<(), chain_client::Error> {
+        self.client
+            .extend_chain_mode(chain_id, ListeningMode::FullChain);
+        self.client.synchronize_chain_state(chain_id).await?;
+        Ok(())
+    }
+
+    /// Reports the chain state we can see, for a caller that has to decide what to sign next.
+    ///
+    /// We resynchronize first, so that a timeout certificate or a locking block that appeared
+    /// while we were working is in what we hand back: those carry their own proof, and are the
+    /// part of this the caller can actually use.
+    async fn hand_back(&self, chain_id: ChainId) -> Result<DelegatedOutcome, NodeError> {
+        let info = match self.client.synchronize_chain_state(chain_id).await {
+            Ok(info) => info,
+            Err(error) => {
+                debug!(%chain_id, %error, "Could not resynchronize before handing the block back");
+                self.client
+                    .local_node
+                    .chain_info(chain_id)
+                    .await
+                    .map_err(internal_error)?
+            }
+        };
+        Ok(DelegatedOutcome::NeedsOwner(info))
+    }
+
+    /// Makes the validators aware of a block we just got confirmed.
+    ///
+    /// A delegate that formed a certificate and left the validators ignorant of it would have
+    /// done half the job, so this always runs; `delivery` only decides whether we also wait for
+    /// the block's outgoing messages to reach their inboxes. A caller that broadcasts for itself
+    /// as well loses nothing, since the operation is idempotent.
+    async fn broadcast(
+        &self,
+        chain_id: ChainId,
+        committee: &Committee,
+        certificate: &ConfirmedBlockCertificate,
+        delivery: CrossChainMessageDelivery,
+    ) {
+        let height = certificate.block().header.height;
+        let cached = self
+            .client
+            .storage_client()
+            .cache_certificate(certificate.clone());
+        if let Err(error) = self
+            .client
+            .communicate_chain_updates(committee, chain_id, height, delivery, Some(cached))
+            .await
+        {
+            // The caller's certificate is good regardless, and the validators that missed this
+            // will catch up through the usual synchronization, so this is not worth failing over.
+            warn!(%chain_id, %height, %error, "Could not broadcast the confirmed block");
+        }
+    }
+
+    /// Carries a signed proposal through the rest of its round. See
+    /// [`ProposerDelegate::submit_and_confirm`].
+    async fn run_proposal(
+        &self,
+        proposal: BlockProposal,
+        block: Block,
+        blobs: Vec<Blob>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<DelegatedOutcome, NodeError> {
+        let chain_id = proposal.content.block.chain_id;
+        let round = proposal.content.round;
+        self.prepare(chain_id).await.map_err(internal_error)?;
+        // Hold the proposal ourselves before offering it around. That is what lets us answer a
+        // validator that reports the blobs missing, since they are then ours to send.
+        self.client
+            .local_node
+            .handle_pending_blobs(chain_id, blobs)
+            .await
+            .map_err(internal_error)?;
+        if let Err(error) = self
+            .client
+            .local_node
+            .handle_block_proposal(proposal.clone())
+            .await
+        {
+            debug!(%chain_id, %round, %error, "Rejected the proposal locally");
+            return self.hand_back(chain_id).await;
+        }
+        let committee = match self.committee(chain_id).await {
+            Ok(committee) => committee,
+            Err(error) => return Err(internal_error(error)),
+        };
+        let proposal = Box::new(proposal);
+        let certificate = if round.is_fast() {
+            self.client
+                .submit_block_proposal(committee.clone(), proposal, ConfirmedBlock::new(block))
+                .await
+        } else {
+            // Nothing in finalization is signed by an owner, so we close the round ourselves
+            // rather than handing the validated certificate back for a second round trip.
+            match self
+                .client
+                .submit_block_proposal(committee.clone(), proposal, ValidatedBlock::new(block))
+                .await
+            {
+                Ok(validated) => self.client.finalize_block(&committee, validated).await,
+                Err(error) => Err(error),
+            }
+        };
+        match certificate {
+            Ok(certificate) => {
+                self.broadcast(chain_id, &committee, &certificate, delivery)
+                    .await;
+                Ok(DelegatedOutcome::Confirmed(Box::new(certificate)))
+            }
+            Err(error) => {
+                debug!(%chain_id, %round, %error, "Could not carry the proposal to a certificate");
+                self.hand_back(chain_id).await
+            }
+        }
+    }
+
+    /// Carries an already validated block to a confirmation certificate. See
+    /// [`ProposerDelegate::finalize`].
+    async fn run_finalization(
+        &self,
+        validated: ValidatedBlockCertificate,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<DelegatedOutcome, NodeError> {
+        let chain_id = validated.block().header.chain_id;
+        self.prepare(chain_id).await.map_err(internal_error)?;
+        let committee = match self.committee(chain_id).await {
+            Ok(committee) => committee,
+            Err(error) => return Err(internal_error(error)),
+        };
+        match self.client.finalize_block(&committee, validated).await {
+            Ok(certificate) => {
+                self.broadcast(chain_id, &committee, &certificate, delivery)
+                    .await;
+                Ok(DelegatedOutcome::Confirmed(Box::new(certificate)))
+            }
+            Err(error) => {
+                debug!(%chain_id, %error, "Could not finalize the validated block");
+                self.hand_back(chain_id).await
+            }
+        }
+    }
+}
+
+impl<Env: Environment> ProposerDelegate for LocalProposerDelegate<Env> {
+    fn address(&self) -> String {
+        self.address.clone()
+    }
+
+    fn submit_and_confirm<'a>(
+        &'a self,
+        proposal: BlockProposal,
+        block: Block,
+        blobs: Vec<Blob>,
+        delivery: CrossChainMessageDelivery,
+    ) -> BoxFuture<'a, Result<DelegatedOutcome, NodeError>> {
+        Box::pin(self.run_proposal(proposal, block, blobs, delivery))
+    }
+
+    fn finalize<'a>(
+        &'a self,
+        certificate: ValidatedBlockCertificate,
+        delivery: CrossChainMessageDelivery,
+    ) -> BoxFuture<'a, Result<DelegatedOutcome, NodeError>> {
+        Box::pin(self.run_finalization(certificate, delivery))
+    }
 }

--- a/linera-core/src/delegate.rs
+++ b/linera-core/src/delegate.rs
@@ -28,6 +28,11 @@
 //! as it meets something that needs a fresh owner signature it stops, hands back the chain state
 //! it observed, and leaves the next signature to the owner.
 //!
+//! A delegate joins a round wherever someone else has already supplied the authority to be there,
+//! so there are two ways in. [`ProposerDelegate::submit_and_confirm`] enters on the owner's
+//! signature over a proposal. [`ProposerDelegate::finalize`] enters on a quorum's signatures over
+//! a validated block, which is what a caller resuming an interrupted attempt has to hand.
+//!
 //! [`ProposalContent`]: linera_chain::data_types::ProposalContent
 //! [`ValidatedBlockCertificate`]: linera_chain::types::ValidatedBlockCertificate
 
@@ -41,7 +46,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::BlockProposal,
-    types::{Block, ConfirmedBlockCertificate},
+    types::{Block, ConfirmedBlockCertificate, ValidatedBlockCertificate},
 };
 
 use crate::{
@@ -98,6 +103,19 @@ pub trait ProposerDelegate: std::fmt::Debug + MaybeSend + MaybeSync {
         proposal: BlockProposal,
         block: Block,
         blobs: Vec<Blob>,
+        delivery: CrossChainMessageDelivery,
+    ) -> BoxFuture<'a, Result<DelegatedOutcome, NodeError>>;
+
+    /// Carries an already validated block to a confirmation certificate.
+    ///
+    /// This is the same work as the tail of [`submit_and_confirm`](Self::submit_and_confirm), for
+    /// a caller that holds a lock rather than a fresh proposal -- one resuming an attempt that
+    /// was interrupted, or that found the lock on the validators. Finalization carries no owner
+    /// signature at all: the certificate authorizes itself, so a delegate accepts one whatever
+    /// the caller's relation to the chain.
+    fn finalize<'a>(
+        &'a self,
+        certificate: ValidatedBlockCertificate,
         delivery: CrossChainMessageDelivery,
     ) -> BoxFuture<'a, Result<DelegatedOutcome, NodeError>>;
 }

--- a/linera-core/src/delegate.rs
+++ b/linera-core/src/delegate.rs
@@ -75,7 +75,7 @@ pub enum DelegatedOutcome {
 /// without another owner signature. It is object-safe so that a delegate can be plugged into a
 /// [`Client`](crate::Client) without every [`Environment`](crate::environment::Environment)
 /// having to name a delegate type.
-pub trait ConfirmationDelegate: std::fmt::Debug + MaybeSend + MaybeSync {
+pub trait ProposerDelegate: std::fmt::Debug + MaybeSend + MaybeSync {
     /// Returns the address of this delegate.
     fn address(&self) -> String;
 

--- a/linera-core/src/delegate.rs
+++ b/linera-core/src/delegate.rs
@@ -1,0 +1,103 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Delegated formation of confirmation certificates.
+//!
+//! A client normally forms a confirmation certificate itself: it fans its signed proposal out
+//! to every validator, aggregates the votes, and pushes the result back out so that the
+//! block's cross-chain messages are delivered. For a client far from the validators each of
+//! those steps costs a wide-area round trip, and so does every repair the fan-out needs on the
+//! way -- uploading a blob a validator is missing, or bringing a lagging validator up to the
+//! proposal's height.
+//!
+//! A delegate does that work on the client's behalf, close to the validators. It holds no
+//! signing authority of its own: the client signs the proposal, the validators sign the votes,
+//! and everything the delegate returns is a quorum-signed artifact that the client checks
+//! against its own committee. A faulty delegate can withhold or delay, but it cannot confirm a
+//! block that the owner did not sign or that the validators did not accept.
+//!
+//! The division of labour follows from how far the owner's signature reaches. The round is part
+//! of [`ProposalContent`], so only the owner can open one. Finalization carries a quorum-signed
+//! [`ValidatedBlockCertificate`] and no owner signature at all, so anyone can close one:
+//!
+//! > A delegate can always finish a round. It can never start one.
+//!
+//! Within the round its proposal was signed for, the delegate runs to completion -- collecting
+//! votes, finalizing a validated certificate, and delivering the resulting cross-chain messages
+//! -- discharging from its own storage whatever the validators turn out to be missing. As soon
+//! as it meets something that needs a fresh owner signature it stops, hands back the chain state
+//! it observed, and leaves the next signature to the owner.
+//!
+//! [`ProposalContent`]: linera_chain::data_types::ProposalContent
+//! [`ValidatedBlockCertificate`]: linera_chain::types::ValidatedBlockCertificate
+
+#[cfg(not(web))]
+use futures::future::BoxFuture;
+#[cfg(web)]
+use futures::future::LocalBoxFuture as BoxFuture;
+use linera_base::{
+    data_types::Blob,
+    task::{MaybeSend, MaybeSync},
+};
+use linera_chain::{
+    data_types::BlockProposal,
+    types::{Block, ConfirmedBlockCertificate},
+};
+
+use crate::{
+    data_types::ChainInfo,
+    node::{CrossChainMessageDelivery, NodeError},
+};
+
+/// What a delegate made of a proposal.
+#[derive(Debug)]
+pub enum DelegatedOutcome {
+    /// The delegate carried the proposal through the rest of its round.
+    ///
+    /// The certificate is quorum-signed, so the caller validates it against its own committee
+    /// instead of trusting the delegate that delivered it.
+    Confirmed(Box<ConfirmedBlockCertificate>),
+
+    /// The delegate stopped at something only the owner can resolve -- the round moved on, a
+    /// different block locked or committed at this height, or a blob it does not hold -- and
+    /// reports the chain state it observed so that the owner can decide what to sign next.
+    ///
+    /// Only the certificate-bearing fields of the [`ChainInfo`] carry their own proof:
+    /// `manager.timeout` and `manager.requested_locking`. The rest are hints from an
+    /// unauthenticated aggregator, so a caller should take the round it proposes in next from
+    /// the certificates it can check rather than from `manager.current_round`.
+    NeedsOwner(Box<ChainInfo>),
+}
+
+/// A node that forms confirmation certificates on a client's behalf.
+///
+/// The trait is deliberately narrow: one call carries one signed proposal as far as it can go
+/// without another owner signature. It is object-safe so that a delegate can be plugged into a
+/// [`Client`](crate::Client) without every [`Environment`](crate::environment::Environment)
+/// having to name a delegate type.
+pub trait ConfirmationDelegate: std::fmt::Debug + MaybeSend + MaybeSync {
+    /// Returns the address of this delegate.
+    fn address(&self) -> String;
+
+    /// Carries a signed proposal through the rest of the round it was signed for.
+    ///
+    /// `block` is the proposed block paired with the execution outcome the caller has already
+    /// computed, so that the delegate can build the value that a certificate needs without
+    /// executing the block itself. Supplying the wrong outcome gains a caller nothing: the
+    /// resulting value hash will not match the votes, and the attempt fails.
+    ///
+    /// `blobs` are the blobs the block publishes. The delegate may have to upload them to
+    /// validators that have not seen them, and for a newly published blob it has no other
+    /// source.
+    ///
+    /// Returning [`DelegatedOutcome::NeedsOwner`] is an ordinary outcome rather than a failure.
+    /// An `Err` means the delegate itself could not be reached or misbehaved, and the caller
+    /// should fall back to forming the certificate itself.
+    fn submit_and_confirm<'a>(
+        &'a self,
+        proposal: BlockProposal,
+        block: Block,
+        blobs: Vec<Blob>,
+        delivery: CrossChainMessageDelivery,
+    ) -> BoxFuture<'a, Result<DelegatedOutcome, NodeError>>;
+}

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod client;
 pub use client::Client;
 /// Data types exchanged between clients, workers, and validator nodes.
 pub mod data_types;
+pub mod delegate;
 pub mod join_set_ext;
 mod local_node;
 /// Traits for communicating with validator nodes.

--- a/linera-core/src/unit_tests/delegate_tests.rs
+++ b/linera-core/src/unit_tests/delegate_tests.rs
@@ -1,0 +1,374 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for delegating the formation of confirmation certificates.
+//!
+//! A delegate is never trusted, so each test asks the same two questions: did the block get
+//! committed, and did it get committed to the *right* value. A delegate that lies, fails, or
+//! hands the work back must cost the client a fallback and nothing else.
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+#[cfg(not(web))]
+use futures::future::BoxFuture;
+#[cfg(web)]
+use futures::future::LocalBoxFuture as BoxFuture;
+use linera_base::{
+    crypto::InMemorySigner,
+    data_types::{Amount, Blob, BlockHeight},
+    identifiers::{Account, AccountOwner, ChainId},
+};
+use linera_chain::{
+    data_types::BlockProposal,
+    manager::LockingBlock,
+    types::{Block, ConfirmedBlockCertificate, ValidatedBlockCertificate},
+};
+use test_case::test_case;
+
+use crate::{
+    client::chain_client,
+    data_types::ChainInfo,
+    delegate::{DelegatedOutcome, LocalProposerDelegate, ProposerDelegate},
+    environment::Impl,
+    node::{CrossChainMessageDelivery, NodeError},
+    test_utils::{
+        ClientOutcomeResultExt as _, FaultType, MemoryStorageBuilder, NodeProvider, StorageBuilder,
+        TestBuilder,
+    },
+};
+
+/// The environment a [`TestBuilder`]'s clients run in.
+type TestEnv<S> = Impl<S, NodeProvider<S>>;
+
+/// Options that route block commits through a delegate, including the block's broadcast.
+fn delegating_options() -> chain_client::Options {
+    chain_client::Options {
+        delegate_validator_updates: true,
+        ..chain_client::Options::test_default()
+    }
+}
+
+/// Builds a delegate backed by its own client, which starts out knowing only the genesis state
+/// and has to catch up with the validators the way a real one would.
+async fn make_delegate<B: StorageBuilder>(
+    builder: &mut TestBuilder<B>,
+    chain_id: ChainId,
+) -> anyhow::Result<Arc<LocalProposerDelegate<TestEnv<B::Storage>>>> {
+    let host = builder
+        .make_client(chain_id, None, BlockHeight::ZERO)
+        .await?;
+    Ok(Arc::new(LocalProposerDelegate::new(
+        host.client().clone(),
+        "delegate",
+    )))
+}
+
+/// A delegate that answers whatever it was built with, and counts the calls it was asked to make.
+#[derive(Debug)]
+struct StubDelegate {
+    answer: StubAnswer,
+    calls: AtomicUsize,
+}
+
+#[derive(Debug)]
+enum StubAnswer {
+    /// Hand the block straight back, as a delegate does when the round has moved on.
+    NeedsOwner(Box<ChainInfo>),
+    /// Return a certificate for some other block than the one that was proposed.
+    WrongBlock(Box<ConfirmedBlockCertificate>),
+    /// Fail outright, as an unreachable delegate does.
+    Unreachable,
+}
+
+impl StubDelegate {
+    fn new(answer: StubAnswer) -> Arc<Self> {
+        Arc::new(Self {
+            answer,
+            calls: AtomicUsize::new(0),
+        })
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+
+    fn answer(&self) -> Result<DelegatedOutcome, NodeError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        match &self.answer {
+            StubAnswer::NeedsOwner(info) => Ok(DelegatedOutcome::NeedsOwner(info.clone())),
+            StubAnswer::WrongBlock(certificate) => {
+                Ok(DelegatedOutcome::Confirmed(certificate.clone()))
+            }
+            StubAnswer::Unreachable => Err(NodeError::ClientIoError {
+                error: "delegate is unreachable".to_string(),
+            }),
+        }
+    }
+}
+
+impl ProposerDelegate for StubDelegate {
+    fn address(&self) -> String {
+        "stub".to_string()
+    }
+
+    fn submit_and_confirm<'a>(
+        &'a self,
+        _proposal: BlockProposal,
+        _block: Block,
+        _blobs: Vec<Blob>,
+        _delivery: CrossChainMessageDelivery,
+    ) -> BoxFuture<'a, Result<DelegatedOutcome, NodeError>> {
+        Box::pin(async move { self.answer() })
+    }
+
+    fn finalize<'a>(
+        &'a self,
+        _certificate: ValidatedBlockCertificate,
+        _delivery: CrossChainMessageDelivery,
+    ) -> BoxFuture<'a, Result<DelegatedOutcome, NodeError>> {
+        Box::pin(async move { self.answer() })
+    }
+}
+
+/// A delegate carries a proposal through both rounds and the block commits, with the client
+/// never talking to a validator about it.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_delegate_commits_a_block<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let mut sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    *sender.options_mut() = delegating_options();
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let delegate = make_delegate(&mut builder, sender.chain_id()).await?;
+    sender.client().set_proposer_delegate(Some(delegate));
+
+    let certificate = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(1),
+            Account::chain(recipient.chain_id()),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    // The default test options skip the fast round, so this went through the two-round path:
+    // the delegate collected the validation votes and then closed the round itself.
+    assert!(!certificate.round().is_fast());
+    assert_eq!(certificate.block().header.height, BlockHeight(0));
+    assert_eq!(sender.local_balance().await?, Amount::from_tokens(3));
+    // Everyone heard about it, so the delegate's broadcast stood in for our own.
+    for index in 0..4 {
+        assert_eq!(
+            builder.next_block_height(index, sender.chain_id()).await,
+            BlockHeight(1)
+        );
+    }
+    Ok(())
+}
+
+/// The same, in the fast round, where validators vote to confirm directly and there is no
+/// validated certificate to finalize.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_delegate_commits_a_fast_block<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let mut sender = builder
+        .add_root_chain_with_ownership(
+            1,
+            Amount::from_tokens(4),
+            linera_base::ownership::ChainOwnership::single_super,
+        )
+        .await?;
+    *sender.options_mut() = chain_client::Options {
+        allow_fast_blocks: true,
+        ..delegating_options()
+    };
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let delegate = make_delegate(&mut builder, sender.chain_id()).await?;
+    sender.client().set_proposer_delegate(Some(delegate));
+
+    let certificate = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(1),
+            Account::chain(recipient.chain_id()),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    assert!(certificate.round().is_fast());
+    assert_eq!(sender.local_balance().await?, Amount::from_tokens(3));
+    Ok(())
+}
+
+/// A delegate takes a lock left behind by an interrupted attempt straight to a confirmation
+/// certificate, which is the entry point a client resuming work has to use.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_delegate_finalizes_a_lock<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let mut sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    *sender.options_mut() = delegating_options();
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+
+    // Two of four validators withhold their confirmation vote, so the block gets validated but
+    // never confirmed and the attempt leaves a lock behind.
+    builder.set_fault_type([2, 3], FaultType::DontSendConfirmVote);
+    let interrupted = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(1),
+            Account::chain(recipient.chain_id()),
+        )
+        .await;
+    assert!(interrupted.is_err());
+    let manager = sender.chain_info_with_manager_values().await?.manager;
+    let locking = *manager
+        .requested_locking
+        .expect("the interrupted attempt should have left a lock");
+    assert!(matches!(locking, LockingBlock::Regular(_)));
+
+    // With the validators answering again, the delegate closes the round on our behalf. We
+    // never form the confirmation certificate ourselves.
+    builder.set_fault_type([2, 3], FaultType::Honest);
+    let delegate = make_delegate(&mut builder, sender.chain_id()).await?;
+    sender.client().set_proposer_delegate(Some(delegate));
+
+    let certificate = sender
+        .process_pending_block()
+        .await
+        .unwrap_ok_committed()
+        .expect("the locking block should have been finalized");
+    assert_eq!(certificate.block().header.height, BlockHeight(0));
+    assert_eq!(sender.local_balance().await?, Amount::from_tokens(3));
+    Ok(())
+}
+
+/// A delegate that hands the block back costs us a fallback, not the block.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_client_falls_back_when_the_delegate_hands_back<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let mut sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    *sender.options_mut() = delegating_options();
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+
+    let info = sender.chain_info_with_manager_values().await?;
+    let stub = StubDelegate::new(StubAnswer::NeedsOwner(info));
+    sender.client().set_proposer_delegate(Some(stub.clone()));
+
+    let certificate = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(1),
+            Account::chain(recipient.chain_id()),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    assert!(stub.calls() > 0, "the delegate should have been asked");
+    assert_eq!(certificate.block().header.height, BlockHeight(0));
+    assert_eq!(sender.local_balance().await?, Amount::from_tokens(3));
+    Ok(())
+}
+
+/// An unreachable delegate costs us a fallback, not the block.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_client_falls_back_when_the_delegate_fails<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let mut sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    *sender.options_mut() = delegating_options();
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+
+    let stub = StubDelegate::new(StubAnswer::Unreachable);
+    sender.client().set_proposer_delegate(Some(stub.clone()));
+
+    let certificate = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(1),
+            Account::chain(recipient.chain_id()),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    assert!(stub.calls() > 0, "the delegate should have been asked");
+    assert_eq!(certificate.block().header.height, BlockHeight(0));
+    assert_eq!(sender.local_balance().await?, Amount::from_tokens(3));
+    Ok(())
+}
+
+/// A delegate that returns a real certificate for the wrong block is refused, and the block we
+/// actually proposed is the one that commits.
+///
+/// The certificate here is genuine and carries a real quorum, so only the check against the
+/// block we proposed can catch it. That is the check that makes delegation safe to enable
+/// without trusting whoever runs the delegate.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_client_refuses_a_certificate_for_a_different_block<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let mut sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    *sender.options_mut() = delegating_options();
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+
+    // Commit one block the honest way, to have a real certificate for the wrong block.
+    let first = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(1),
+            Account::chain(recipient.chain_id()),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    let stub = StubDelegate::new(StubAnswer::WrongBlock(Box::new(first.clone())));
+    sender.client().set_proposer_delegate(Some(stub.clone()));
+
+    let second = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(1),
+            Account::chain(recipient.chain_id()),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    assert!(stub.calls() > 0, "the delegate should have been asked");
+    assert_ne!(second.hash(), first.hash());
+    assert_eq!(second.block().header.height, BlockHeight(1));
+    assert_eq!(sender.local_balance().await?, Amount::from_tokens(2));
+    Ok(())
+}

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -100,7 +100,7 @@ service ValidatorWorker {
 // storage whatever the validators turn out to be missing. The round is covered by the owner's
 // signature, so a delegate can never open one; anything that needs a new signature goes back to
 // the owner as the chain state the delegate observed.
-service ConfirmationDelegate {
+service ProposerDelegate {
   // Carry a signed proposal through the rest of the round it was signed for.
   rpc SubmitAndConfirm(DelegatedProposal) returns (DelegatedOutcomeResult);
 }

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -88,6 +88,59 @@ service ValidatorWorker {
   rpc HandleCrossChainRequest(CrossChainRequest) returns (google.protobuf.Empty);
 }
 
+// A service that forms confirmation certificates on behalf of a client.
+//
+// The delegate holds no signing authority of its own. The client signs the proposal, the
+// validators sign the votes, and every value the delegate returns carries a quorum of validator
+// signatures that the client checks against its own committee. A faulty delegate can withhold or
+// delay, but it cannot confirm a block the owner did not sign or the validators did not accept.
+//
+// A delegate finishes the round its proposal was signed for: it collects the votes, finalizes a
+// validated certificate, and delivers the block's cross-chain messages, resolving from its own
+// storage whatever the validators turn out to be missing. The round is covered by the owner's
+// signature, so a delegate can never open one; anything that needs a new signature goes back to
+// the owner as the chain state the delegate observed.
+service ConfirmationDelegate {
+  // Carry a signed proposal through the rest of the round it was signed for.
+  rpc SubmitAndConfirm(DelegatedProposal) returns (DelegatedOutcomeResult);
+}
+
+// A signed proposal, together with everything a delegate needs to form a certificate from it.
+message DelegatedProposal {
+  // The ID of the chain (used for routing).
+  ChainId chain_id = 1;
+
+  // The signed proposal to carry.
+  BlockProposal proposal = 2;
+
+  // bincode-encoded `Block`: the proposed block paired with the execution outcome the client has
+  // already computed, so that the delegate can build the value a certificate is over without
+  // executing the block itself. A wrong outcome costs the sender the attempt and nothing else,
+  // since the resulting value hash does not match the votes.
+  bytes block = 3;
+
+  // The blobs the block publishes. A newly published blob has no other source, so the delegate
+  // uploads these to the validators that have not seen them.
+  repeated BlobContent blobs = 4;
+
+  // Whether to wait for the delivery of the block's outgoing cross-chain messages.
+  bool blocking_delivery = 5;
+}
+
+message DelegatedOutcomeResult {
+  oneof inner {
+    // The delegate finished the round: a confirmation certificate for the proposed block.
+    Certificate confirmed = 1;
+
+    // The delegate stopped at something that needs a new owner signature, and reports the chain
+    // state it observed. Only the certificates within it carry their own proof.
+    ChainInfoResponse needs_owner = 2;
+
+    // a bincode wrapper around `NodeError`
+    bytes error = 3;
+  }
+}
+
 // How to communicate with a validator or a local node.
 service ValidatorNode {
   // Propose a new block.


### PR DESCRIPTION
## Motivation

A client forms confirmation certificates itself: it fans its signed proposal out to every
validator, aggregates the votes, and pushes the result back out so the block's cross-chain
messages are delivered. For a client far from the validators, every one of those steps is a
wide-area round trip, and so is every repair the fan-out needs along the way — uploading a blob
a validator is missing, or bringing a lagging validator up to the proposal's height.

Outside the fast round that is three quorum round trips per block (submit, finalize, deliver),
plus one more per repair. The repairs are the expensive part in practice: they are sequential,
and `MissingCrossChainUpdate` needs the *sender* chain's certificates before the proposal can be
retried at all.

This adds the client-side half of an extension that lets a client hand that work to a delegate
sitting close to the validators.

## Proposal

The split follows from how far the owner's signature reaches. The round is part of
`ProposalContent`, so only the owner can open one. Finalization carries a quorum-signed
`ValidatedBlockCertificate` and no owner signature at all, so anyone can close one:

> A delegate can always finish a round. It can never start one.

Within the round its proposal was signed for, a delegate runs to completion — collecting votes,
finalizing, and delivering the cross-chain messages — discharging from its own storage whatever
the validators turn out to be missing. As soon as it meets something that needs a fresh owner
signature it stops and reports the chain state it observed.

The delegate holds no authority. The client signs the proposal, validators sign the votes, and
everything returned is a quorum-signed artifact checked against the client's own committee, so a
faulty delegate can only withhold or delay. That is what makes the seam safe to make optional:
on any failure, handback, or unverifiable answer, the client falls back to the existing quorum
path, re-submitting *the same* signed proposal — a super owner that proposes two different blocks
for one round can wedge its chain, so the fallback must never build a new one.

A delegate joins a round wherever someone else has already supplied the authority to be there,
so there are two ways in. `submit_and_confirm` enters on the owner's signature over a proposal.
`finalize` enters on a quorum's signatures over a validated block, which is what a client resuming
an interrupted attempt has to hand -- `finalize_locking_block` is reached after any attempt that
was cut short, or after synchronization absorbs a lock from the validators, and finalization
carries no owner signature at all.

Contents:

- `linera-core/src/delegate.rs` — `ProposerDelegate` and `DelegatedOutcome`. The trait is
  object-safe so a delegate can be plugged into a `Client` without every `Environment` naming a
  delegate type. `Block` is passed alongside the proposal so the delegate never has to execute:
  it builds the certified value from the outcome the client already computed, and a wrong outcome
  simply fails the value-hash check against the votes.
- `Client::set_confirmation_delegate` / `confirmation_delegate`.
- `ChainClient::try_delegated_submission` and the branch in
  `process_pending_block_without_prepare`, which now folds submit, finalize and
  `update_validators` into the single delegated call when one succeeds.
- `ChainClient::try_delegated_finalization` and the same seam in `finalize_locking_block`.
- `Options::delegate_validator_updates` (off by default, with a matching CLI flag): whether the
  delegate also broadcasts the confirmed certificate to the validators, in place of
  `update_validators`. That broadcast is the one part of the delegated work whose result is not a
  certificate we can check, so with it off we make it ourselves and the delegate saves only the
  round trips it can prove it made.
- `rpc.proto`: a `ProposerDelegate` service, deliberately narrow like `ValidatorRelay`.
- `LocalProposerDelegate`: the delegate itself, driving a `Client` that needs no key for the
  chains it serves. It follows the chain on demand (`extend_chain_mode`), synchronizes, holds the
  proposal locally so it can answer a validator that reports the blobs missing, then submits,
  finalizes and broadcasts. Any consensus-level failure is resynchronized and handed back as
  `NeedsOwner`; `Err` is reserved for the delegate's own machinery failing.

There is no transport for the new service yet, so a delegate is reachable only in-process; the
gRPC layer is a thin adapter over `LocalProposerDelegate` and comes next. With no delegate
configured, every path is byte-for-byte the existing one.

Deliberately excluded: the pull-side quorum sweeps (`find_received_certificates`,
`sync_publisher_chain_events`). Those return an assertion of *completeness* rather than a
self-authenticating artifact — `sync_publisher_chain_events` relies on at least one honest
validator in the quorum holding any confirmed event — and a single delegate cannot reproduce that
guarantee, because an omission is not detectable or attributable. Chain-body download
(`synchronize_up_to`, `synchronize_chain_state_from_committee`) is hash-linked and so is
delegable later against a quorum-established tip; that is not in this PR.

## Test Plan

`linera-core/src/unit_tests/delegate_tests.rs`, six tests, all against `TestBuilder` with four
validators. Each asks the same two questions: did the block commit, and did it commit to the
right value.

Against a real `LocalProposerDelegate`, backed by its own client that starts from genesis and has
to catch up with the validators the way a real one would:

- `test_delegate_commits_a_block` — the two-round path: the delegate collects the validation
  votes, closes the round itself, and its broadcast reaches all four validators.
- `test_delegate_commits_a_fast_block` — the fast round, where there is no validated certificate
  to finalize.
- `test_delegate_finalizes_a_lock` — two validators withhold their confirmation vote, leaving a
  lock behind; with them answering again the delegate takes that lock to a certificate through
  `finalize`, which is the entry point a resuming client needs.

Against a stub delegate, for the paths where the delegate is faulty:

- `test_client_falls_back_when_the_delegate_hands_back`
- `test_client_falls_back_when_the_delegate_fails`
- `test_client_refuses_a_certificate_for_a_different_block` — the certificate is genuine and
  carries a real quorum, so only the check against the block we proposed can catch it.

The full `linera-core` lib suite passes (199 tests), along with `cargo +nightly fmt --check` and
`clippy --all-targets -D warnings`.

Writing these caught a real bug: the client verified the delegate's certificate but never
executed it locally, since the round it skipped is where that normally happens. Its own balance
never moved. `accept_delegated_outcome` now runs
`receive_certificate_with_checked_signatures(.., Execute)` and falls back if that fails.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

Backport to `testnet_conway` is intended once the delegate implementation lands, so it can sit
next to the block exporter that already replays certificates and blobs into validators.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
