### PR TITLE
Open the partition inside create_root_context so views require an exclusive store

### DIFF
--- a/linera-indexer/lib/src/plugin.rs
+++ b/linera-indexer/lib/src/plugin.rs
@@ -78,10 +78,7 @@ where
     D::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
 {
     let root_key = name.as_bytes().to_vec();
-    let store = database
-        .open_exclusive(&root_key)
-        .map_err(|_e| IndexerError::OpenExclusiveError)?;
-    let context = ViewContext::create_root_context(store, ())
+    let context = ViewContext::create_root_context(&database, &root_key, ())
         .await
         .map_err(|e| IndexerError::ViewError(e.into()))?;
     let plugin = V::load(context).await?;

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -766,8 +766,8 @@ where
             user_services: self.user_services.clone(),
         };
         let root_key = RootKey::ChainState(chain_id).bytes();
-        let store = self.database.open_exclusive(&root_key)?;
-        let context = ViewContext::create_root_context(store, runtime_context).await?;
+        let context =
+            ViewContext::create_root_context(&*self.database, &root_key, runtime_context).await?;
         ChainStateView::load(context).await
     }
 
@@ -1580,8 +1580,7 @@ where
         block_exporter_id: u32,
     ) -> Result<Self::BlockExporterContext, ViewError> {
         let root_key = RootKey::BlockExporterState(block_exporter_id).bytes();
-        let store = self.database.open_exclusive(&root_key)?;
-        Ok(ViewContext::create_root_context(store, block_exporter_id).await?)
+        Ok(ViewContext::create_root_context(&*self.database, &root_key, block_exporter_id).await?)
     }
 
     async fn list_blob_ids(&self) -> Result<Vec<BlobId>, ViewError> {

--- a/linera-views/benches/queue_view.rs
+++ b/linera-views/benches/queue_view.rs
@@ -61,8 +61,7 @@ where
     D::Store: ReadableKeyValueStore + WritableKeyValueStore + Clone + 'static,
 {
     let database = D::connect_test_namespace().await.unwrap();
-    let store = database.open_shared(&[]).unwrap();
-    let context = ViewContext::<(), D::Store>::create_root_context(store, ())
+    let context = ViewContext::<(), D::Store>::create_root_context(&database, &[], ())
         .await
         .unwrap();
     let mut total_time = Duration::ZERO;
@@ -133,8 +132,7 @@ where
     D::Store: ReadableKeyValueStore + WritableKeyValueStore + Clone + 'static,
 {
     let database = D::connect_test_namespace().await.unwrap();
-    let store = database.open_shared(&[]).unwrap();
-    let context = ViewContext::<(), D::Store>::create_root_context(store, ())
+    let context = ViewContext::<(), D::Store>::create_root_context(&database, &[], ())
         .await
         .unwrap();
     let mut total_time = Duration::ZERO;
@@ -210,8 +208,7 @@ where
 
     for _ in 0..iterations {
         let database = D::connect_test_namespace().await.unwrap();
-        let store = database.open_shared(&[]).unwrap();
-        let context = ViewContext::<(), D::Store>::create_root_context(store, ())
+        let context = ViewContext::<(), D::Store>::create_root_context(&database, &[], ())
             .await
             .unwrap();
 
@@ -247,8 +244,7 @@ where
 
     for _ in 0..iterations {
         let database = D::connect_test_namespace().await.unwrap();
-        let store = database.open_shared(&[]).unwrap();
-        let context = ViewContext::<(), D::Store>::create_root_context(store, ())
+        let context = ViewContext::<(), D::Store>::create_root_context(&database, &[], ())
             .await
             .unwrap();
 

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -8,7 +8,10 @@ use serde::{de::DeserializeOwned, Serialize};
 use crate::{
     batch::DeletePrefixExpander,
     memory::MemoryStore,
-    store::{KeyValueStoreError, ReadableKeyValueStore, WithError, WritableKeyValueStore},
+    store::{
+        KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore, WithError,
+        WritableKeyValueStore,
+    },
     views::MIN_VIEW_TAG,
 };
 
@@ -169,10 +172,21 @@ impl<E, S> ViewContext<E, S>
 where
     S: ReadableKeyValueStore + WritableKeyValueStore,
 {
-    /// Creates a context suitable for a root view, using the given store. If the
-    /// journal's store is non-empty, it will be cleared first, before the context is
-    /// returned.
-    pub async fn create_root_context(store: S, extra: E) -> Result<Self, S::Error> {
+    /// Creates a context suitable for a root view over the partition at `root_key`,
+    /// which is opened in exclusive mode. If the journal is non-empty, it is cleared
+    /// first, before the context is returned.
+    ///
+    /// Taking the database rather than an already-opened store is what keeps a view
+    /// from being backed by a shared partition: the caller never chooses the mode.
+    pub async fn create_root_context<D>(
+        database: &D,
+        root_key: &[u8],
+        extra: E,
+    ) -> Result<Self, S::Error>
+    where
+        D: KeyValueDatabase<Store = S> + WithError<Error = S::Error>,
+    {
+        let store = database.open_exclusive(root_key)?;
         store.clear_journal().await?;
         Ok(Self::new_unchecked(store, Vec::new(), extra))
     }

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -148,8 +148,8 @@ pub trait KeyValueDatabase: WithError + linera_base::util::traits::AutoTraits + 
     /// The configuration needed to interact with a new backend.
     type Config: Send + Sync;
 
-    /// The result of opening a partition.
-    type Store;
+    /// The result of opening a partition. Its errors are the database's errors.
+    type Store: WithError<Error = Self::Error>;
 
     /// The name of this database.
     fn get_name() -> String;

--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -204,8 +204,7 @@ impl TestContextFactory for RocksDbContextFactory {
         let config = RocksDbDatabase::new_test_config().await?;
         let namespace = generate_test_namespace();
         let database = RocksDbDatabase::recreate_and_connect(&config, &namespace).await?;
-        let store = database.open_shared(&[])?;
-        let context = ViewContext::create_root_context(store, ()).await?;
+        let context = ViewContext::create_root_context(&database, &[], ()).await?;
 
         Ok(context)
     }
@@ -222,8 +221,7 @@ impl TestContextFactory for ScyllaDbContextFactory {
         let config = ScyllaDbDatabase::new_test_config().await?;
         let namespace = generate_test_namespace();
         let database = ScyllaDbDatabase::recreate_and_connect(&config, &namespace).await?;
-        let store = database.open_shared(&[])?;
-        let context = ViewContext::create_root_context(store, ()).await?;
+        let context = ViewContext::create_root_context(&database, &[], ()).await?;
         Ok(context)
     }
 }

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -84,8 +84,7 @@ impl StateStorage for MemoryTestStorage {
     async fn load(&mut self, id: usize) -> Result<StateView<Self::Context>, ViewError> {
         self.accessed_chains.insert(id);
         let root_key = bcs::to_bytes(&id)?;
-        let store = self.database.open_exclusive(&root_key)?;
-        let context = ViewContext::create_root_context(store, id).await?;
+        let context = ViewContext::create_root_context(&self.database, &root_key, id).await?;
         StateView::load(context).await
     }
 }
@@ -137,8 +136,7 @@ impl StateStorage for LruMemoryStorage {
     async fn load(&mut self, id: usize) -> Result<StateView<Self::Context>, ViewError> {
         self.accessed_chains.insert(id);
         let root_key = bcs::to_bytes(&id)?;
-        let store = self.database.open_exclusive(&root_key)?;
-        let context = ViewContext::create_root_context(store, id).await?;
+        let context = ViewContext::create_root_context(&self.database, &root_key, id).await?;
         StateView::load(context).await
     }
 }
@@ -165,8 +163,7 @@ impl StateStorage for RocksDbTestStorage {
     async fn load(&mut self, id: usize) -> Result<StateView<Self::Context>, ViewError> {
         self.accessed_chains.insert(id);
         let root_key = bcs::to_bytes(&id)?;
-        let store = self.database.open_exclusive(&root_key)?;
-        let context = ViewContext::create_root_context(store, id).await?;
+        let context = ViewContext::create_root_context(&self.database, &root_key, id).await?;
         StateView::load(context).await
     }
 }
@@ -193,8 +190,7 @@ impl StateStorage for ScyllaDbTestStorage {
     async fn load(&mut self, id: usize) -> Result<StateView<Self::Context>, ViewError> {
         self.accessed_chains.insert(id);
         let root_key = bcs::to_bytes(&id)?;
-        let store = self.database.open_exclusive(&root_key)?;
-        let context = ViewContext::create_root_context(store, id).await?;
+        let context = ViewContext::create_root_context(&self.database, &root_key, id).await?;
         StateView::load(context).await
     }
 }


### PR DESCRIPTION
## Motivation

Closes #6777.

`must_reload_view` means "this write's outcome is undetermined, so the in-memory **view** may no longer match storage — discard it and reload". It is only meaningful when the store backs a view, and #6776 relies on that: it stops the ScyllaDB shared path from producing the flag, on the grounds that a shared store backs none.

That holds today by convention, not by construction. `KeyValueDatabase` has a single `type Store`, and **both** `open_shared` and `open_exclusive` return it, so the mode is a runtime property of the value and nothing stops a view being built on a shared partition.

Two places already depend on the convention:

- #6776's classification in `ScyllaDbStoreInternalError::must_reload_view`
- `JournalingKeyValueStore::clear_journal`, which produces `JournalResolutionFailed` (→ `must_reload_view: true`) with no exclusivity check, unlike its sibling `write_batch`, which has exactly that check three lines away

And it was already being violated. `linera-views/src/views/unit_tests/views.rs` and `linera-views/benches/queue_view.rs` both did `open_shared(&[])` and then `create_root_context` — six call sites building views on shared partitions. They compile fine today; after this change they do not.

## Proposal

Stop passing `create_root_context` a store. Give it the database and a root key, and let it open the partition itself — always exclusively. The caller never chooses the mode, so it cannot choose wrong.

```rust
-    pub async fn create_root_context(store: S, extra: E) -> Result<Self, S::Error> {
-        store.clear_journal().await?;
-        Ok(Self::new_unchecked(store, Vec::new(), extra))
-    }
+    pub async fn create_root_context<D>(
+        database: &D,
+        root_key: &[u8],
+        extra: E,
+    ) -> Result<Self, S::Error>
+    where
+        D: KeyValueDatabase<Store = S> + WithError<Error = S::Error>,
+    {
+        let store = database.open_exclusive(root_key)?;
+        store.clear_journal().await?;
+        Ok(Self::new_unchecked(store, Vec::new(), extra))
+    }
```

This needs one supporting change. The bound `WithError<Error = S::Error>` cannot be discharged by a generic caller today, because the trait never states that a store's errors are its database's errors:

```rust
-    /// The result of opening a partition.
-    type Store;
+    /// The result of opening a partition. Its errors are the database's errors.
+    type Store: WithError<Error = Self::Error>;
```

Every backend already satisfies this — no backend needed changing — but it was not written down, so `<D::Store as WithError>::Error` and `<D as WithError>::Error` were formally unrelated. Worth stating regardless of this PR.

### Alternatives considered

- **Marker trait** (`ExclusiveStore: KeyValueStore`) — impossible: both openers return the same concrete `Self::Store`, so there is nothing to implement differentially. This is what rules out the cheapest option and forces the rest.
- **Newtype `Exclusive<S>`** returned by `open_exclusive` and demanded by `create_root_context` — same guarantee, but needs forwarding impls for `WithError`, `ReadableKeyValueStore`, `WritableKeyValueStore`, `DirectWritableKeyValueStore` and `Clone`. Worth it only if `Exclusive<S>` should travel as a concept beyond this one constructor; it does not today.
- **A second associated type** `type ExclusiveStore` — same guarantee, but all 8 `KeyValueDatabase` impls must define and produce it, and the five wrapper databases thread two store types through their generics.
- **A runtime `is_exclusive()` assertion** — requires every backend to *track* a mode only ScyllaDB currently knows, and degrades a compile-time guarantee to a runtime one.
- **A CI grep**, in the style of `scripts/check_chain_loads.sh` — enforces a call-site pattern rather than the invariant, and only within the directory it scans.

### What this does not close

`new_unchecked` stays public and unconstrained, so `open_shared(…)` → `new_unchecked` → `View::load` remains possible. It is used outside this crate — four sites in `linera-sdk`, plus `examples/matching-engine` — over `ViewContext<(), KeyValueStore>`, the WASM syscall store, which has no `KeyValueDatabase` behind it and never produces `must_reload_view`. So the remaining surface is a deliberate opt-out whose doc already says "In doubt, use `create_root_context` instead", rather than the accidental path this closes.

## Test Plan

```
cargo check --workspace --all-targets
cargo clippy -p linera-views -p linera-storage --all-targets -- -D warnings
cargo test  -p linera-views --lib
cargo +nightly fmt --all -- --check
```

The change is enforced by the type system, so the meaningful evidence is that the six pre-existing violations no longer compile and had to be corrected — see the diff in `unit_tests/views.rs` and `benches/queue_view.rs`, which now exercise exclusive partitions as they always should have.

Call sites converted: 2 in `linera-storage`, 1 in `linera-indexer`, 4 in `views_tests.rs`, 4 in `benches/queue_view.rs`, 2 in `unit_tests/views.rs`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

`create_root_context` is public API, so this is a breaking change for any out-of-tree caller; the fix is mechanical (pass the database and root key instead of an opened store). No protocol or storage format change.

## Links

- Closes #6777
- #6776 / #6778 — the change whose premise this enforces
- Follow-up worth doing separately: `JournalingKeyValueStore::clear_journal` still produces `JournalResolutionFailed` without an exclusivity check, mirroring the guard its sibling `write_batch` already has.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
