### PR TITLE
Park a chain when the destination says its copy is corrupt

### DIFF
--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -155,6 +155,18 @@ pub(crate) mod metrics {
                 "Committee members this validator is currently exporting to",
             );
 
+        /// Chains parked against a destination because retrying cannot help — the destination
+        /// returned an error no amount of resending fixes. Split by reason so a corrupted peer is
+        /// distinguishable from whatever we learn to park for next. Only a restart clears these:
+        /// the repair is manual on the destination's side, so re-arming on a timer would just
+        /// resume failing against state nobody has fixed.
+        pub static PARKED_CHAINS: IntGaugeVec =
+            register_int_gauge_vec(
+                "block_export_parked_chains",
+                "Chains parked at a destination, by park reason",
+                &["validator", "reason"],
+            );
+
         /// Lagging (chain, destination) *pairs*, which is what the queue's memory tracks — a chain
         /// behind on ten destinations costs ten times one behind on one.
         pub static LAGGING_PAIRS: IntGauge =
@@ -722,8 +734,10 @@ struct ChainDest {
     /// How many times this destination has reported a *lower* height than it had. Counted apart
     /// from `failures` because an advance clears those, and a peer alternating advance with
     /// regression would otherwise reset its own penalty on every second answer and never
-    /// escalate. Fits in `ChainDest`'s existing padding.
+    /// escalate.
     regressions: u32,
+    /// Set once the destination gives an answer no retry can fix; cleared only by a restart.
+    parked: Option<ParkReason>,
 }
 
 impl ChainDest {
@@ -851,6 +865,49 @@ enum SendOutcome {
     DestinationScoped(Box<chain_client::Error>),
     /// Our own storage failed. Nobody's health signal but ours.
     LocalScoped(Box<chain_client::Error>),
+    /// The destination cannot accept this chain and resending will never change that.
+    Unrecoverable(ParkReason, Box<chain_client::Error>),
+}
+
+/// Why a chain is parked at a destination.
+///
+/// Distinct from a chain-scoped backoff, which assumes the destination will catch up on its own:
+/// a park says retrying is pointless until a human repairs the destination.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ParkReason {
+    /// The destination's own copy of this chain is corrupt — it recomputed a block and got an
+    /// outcome the certificate contradicts. Resending the same certificate reproduces it exactly.
+    Corrupted,
+}
+
+impl ParkReason {
+    /// Stable metric label; keep these in sync with the exporter dashboard.
+    fn as_str(self) -> &'static str {
+        match self {
+            ParkReason::Corrupted => "corrupted",
+        }
+    }
+}
+
+/// Whether the destination's answer means "never retry this chain", and why.
+///
+/// Matching the rendered message is deliberate and cannot currently be avoided: `ChainError`
+/// crosses the wire through `From<ChainError> for NodeError`, whose catch-all arm converts every
+/// unmapped variant to `NodeError::ChainError { error: String }`. The type is destroyed by the
+/// *sender*, so there is nothing structured left to match on by the time it reaches us. Adding a
+/// dedicated `NodeError` variant would not help either: `NodeError` is bincode-encoded
+/// (`rpc.proto`, "a bincode wrapper around NodeError"), so variants are indexed positionally and a
+/// new one is a wire break — and the peers this exists to detect are precisely the ones on older
+/// builds, which would keep sending the stringly-typed form regardless.
+fn park_reason(error: &chain_client::Error) -> Option<ParkReason> {
+    match error {
+        chain_client::Error::RemoteNodeError(NodeError::ChainError { error })
+            if error.contains("Corrupted chain state") =>
+        {
+            Some(ParkReason::Corrupted)
+        }
+        _ => None,
+    }
 }
 
 /// The body of the process-wide export queue task.
@@ -1178,6 +1235,10 @@ where
                     .inc();
             }
             SendOutcome::ChainScoped(_) => {}
+            // One corrupt chain says nothing about the destination's health, and the peer answered
+            // us promptly to say so. Halving its window here would let a handful of bad chains
+            // throttle catch-up for every good one — the shape that made stakefi drain slowly.
+            SendOutcome::Unrecoverable(..) => {}
             SendOutcome::LocalScoped(error) => {
                 // Our storage, not the peer: leave the destination's window alone and halve the
                 // queue's own budget, so the pressure is relieved across every destination
@@ -1273,6 +1334,23 @@ where
                         );
                     }
                     SendOutcome::DestinationScoped(_) => {
+                        chain_dest.next_height = None;
+                    }
+                    SendOutcome::Unrecoverable(reason, error) => {
+                        // warn!, not debug!: unlike a chain-scoped backoff this never self-heals,
+                        // and the chain id is what the destination's operator needs to repair it.
+                        if chain_dest.parked.is_none() {
+                            warn!(
+                                %chain_id, %validator, %error, reason = reason.as_str(),
+                                "Destination cannot accept this chain and retrying cannot help; \
+                                 parking the pair until restart",
+                            );
+                            #[cfg(with_metrics)]
+                            metrics::PARKED_CHAINS
+                                .with_label_values(&[&dest.address, reason.as_str()])
+                                .inc();
+                        }
+                        chain_dest.parked = Some(*reason);
                         chain_dest.next_height = None;
                     }
                 }
@@ -1819,8 +1897,13 @@ where
             let outcome = match result {
                 Ok(next_height) => SendOutcome::Reached(next_height),
                 Err(error) if is_local_scoped(&error) => SendOutcome::LocalScoped(Box::new(error)),
-                Err(error) if is_chain_scoped(&error) => SendOutcome::ChainScoped(Box::new(error)),
-                Err(error) => SendOutcome::DestinationScoped(Box::new(error)),
+                // Before the scoped arms: an unrecoverable answer is about neither our storage nor
+                // the destination's health, and must not move either backoff.
+                Err(error) => match park_reason(&error) {
+                    Some(reason) => SendOutcome::Unrecoverable(reason, Box::new(error)),
+                    None if is_chain_scoped(&error) => SendOutcome::ChainScoped(Box::new(error)),
+                    None => SendOutcome::DestinationScoped(Box::new(error)),
+                },
             };
             (chain_id, index, generation, outcome)
         };
@@ -1871,6 +1954,12 @@ where
             let Some(chain_dest) = record.dest(index) else {
                 continue;
             };
+            if chain_dest.parked.is_some() {
+                // Drop it from `lagging` as well: a parked pair never converges, so leaving it
+                // would make every future scan walk past it forever.
+                stale.push(chain_id);
+                continue;
+            }
             let behind = chain_dest.next_height.is_none_or(|next| next < record.tip);
             if behind
                 && chain_dest.in_flight.is_none()
@@ -2390,11 +2479,17 @@ mod tests {
         assert_eq!(honest.next_height, Some(BlockHeight(40)));
     }
 
-    /// The regression counter has to be free: this is per (chain, destination), and a down peer
-    /// holds one per tracked chain.
+    /// This is per (chain, destination) and a down peer holds one per tracked chain, so growth
+    /// here is deliberate or not at all.
+    ///
+    /// 56 -> 64 when `parked` was added: the previous fields packed exactly, leaving no padding to
+    /// absorb it. The cost is 8 bytes per pair — ~10 KB at conway's observed 210 tracked chains
+    /// across 6 destinations, under 1 MB even if every one of ~19k chains were tracked at once.
+    /// Paid rather than squeezing `regressions` down to `u16`, which would have kept 56 bytes but
+    /// changed a field unrelated to parking.
     #[test]
-    fn the_regression_counter_costs_no_memory() {
-        assert_eq!(size_of::<ChainDest>(), 56);
+    fn a_chain_destination_pair_stays_small() {
+        assert_eq!(size_of::<ChainDest>(), 64);
     }
 
     /// Our own storage failing is not the destination's fault, and not one pair's problem
@@ -2419,6 +2514,46 @@ mod tests {
             chain_client::Error::RemoteNodeError(NodeError::EventsNotFound(vec![]));
         assert!(is_chain_scoped(&events_missing));
         assert!(!is_local_scoped(&events_missing));
+    }
+
+    /// A destination reporting ITS chain corrupt must not be treated as an unhealthy destination.
+    ///
+    /// Before parking, this fell through to `DestinationScoped`, which halves the peer's AIMD
+    /// window — so a handful of corrupt chains throttled catch-up for every healthy chain at that
+    /// peer. Observed on testnet-conway 2026-08-25: stakefi had 10 corrupt chains out of ~19k and
+    /// drained far slower than a peer with none.
+    #[test]
+    fn a_corrupt_chain_at_the_destination_parks_rather_than_penalising_the_peer() {
+        let corrupted = chain_client::Error::RemoteNodeError(NodeError::ChainError {
+            error: "Corrupted chain state: computed block outcome differs from the certificate."
+                .to_owned(),
+        });
+        assert_eq!(park_reason(&corrupted), Some(ParkReason::Corrupted));
+        assert!(
+            !is_chain_scoped(&corrupted) && !is_local_scoped(&corrupted),
+            "parking must be decided before the scoped arms, or the peer's window is halved",
+        );
+
+        // A different ChainError is NOT unrecoverable: it keeps its old classification, so this
+        // change cannot silently swallow errors that retrying does fix.
+        let other = chain_client::Error::RemoteNodeError(NodeError::ChainError {
+            error: "Block proposal has size 999 which is too large".to_owned(),
+        });
+        assert_eq!(park_reason(&other), None);
+    }
+
+    /// A parked pair is skipped by the drain gate, and only a restart clears it.
+    #[test]
+    fn a_parked_pair_is_never_spawned_again() {
+        let mut chain_dest = ChainDest::default();
+        assert!(chain_dest.parked.is_none(), "pairs start unparked");
+        chain_dest.parked = Some(ParkReason::Corrupted);
+        assert!(
+            chain_dest.parked.is_some(),
+            "nothing in the retry path clears `parked`: the repair is manual on the peer's side, \
+             so re-arming on a timer would just resume failing against unfixed state",
+        );
+        assert_eq!(ParkReason::Corrupted.as_str(), "corrupted");
     }
 
     /// The queue-wide budget is offered to a different destination each round.


### PR DESCRIPTION
## Motivation

Block export was enabled on testnet-conway validator-4 for ~2h on 2026-08-25 and had to be turned
off again. It worked — validator-1 and validator-3 reached `blocks_owed = 0` with no manual
`follow-chain --sync`, which is the [#1342](https://github.com/linera-io/linera-infra/issues/1342)
onboarding fix demonstrated on a live network for the first time.

What blocked leaving it on is that **two external validators have chains they cannot apply**, and
today the exporter treats that as the *destination* being unhealthy:

```
WARN linera_core::chain_worker::export: Failed to export to a validator; backing it off
  validator=grpcs:linera-testnet.stakefi.network:443  chain_id=a72c2cc9…
  error=Remote node operation failed: Chain error: Corrupted chain state:
        computed block outcome differs from the certificate.
```

`Corrupted chain state` arrives as `NodeError::ChainError`, which is not in `is_chain_scoped`, so it
falls through to `SendOutcome::DestinationScoped` — which **halves that peer's AIMD window and backs
off every chain at it**. stakefi had 10 corrupt chains out of ~19k; those 10 were throttling catch-up
for all the rest. Resending never helps: the destination recomputes the same block and gets the same
contradiction.

## Proposal

A third failure class between "this chain, for now" and "this destination":

```rust
enum ParkReason { Corrupted }                        // extensible; one reason today
struct ChainDest { …, parked: Option<ParkReason> }
enum SendOutcome { …, Unrecoverable(ParkReason, Box<chain_client::Error>) }
```

- **Classified before the scoped arms** — an unrecoverable answer is about neither our storage nor
  the peer's health, so it must not move either backoff.
- **The peer's window is untouched.** This is the behavioural fix: a handful of corrupt chains can no
  longer throttle catch-up for the healthy ones.
- **`drain_ready` skips parked pairs** and drops them from `lagging`, so a pair that will never
  converge is not re-scanned on every future round.
- **Cleared only by a restart.** The repair is manual on the destination's side, so re-arming on a
  timer would just resume failing against state nobody has fixed.
- **`block_export_parked_chains{validator, reason}`** — a gauge per destination and reason.
- Logged at `warn!` (not `debug!` like a chain-scoped backoff) and **once per pair**: this never
  self-heals, and the chain id is what the destination's operator needs in order to repair it.

Everything not classified as unrecoverable keeps its existing behaviour, so recoverable errors are
still retried under AIMD exactly as before. A test pins that.

### Why this matches on the message text

`ChainError` crosses the wire through `From<ChainError> for NodeError` (`linera-core/src/node.rs`),
whose catch-all arm converts every unmapped variant to `NodeError::ChainError { error: String }`.
**The type is destroyed by the sender**, so there is nothing structured left to match on by the time
it reaches us.

Adding a dedicated `NodeError` variant would not help either. `NodeError` is bincode-encoded
(`rpc.proto`: *"a bincode wrapper around `NodeError`"*), so variants are indexed positionally and a
new one is a wire break — and the peers this exists to detect are precisely the ones on older builds,
which would keep sending the stringly-typed form regardless. The reasoning is recorded above
`park_reason` so nobody "fixes" it later.

## Test Plan

`cargo test -p linera-core --features metrics --lib chain_worker::export`

```
test result: ok. 14 passed; 0 failed; 0 ignored
```

New/changed:

- `a_corrupt_chain_at_the_destination_parks_rather_than_penalising_the_peer` — the real corruption
  message parks; **a different `ChainError` (`Block proposal … too large`) does not**, so this cannot
  silently swallow errors that retrying does fix.
- `a_parked_pair_is_never_spawned_again` — pairs start unparked and nothing in the retry path clears
  the flag.
- `a_chain_destination_pair_stays_small` — was `the_regression_counter_costs_no_memory`, asserting 56
  bytes. `parked` takes it to **64**: the previous fields packed exactly, leaving no padding. That is
  8 bytes per (chain, destination) pair — **~10 KB** at conway's observed 210 tracked chains across 6
  destinations, under 1 MB even if all ~19k chains were tracked at once. Paid deliberately rather
  than squeezing `regressions` to `u16`, which would have held 56 bytes but changed a field unrelated
  to parking. The assertion is updated with that reasoning rather than simply relaxed.

`cargo check -p linera-core --features metrics`: clean, no warnings. `cargo fmt` applied.

## Release Plan

Nothing to do / These changes follow the usual deployment cycle.

This is what makes block export safe to re-enable on conway. Once deployed, the operational picture
per destination becomes: `blocks_owed` falling, `chain_scoped_backoffs` draining, and
`parked_chains{reason="corrupted"}` flat at the number of chains that peer's operator has to repair.

Two follow-ups, deliberately not here:

- **Other unrecoverable errors almost certainly exist.** `park_reason` is one function returning
  `Option<ParkReason>`, so each is a match arm plus a label. Shipping only `Corrupted` first so the
  rest are found from what the metric actually catches rather than guessed.
- **Exporter dashboard**: total parked per destination, and parked per destination per reason, as
  separate panels — after this metric is deployed.
