### PR TITLE
Backport #6754 to testnet_conway: leave generated Solidity untouched when forge fmt cannot run

### DIFF
--- a/linera-bridge/build.rs
+++ b/linera-bridge/build.rs
@@ -8,38 +8,66 @@ fn main() {
 
 #[cfg(feature = "codegen")]
 mod codegen {
-    use std::{collections::BTreeMap, path::PathBuf, process::Command};
+    use std::{collections::BTreeMap, fs, path::PathBuf, process::Command};
 
     use serde_generate::{solidity, CodeGeneratorConfig, SourceInstaller};
     use serde_reflection::Registry;
 
     pub fn generate() {
+        let generated = [
+            PathBuf::from("src/solidity/BridgeTypes.sol"),
+            PathBuf::from("src/solidity/WrappedFungibleTypesV1.sol"),
+        ];
+        // The generators overwrite the checked-in sources, and only `forge fmt` turns their
+        // output into the committed form, so without it every build leaves the tree dirty
+        // with equivalent-but-unformatted code that is easy to commit by accident.
+        let committed: Vec<Option<String>> = generated
+            .iter()
+            .map(|path| fs::read_to_string(path).ok())
+            .collect();
+
         generate_bridge_types();
         generate_fungible_types();
-        forge_fmt(&PathBuf::from("src/solidity/BridgeTypes.sol"));
-        forge_fmt(&PathBuf::from("src/solidity/WrappedFungibleTypesV1.sol"));
+
+        for (path, committed) in generated.iter().zip(committed) {
+            if forge_fmt(path) {
+                continue;
+            }
+            if let Some(committed) = committed {
+                if let Err(e) = fs::write(path, committed) {
+                    println!("cargo:warning=could not restore {}: {e}", path.display());
+                }
+            }
+        }
     }
 
-    /// Reformats a freshly generated Solidity file with `forge fmt` so the
-    /// generator's output matches the rest of the codebase. Falls back to
-    /// a warning (non-fatal) if `forge` is not on PATH — codegen is a
-    /// best-effort developer convenience and shouldn't break a build that
-    /// otherwise wouldn't have run forge.
-    fn forge_fmt(path: &PathBuf) {
+    /// Reformats a freshly generated Solidity file with `forge fmt` so the generator's
+    /// output matches the rest of the codebase, reporting whether it succeeded. Failure is
+    /// non-fatal (codegen is a developer convenience and should not break a build that
+    /// would not otherwise have run forge), but the caller restores the committed file,
+    /// because unformatted output differs from it and would dirty the tree.
+    fn forge_fmt(path: &PathBuf) -> bool {
         if !path.exists() {
-            return;
+            return false;
         }
         let status = Command::new("forge").arg("fmt").arg(path).status();
         match status {
-            Ok(s) if s.success() => {}
+            Ok(s) if s.success() => true,
             Ok(s) => {
-                println!("cargo:warning=forge fmt {} exited with {s}", path.display());
+                println!(
+                    "cargo:warning=forge fmt {} exited with {s}; leaving the committed file \
+                     in place",
+                    path.display()
+                );
+                false
             }
             Err(e) => {
                 println!(
-                    "cargo:warning=forge fmt {} could not be invoked: {e}",
+                    "cargo:warning=forge fmt {} could not be invoked: {e}; leaving the \
+                     committed file in place",
                     path.display()
                 );
+                false
             }
         }
     }


### PR DESCRIPTION
## Motivation

Backport of #6754 to `testnet_conway`.

On this branch, `linera-bridge/build.rs` runs the Solidity generators and then calls `forge fmt`, ignoring whether it worked:

```rust
pub fn generate() {
    generate_bridge_types();
    generate_fungible_types();
    forge_fmt(&PathBuf::from("src/solidity/BridgeTypes.sol"));
    forge_fmt(&PathBuf::from("src/solidity/WrappedFungibleTypesV1.sol"));
}
```

The generators overwrite the checked-in sources, and only `forge fmt` turns their output into the committed form. So on any machine without `forge` on `PATH`, every `--all-features` build leaves `BridgeTypes.sol` and `WrappedFungibleTypesV1.sol` rewritten into equivalent-but-unformatted code, and the tree dirty.

That is easy to commit by accident: it is 1,834 lines of pure reformatting that a `git add -A` picks up silently while looking like generated churn. It reached the staging area twice while I was preparing the backports of #6722 and #6747 to this branch, and was only caught by reading the commit stat.

`main` fixed this in #6754; this branch predates it.

## Proposal

Cherry-pick of bcc9b2f572, unmodified — `linera-bridge/build.rs` has not diverged between the branches, so it applies cleanly and keeps the original authorship.

The build script now snapshots the committed contents before running the generators, and restores them when `forge fmt` cannot run or fails. Codegen stays a developer convenience that does not break a build which would not otherwise have invoked `forge`, but it no longer dirties the tree on machines that lack it.

## Test Plan

`cargo check -p linera-bridge --all-features` on a machine without `forge` installed:

- before: `git status` shows both `.sol` files modified.
- after: the tree is clean, and the build reports `forge fmt … could not be invoked … leaving the committed file in place`.

## Release Plan

- These changes should be backported to the latest `testnet` branch — this is that backport.

Build-time developer convenience only; no runtime or protocol effect.

## Links

- #6754 — the same change on `main`.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
