### PR TITLE
Describe faucet request failures without reproducing the JavaScript stack

### DIFF
--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -29,13 +29,13 @@ pub enum Error {
     #[error("GraphQL error: {0:?}")]
     GraphQl(Vec<serde_json::Value>),
     /// An HTTP request to the faucet failed.
-    #[error("HTTP error: {0:?}")]
+    #[error("{}", describe_http_failure(.0))]
     Http(#[from] reqwest::Error),
     /// An arithmetic operation overflowed.
     #[error(transparent)]
     ArithmeticError(#[from] ArithmeticError),
     /// A GraphQL query could not be sent to the faucet.
-    #[error("failed to execute query {query:?}: {source}")]
+    #[error("failed to execute query {query:?}: {}", describe_http_failure(.source))]
     Query {
         /// The query that could not be sent.
         query: String,
@@ -43,6 +43,32 @@ pub enum Error {
         #[source]
         source: reqwest::Error,
     },
+}
+
+/// Describes a `reqwest` failure without reproducing its source.
+///
+/// On wasm that source is built with `format!("{js_val:?}")`, which embeds the JavaScript
+/// stack trace of the failed `fetch`. The trace differs per browser and per bundle hash, so
+/// carrying it splits one underlying failure across many distinct-looking reports. It buys
+/// little in exchange: browsers deliberately report CORS rejections, offline and DNS
+/// failures as the same opaque `TypeError`, so the text that varies is mostly the browser's
+/// own phrasing. The error is still available through `source()` for anything that wants it.
+fn describe_http_failure(error: &reqwest::Error) -> String {
+    let where_ = match error.url() {
+        Some(url) => format!(" at {url}"),
+        None => String::new(),
+    };
+    if let Some(status) = error.status() {
+        format!("the faucet{where_} returned {status}")
+    } else if error.is_timeout() {
+        format!("the request to the faucet{where_} timed out")
+    } else if error.is_decode() {
+        format!("could not decode the faucet's response{where_}")
+    } else if error.is_body() {
+        format!("the request body sent to the faucet{where_} was rejected")
+    } else {
+        format!("could not reach the faucet{where_}")
+    }
 }
 
 /// The result of a successful claim mutation.


### PR DESCRIPTION
## Motivation

The top wasm-related error in the web client's Sentry project is the faucet being unreachable: roughly 13,200 events across 5 separate issues in 90 days, the largest alone 10,932 events / 1,951 users. All five are the same failure. They are split because the message carries a JavaScript stack trace that differs per browser and per bundle hash:

```
Failed to connect to Linera network: HTTP error: reqwest::Error { kind: Request,
url: "https://faucet…", source: "JsValue(TypeError: Failed to fetch
(faucet.testnet-conway.linera.net)\nTypeError: Failed to fetch
    at https://app.linera.xyz/assets/index-CLXCZRbV.js:67:4987\n…" }
```

The trace is not framing that a format specifier can strip. `reqwest` builds its wasm source with `format!("{js_val:?}")` (`reqwest-0.11.27/src/error.rs:283-285`), and wasm-bindgen's `debugString` renders an `Error` as `` `${val.name}: ${val.message}\n${val.stack}` ``. So the trace is baked into a `String` before `reqwest` formats anything, and both `Display` (`src/error.rs:209-211`) and `Debug` (`177-179`) append it. Switching `{0:?}` to `{0}` would only remove the `reqwest::Error { … }` wrapper.

## Proposal

Render these failures from `reqwest`'s own predicates and drop the source from the message. The error is still reachable through `source()` for anything that wants it; only what we print changes.

```rust
#[error("{}", describe_http_failure(.0))]
Http(#[from] reqwest::Error),
```

Both variants that carry a `reqwest::Error` go through it — `Http`, and the `Query` variant added in #6747, which used `{source}` and so leaked the trace the same way.

Against real `reqwest` errors:

| | message |
|---|---|
| before (`Display`) | `error sending request for url (http://127.0.0.1:1/graphql): error trying to connect: tcp connect error: Connection refused (os error 111)` |
| after, connect failure | `could not reach the faucet at http://127.0.0.1:1/graphql` |
| after, timeout | `the request to the faucet at http://10.255.255.1/graphql timed out` |

On wasm the production case becomes `could not reach the faucet at https://faucet.testnet-conway.linera.net/`, identical in every browser and every build — one Sentry issue instead of five.

### What this gives up

On wasm, essentially every network failure renders the same way. `is_connect()` is `#[cfg(not(target_arch = "wasm32"))]` and does not exist there, and a failed `fetch` carries no status, so the predicates cannot separate DNS failure from a CORS rejection from being offline.

That is less than it appears: browsers deliberately collapse those into one opaque `TypeError` precisely so pages cannot distinguish them. What the old message actually varied by was the browser's own phrasing — `Failed to fetch`, `NetworkError when attempting to fetch resource.`, `Load failed` — plus the bundle hash in the stack. Neither tells us anything about the failure.

Status-bearing and timeout failures still render distinctly, and those are the ones where the distinction is real.

### Not included

`linera-execution`, `linera-indexer` and `linera-service-graphql-client` wrap `reqwest::Error` with `{0}` or `#[error(transparent)]`, which has the same shape on wasm. Only `linera-execution` is reachable from the web client, and it is the application HTTP-request path rather than faucet connection, with no measured Sentry population. Left alone rather than widened on speculation.

## Test Plan

`cargo check` and `cargo clippy --all-targets` for `linera-faucet-client`, plus `cargo fmt`.

The rendered output above was produced by running the renderer against real `reqwest` errors — a refused connection and a timeout — rather than reasoned from the branches.

## Release Plan

- These changes follow the usual release cycle.

User-visible error text changes; no API change.

## Links

- The `{0:?}` → `{0}` framing was proposed and rejected in #6722, which established why a format-specifier change cannot reach the trace.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
