### PR TITLE
Add a root AGENTS.md routing to CONTRIBUTING.md and the existing docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+Instructions for AI agents working on `linera-protocol`.
+
+This file routes; it is not a second source of truth. **On any conflict, the linked file wins.**
+
+- **Coding conventions, panics policy, cargo features, Wasm support, reviewer checklist** — [CONTRIBUTING.md](CONTRIBUTING.md). Read it before changing code.
+- **Before every commit** — `cargo clippy --all-targets --all-features` and `cargo +nightly fmt`. CI enforces both; nightly is required for `fmt`.
+- **After changing CLI flags** — `linera help-markdown > CLI.md`. CI fails on a stale `CLI.md`.
+- **Building and running locally** — [INSTALL.md](INSTALL.md).
+- **Concepts, tutorials, SDK guides** — [`docs/`](docs/), published at <https://linera.dev>.


### PR DESCRIPTION
## Motivation

Closes the "what shape?" question in #5579.

`.gitignore` excludes `.claude`, `CLAUDE.md` and `CLAUDE.local.md`, so today every
contributor maintains a private copy of the same project knowledge and agents that
aren't Claude Code get nothing. `AGENTS.md` is the one agent-instruction filename the
repo already permits committing.

In #5579, @afck pushed back on the original proposal:

> Maybe we should just point to `CONTRIBUTING.md` for that, and extend that file
> instead. Actually, that should go for most of the points in the list: a lot of them
> are just as relevant for human contributors.

That's right, and this PR implements it rather than the original proposal. Every bullet
#5579 wanted to add already exists in `CONTRIBUTING.md` (363 lines): naming conventions,
API guidelines, panics policy, cargo features, Wasm support, the `cargo +nightly fmt`
dance, the reviewer checklist. The gap was never missing content — it was that agents
don't auto-load `CONTRIBUTING.md`.

## Proposal

Add a root `AGENTS.md` that is a **pure router**: it points at the documents humans
already maintain and states that the linked file wins on conflict. No architecture
summary, no crate table, no restated conventions — nothing that can silently diverge
from the code.

That constraint is not theoretical. `linera-io/agentctl` is the one repo in the org that
committed both an `AGENTS.md` and a `CLAUDE.md` with overlapping prose. The result:

- `AGENTS.md` — 1 commit, 2026-04-19, never updated since.
- `CLAUDE.md` — 5 commits, last 2026-04-28.
- They now contradict each other. `AGENTS.md` says *"No async runtime — synchronous with
  polling"*; `CLAUDE.md` describes a 2-worker `tokio::runtime` with `spawn_blocking`.
  `Cargo.toml` has `tokio = { version = "1", features = ["rt-multi-thread", ...] }`, so
  `AGENTS.md` is the stale one. It also claims "7 runtime crates" where the manifest
  lists 8.

Nine days to diverge, four months wrong. The router shape plus an explicit precedence
rule is what avoids repeating that here.

## Test Plan

- Every link target verified to exist at this commit: `CONTRIBUTING.md`, `INSTALL.md`,
  `CLI.md`, `docs/`.
- Both commands are the ones `CONTRIBUTING.md` documents (lines 22 and 173) and CI
  already enforces.
- `linera help-markdown > CLI.md` is taken verbatim from the remediation message in
  `.github/workflows/rust.yml:236`.
- No CI surface is added: `cargo-spellcheck` is configured via `spellcheck-cfg.toml` but
  is not invoked by any workflow, and `test-readmes.yml` runs crate README doctests, not
  arbitrary root markdown.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #5579
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
