### PR TITLE
Document the RocksDB durability contract (WAL on, sync off)

### DIFF
--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -2,6 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Implements [`crate::store::KeyValueStore`] for the RocksDB database.
+//!
+//! # Durability
+//!
+//! Writes go through `DB::write` with RocksDB's default `WriteOptions`: the write-ahead log
+//! is enabled and `sync` is off. Upstream states that such a write survives a process crash
+//! but not a machine crash — "if it is just the process that crashes (i.e., the machine does
+//! not reboot), no writes will be lost even if sync==false", whereas on a machine crash "some
+//! recent writes may be lost". A caller that needs power-loss durability cannot get it from
+//! this backend; the absence of `WriteOptions` here is the contract, not an oversight.
 
 // RocksDB's C API uses `i32` and signed sizes; casts at this boundary are
 // by design.


### PR DESCRIPTION
## Motivation

The RocksDB backend's durability contract is invisible, because it lives in a call we *don't*
make: `write_batch_internal` calls `DB::write` with no `WriteOptions`, so every write takes
RocksDB's defaults (WAL on, `sync` off). Nothing in `linera-views` or `linera-storage` sets
`WriteOptions`, `set_sync`, `disable_wal` or `flush_wal` anywhere:

```
$ grep -rnE 'WriteOptions|set_sync|disable_wal|flush_wal' linera-views/src/ linera-storage/src/
(no output)
```

A reader asking "are we crash-safe?" therefore has to re-derive the answer from an absence,
which is easy to get wrong in either direction — either assuming the WAL is disabled, or
assuming a completed write is power-loss durable. That question has now been worked out from
scratch twice.

## Proposal

Add a `# Durability` section to the `rocks_db` module docs stating the contract, quoting
upstream's own wording for the distinction that actually matters — process crash vs machine
crash:

> If this flag is false, and the machine crashes, some recent writes may be lost. Note that if
> it is just the process that crashes (i.e., the machine does not reboot), no writes will be
> lost even if sync==false.

— [`include/rocksdb/options.h`](https://github.com/facebook/rocksdb/blob/main/include/rocksdb/options.h)

The note deliberately says nothing about which deployments use this backend, so it can't rot
as deployments change. It records only what is true of this code.

Docs only — no behaviour change.

## Test Plan

`cargo check -p linera-views --features rocksdb` passes clean; `cargo fmt` clean. The change is
a comment with no intra-doc links, so it cannot affect codegen. CI covers the rest.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
