### PR TITLE
Drop the stray v prefix from the WIT API hash in validator output

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -124,7 +124,7 @@ impl ValidatorQueryResults {
                     println!("GraphQL API hash: {}", version_info.graphql_hash);
                 }
                 if ref_version.is_none_or(|ref_v| ref_v.wit_hash != version_info.wit_hash) {
-                    println!("WIT API hash: v{}", version_info.wit_hash);
+                    println!("WIT API hash: {}", version_info.wit_hash);
                 }
                 if ref_version.is_none_or(|ref_v| {
                     (&ref_v.git_commit, ref_v.git_dirty)


### PR DESCRIPTION
> Targets `testnet_conway`. **`main` already prints this correctly** — this brings conway into line, it is not a change `main` needs.

## Motivation

`linera validator list` and `validator query` print the WIT API hash with a `v` in front of it:

```
Linera protocol: v0.15.21
RPC API hash: R+hOHa12w3uYcIYh7AW+JXwo97bEOH1Nm0IoAqZshvs
GraphQL API hash: u/1mosg1Nwe2EyvhMVpFVSy7lVNYuKecArYcNK80nw8
WIT API hash: vLBDK3ZORkwFJX1WI+P0neR3xZNtvhufYjvfROgBR3QM
                 ^
```

That is a base64 hash, not a version. `wit_hash` is typed `Hash`, and its two neighbours print without a prefix; the `v` belongs to `Linera protocol: v{}` on the line above, which is where it was copy-pasted from when all four lines were added together in #4738.

`linera-version`'s own `Display` impl — what `linera --version` uses — already prints it without the prefix, so the same field renders two different ways depending on which command you run.

The output above is real, captured from the `testnet-conway` daily validator check on 2026-08-27.

## Proposal

Drop the `v`. One character; no behaviour depends on it.

**Why this targets conway and not `main`.** `main` was already fixed:

```
$ gh api repos/linera-io/linera-protocol/contents/linera-client/src/client_context.rs?ref=main \
    --jq .content | base64 -d | grep -n "API hash"
121:  println!("RPC API hash: {}", version_info.rpc_hash);
124:  println!("GraphQL API hash: {}", version_info.graphql_hash);
127:  println!("WIT API hash: {}", version_info.wit_hash);

$ ... ?ref=testnet_conway ...
127:  println!("WIT API hash: v{}", version_info.wit_hash);
```

## Test Plan

`cargo check -p linera-client` and `cargo clippy -p linera-client --all-targets` both exit 0; `cargo fmt --check` clean. Clippy reports 3 pre-existing `dead_code` warnings in `linera-client/src/unit_tests/chain_listener.rs`, a file this PR does not touch.

Nothing parses this line: the only two producers of the string in the tree are `linera-version`'s `Display` impl (already prefix-free) and this call site. No test or doc asserts on it.

**Safe for the network health check**, which does parse `validator list` output. Every line in a run — the Local Node block and each validator's — is rendered by the *client's* single binary from data fetched over RPC, not by the validators themselves, so this format change applies uniformly within any one run and cannot make two validators' hashes compare unequal. It also takes field `$4` either way.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Introduced in #4738, which added all four lines at once — `RPC` and `GraphQL` correctly without a prefix, `WIT` with one.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
