### PR TITLE
Time a single certificate push, not a whole catch-up round

### DIFF
--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -129,11 +129,32 @@ pub(crate) mod metrics {
                 exponential_bucket_latencies(60_000.0),
             );
 
-        /// Time for one push to one destination, including any catch-up it triggered.
+        /// Time for one catch-up ROUND against one destination — every certificate it pushed, not
+        /// one block. A round closes up to `max_catch_up_blocks` of the gap, so this scales with
+        /// how far behind the destination is and says nothing on its own about how responsive that
+        /// destination is. Use `CERTIFICATE_SEND_LATENCY` for that, and read this one as "how long
+        /// a unit of catch-up work takes".
+        ///
+        /// The ceiling is well above `max_retry_delay` so a slow round lands in a real bucket
+        /// instead of piling into `+Inf`: at 60 s every destination with a backlog pegged at the
+        /// top bucket and the quantiles stopped discriminating between them.
         pub static SEND_LATENCY: HistogramVec =
             register_histogram_vec(
                 "block_export_send_latency",
-                "Time (ms) to push one block to one destination validator",
+                "Time (ms) for one catch-up round against one destination validator",
+                &["validator"],
+                exponential_bucket_latencies(600_000.0),
+            );
+
+        /// Time for a SINGLE certificate push, which is one round trip to the destination.
+        ///
+        /// This is the destination's actual responsiveness, independent of how much catch-up the
+        /// round carried: a peer that is far behind makes long rounds out of fast round trips, and
+        /// only this metric can tell that apart from a peer that is genuinely slow to answer.
+        pub static CERTIFICATE_SEND_LATENCY: HistogramVec =
+            register_histogram_vec(
+                "block_export_certificate_send_latency",
+                "Time (ms) for one certificate round trip to one destination validator",
                 &["validator"],
                 exponential_bucket_latencies(60_000.0),
             );
@@ -1667,6 +1688,9 @@ where
                 .remove_label_values(&[address])
                 .ok();
             metrics::SEND_LATENCY.remove_label_values(&[address]).ok();
+            metrics::CERTIFICATE_SEND_LATENCY
+                .remove_label_values(&[address])
+                .ok();
             metrics::SENDS_SUCCEEDED
                 .remove_label_values(&[address])
                 .ok();
@@ -1865,6 +1889,8 @@ where
             },
             storage: storage.clone(),
             certificate_upload_batch_size: config.certificate_upload_batch_size,
+            #[cfg(with_metrics)]
+            address: dest.address.clone(),
         };
         let cursor = chain_dest.next_height;
         let max_catch_up = config.max_catch_up_blocks;
@@ -2047,6 +2073,9 @@ pub(crate) struct BlockSender<S, N> {
     pub(crate) remote_node: RemoteNode<N>,
     pub(crate) storage: S,
     pub(crate) certificate_upload_batch_size: u64,
+    /// Destination address, carried only to label per-certificate latency.
+    #[cfg(with_metrics)]
+    pub(crate) address: String,
 }
 
 impl<S, N> BlockSender<S, N>
@@ -2150,6 +2179,13 @@ where
         held: &[CacheArc<Blob>],
     ) -> Result<Box<crate::data_types::ChainInfo>, chain_client::Error> {
         let delivery = CrossChainMessageDelivery::NonBlocking;
+        // Covers the blob-recovery retries below too: what the caller cares about is how long this
+        // certificate took to land, not how many attempts it needed.
+        #[cfg(with_metrics)]
+        let certificate_latency =
+            metrics::CERTIFICATE_SEND_LATENCY.with_label_values(&[&self.address]);
+        #[cfg(with_metrics)]
+        let _certificate_latency = certificate_latency.measure_latency();
         let mut result = self
             .remote_node
             .handle_optimized_confirmed_certificate(certificate, delivery)

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4776,6 +4776,8 @@ where
         },
         storage: builder.validator_storage(0),
         certificate_upload_batch_size: 100,
+        #[cfg(with_metrics)]
+        address: "test".to_owned(),
     };
 
     // Round by round: each one advances by exactly the bound until the last, which sends only the
@@ -4938,6 +4940,8 @@ where
         },
         storage,
         certificate_upload_batch_size: 100,
+        #[cfg(with_metrics)]
+        address: "test".to_owned(),
     };
 
     // Re-offer an old block, exactly as a re-execution would.
@@ -5048,6 +5052,8 @@ where
         },
         storage,
         certificate_upload_batch_size: 100,
+        #[cfg(with_metrics)]
+        address: "test".to_owned(),
     };
 
     // Ask with no cursor at all — the state a failed send leaves behind. One bounded round must


### PR DESCRIPTION
## Motivation

`block_export_send_latency` cannot answer the question it looks like it answers, and its help text
says something that is not true:

```
"Time (ms) to push one block to one destination validator"
```

It is not one block. `measure_latency()` is held for the whole job (`export.rs`), which wraps
`send_block` / `send_missing_blocks` — and those **loop, issuing one RPC per certificate**, closing
up to `max_catch_up_blocks` (2000) of the gap in a single round. So the value is roughly

```
blocks the destination is behind  ×  round-trip time
```

A destination that is further behind therefore *looks* slower, while every individual round trip is
identical. On testnet-conway 2026-08-25 this made three external validators look catastrophically
slow, and the numbers only made sense after normalising by `destination_lag`:

| destination | lag (blocks/round) | mean round | per block |
|---|---|---|---|
| validator-1 | 1.0 | 8.4 ms | 8.4 ms |
| validator-2 | 42 | 122 ms | 2.9 ms |
| rubynodes | 3,713 | 3,318 ms | **0.89 ms** |
| unitynodes | 4,203 | 3,963 ms | **0.94 ms** |
| stakefi | 3,866 | 8,196 ms | 2.1 ms |

Per block, the peers that looked worst were the *fastest*. `validator-1` only looks quick because
its rounds carry a single live block and pay full per-round overhead on it.

**The quantiles could not settle it either**, because the histogram tops out at 60 s: p99 returned
exactly `60000` for all three backlogged destinations. That is the instrument saturating, not three
peers coincidentally sharing a latency. With a variable-size unit of work *and* a clipped tail there
was no way to distinguish "slow peer" from "far-behind peer" — which is the only thing anyone
actually wants to know from this metric.

## Proposal

**Add `block_export_certificate_send_latency`** — one certificate, one round trip, labelled by
destination. This is the destination's real responsiveness, independent of how much catch-up the
round carried. The timer spans the blob-recovery retries inside `send_confirmed_certificate` on
purpose: what matters is how long that certificate took to land, not how many attempts it needed.

**Keep `block_export_send_latency`, but tell the truth about it.** Help text now says *round*, and
the doc comment says it scales with how far behind the destination is and points at the new metric
for peer health. Read as "how long a unit of catch-up work takes", it is still worth having.

**Raise its ceiling 60 s → 600 s**, comfortably above `max_retry_delay`, so a long round lands in a
real bucket instead of piling into `+Inf` and flattening every quantile to the same number.

`BlockSender` gains an `address` field, `#[cfg(with_metrics)]`-gated so it costs nothing when
metrics are off. The new metric is removed alongside its siblings when a destination leaves the
committee, or it would leak one series per departed validator.

## Test Plan

- `cargo check -p linera-core --features metrics` — clean, no warnings.
- `cargo check -p linera-core --no-default-features` — clean. Checked explicitly because the new
  field and timer are both `cfg`-gated and `lint-check-all-features` does not run on PRs in this
  repo, so CI would not have caught a break there.
- `cargo test -p linera-core --features metrics --lib chain_worker::export` — passing.
- `cargo fmt` applied.

Behaviour is unchanged: this adds an observation and rewords a help string. Nothing on the send path
is reordered, and the three test construction sites of `BlockSender` are updated for the new field.

## Release Plan

Nothing to do / These changes follow the usual deployment cycle.

Once deployed, the open question about rubynodes becomes answerable: if its **certificate** latency
sits at the ~127 ms transatlantic round trip it is healthy and merely far behind, and its 326
timeouts are about something other than the peer being slow. If that number is high, the peer really
is slow. Today neither can be shown.
