### PR TITLE
Export both cache and db children of source-labelled counters

### DIFF
--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -62,73 +62,81 @@ pub mod metrics {
     /// Label value for items served from the database.
     pub(super) const DB: &str = "db";
 
+    /// Registers a counter labelled by [`SOURCE_LABEL`], with both children created up front.
+    ///
+    /// `materialize_unlabeled` cannot reach a labelled vector, because label values are not
+    /// knowable in general — but this domain is exactly {[`CACHE`], [`DB`]} and known right here.
+    /// Left lazy, a counter whose cache path has not run yet exports nothing at all, which reads
+    /// identically to the metric having been deleted: measured 2026-08-28, `contains_blob_state`,
+    /// `contains_certificate` and `read_event_block_height` were absent fleet-wide despite live
+    /// call sites, and `contains_blobs` and `read_blob_state` exported only the `db` side, which
+    /// silently skews any cache-hit ratio built from them.
+    fn register_source_counter(name: &str, description: &str) -> IntCounterVec {
+        let counter = register_int_counter_vec(name, description, &[SOURCE_LABEL]);
+        counter.with_label_values(&[CACHE]);
+        counter.with_label_values(&[DB]);
+        counter
+    }
+
     linera_base::declare_metrics! {
         /// The metric counting how often a blob is tested for existence from storage
         pub(super) static CONTAINS_BLOB_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "contains_blob",
                 "The metric counting how often a blob is tested for existence from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often multiple blobs are tested for existence from storage
         pub(super) static CONTAINS_BLOBS_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "contains_blobs",
                 "The metric counting how often multiple blobs are tested for existence from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a blob state is tested for existence from storage
         pub(super) static CONTAINS_BLOB_STATE_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "contains_blob_state",
                 "The metric counting how often a blob state is tested for existence from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a certificate is tested for existence from storage.
         pub(super) static CONTAINS_CERTIFICATE_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "contains_certificate",
                 "The metric counting how often a certificate is tested for existence from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a hashed certificate value is read from storage.
         #[doc(hidden)]
         pub static READ_CONFIRMED_BLOCK_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_confirmed_block",
                 "The metric counting how often a hashed confirmed block is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often confirmed blocks are read from storage.
         #[doc(hidden)]
         pub(super) static READ_CONFIRMED_BLOCKS_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_confirmed_blocks",
                 "The metric counting how often confirmed blocks are read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a blob is read from storage.
         #[doc(hidden)]
         pub(super) static READ_BLOB_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_blob",
                 "The metric counting how often a blob is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a blob state is read from storage.
         #[doc(hidden)]
         pub(super) static READ_BLOB_STATE_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_blob_state",
                 "The metric counting how often a blob state is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a blob is written to storage.
@@ -142,19 +150,17 @@ pub mod metrics {
         /// The metric counting how often a certificate is read from storage.
         #[doc(hidden)]
         pub static READ_CERTIFICATE_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_certificate",
                 "The metric counting how often a certificate is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often certificates are read from storage.
         #[doc(hidden)]
         pub(super) static READ_CERTIFICATES_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_certificates",
                 "The metric counting how often certificate are read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a certificate is written to storage.
@@ -210,18 +216,16 @@ pub mod metrics {
         /// The metric counting how often an event is read from storage.
         #[doc(hidden)]
         pub(super) static READ_EVENT_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_event",
                 "The metric counting how often an event is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often an event is tested for existence from storage
         pub(super) static CONTAINS_EVENT_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "contains_event",
                 "The metric counting how often an event is tested for existence from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often an event is written to storage.
@@ -235,28 +239,25 @@ pub mod metrics {
         /// The metric counting how often a block hash is read by height from storage.
         #[doc(hidden)]
         pub(super) static READ_BLOCK_HASH_BY_HEIGHT_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_block_hash_by_height",
                 "The metric counting how often a block hash is read by height from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often an event block height is read from storage.
         #[doc(hidden)]
         pub(super) static READ_EVENT_BLOCK_HEIGHT_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_event_block_height",
                 "The metric counting how often an event block height is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often the network description is read from storage.
         #[doc(hidden)]
         pub(super) static READ_NETWORK_DESCRIPTION: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "network_description",
                 "The metric counting how often the network description is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often the network description is written to storage.
@@ -2165,5 +2166,41 @@ mod tests {
             cert_by_hash.value().block().header,
             cert_by_height.value().block().header
         );
+    }
+
+    /// A source-labelled counter must export both children before either path has run, so a
+    /// cold `cache` side cannot be mistaken for a deleted metric and a hit ratio built from
+    /// the two is never missing a denominator.
+    #[cfg(with_metrics)]
+    #[test]
+    fn source_labelled_counters_export_both_sources_before_any_read() {
+        crate::init_metrics();
+
+        let families = prometheus::gather();
+        for name in [
+            "linera_contains_blob_state",
+            "linera_contains_certificate",
+            "linera_read_event_block_height",
+            "linera_contains_blobs",
+            "linera_read_blob_state",
+        ] {
+            let family = families
+                .iter()
+                .find(|family| family.get_name() == name)
+                .unwrap_or_else(|| panic!("{name} must be exported once init_metrics has run"));
+            let mut sources = family
+                .get_metric()
+                .iter()
+                .flat_map(|metric| metric.get_label())
+                .filter(|label| label.get_name() == super::metrics::SOURCE_LABEL)
+                .map(|label| label.get_value())
+                .collect::<Vec<_>>();
+            sources.sort_unstable();
+            assert_eq!(
+                sources,
+                [super::metrics::CACHE, super::metrics::DB],
+                "{name} must export both sources"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Motivation

`materialize_unlabeled` (`linera-base/src/prometheus_util.rs`) creates the sole child of a
label-free `MetricVec` at registration, so the metric exports at zero instead of appearing only
once its code path first runs. Its own doc comment states the limit: *"Vectors that do have labels
cannot get this treatment, because their label values are not known ahead of time."*

That is true in general, but not for `SOURCE_LABEL`, whose domain is exactly `{CACHE, DB}` and is
declared three lines above the metrics that use it. Leaving those children lazy has a measurable
cost. Queried against Mimir on 2026-08-28, of the 15 source-labelled counters:

| state | metrics |
|---|---|
| absent fleet-wide, despite live call sites | `linera_contains_blob_state`, `linera_contains_certificate`, `linera_read_event_block_height` |
| only the `db` side exported | `linera_contains_blobs`, `linera_read_blob_state` |
| asymmetric across validators | `read_confirmed_block` (cache 6 / db 10), `read_certificate` (17/21), `read_confirmed_blocks` (35/40) |

Two consequences:

1. A metric that exports nothing is indistinguishable from one that was deleted, which is what
   `LineraMetricStoppedReporting` fires on — `linera_contains_blobs` spent 483 minutes firing in
   the 7 days to 2026-08-28.
2. More seriously, a cache-hit ratio of the form `cache / (cache + db)` is **silently wrong**
   wherever one side is missing. The denominator quietly loses a term rather than the panel going
   blank, so the number looks plausible and is not.

## Proposal

Register the source-labelled counters through a helper that creates both children up front.

```rust
fn register_source_counter(name: &str, description: &str) -> IntCounterVec {
    let counter = register_int_counter_vec(name, description, &[SOURCE_LABEL]);
    counter.with_label_values(&[CACHE]);
    counter.with_label_values(&[DB]);
    counter
}
```

All 15 call sites lose their repeated `&[SOURCE_LABEL]` argument, so the diff is a net
simplification and the invariant lives in one place. Exporting `0` for a path that has not run is
the accurate statement — it is what `materialize_unlabeled` already does for the label-free case.

Deliberately **not** generalised to every labelled vector. `&["validator"]`, `&["address"]` and
`&["destination"]` take values only known at runtime and must stay lazy; pre-creating them is not
possible, not merely unwise.

Deliberately **not** extended to `&["phase"]` (`linera-chain/src/chain.rs`, 10 metrics). I checked:
all three `BlockExecutionPhase` values are present in production (`stage_proposal` 2 series,
`handle_proposal` 34, `handle_confirmed` 33 — `stage_proposal` is thin only because few nodes
propose). No metric name is absent there, so it is neither an alerting nor a correctness problem
today. It is enumerable via `strum` if we later want every node to export all three at zero.

## Test Plan

- New unit test `source_labelled_counters_export_both_sources_before_any_read` asserts each of the
  five affected metrics exports exactly `[cache, db]` after `init_metrics()` and before any read.
- **Positive-controlled**: removing the two `with_label_values` lines makes it fail with
  `linera_contains_blob_state must be exported once init_metrics has run`, then pass again when
  restored. A test that cannot fail is worthless, so this was verified both ways rather than
  assumed.
- `cargo test -p linera-storage --features metrics` → 10 passed, 7 passed, 0 failed.
- `cargo test -p linera-views --features metrics metrics::` → 2 passed. In particular
  `labelled_metrics_stay_absent_until_a_label_combination_is_observed` still passes: it pins the
  general lazy behaviour for `linera_load_view`, whose `["type"]` domain is genuinely runtime, and
  this change does not weaken that.
- `cargo clippy -p linera-storage --features metrics --all-targets` → no warnings.
- `cargo fmt --all -- --check` → clean.

After deploy, the check is that `count by (__name__, source)` over these 15 names returns both
`cache` and `db` for every one, instead of the gaps in the table above.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

`testnet_conway` carries the same 15 registrations (16 `SOURCE_LABEL` occurrences in
`linera-storage/src/db_storage.rs`), so the patch applies there and the same observability gap
exists on that fleet. Happy to drop this line if you would rather it ride the normal cycle — it is
a metrics-only change with no protocol or storage-format impact.

## Links

- linera-infra#1979 removed the *other* source of `LineraMetricStoppedReporting` noise: Loki
  log-derived recording rules, whose absence is the healthy state.
- The `materialize_unlabeled` / `declare_metrics!` mechanism this extends came from the
  lazily-registered-metric fix in linera-infra#1740.
