### PR TITLE
Export both cache and db children of source-labelled counters (backport of #6795)

### DIFF
--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -62,73 +62,81 @@ pub mod metrics {
     /// Label value for items served from the database.
     pub(super) const DB: &str = "db";
 
+    /// Registers a counter labelled by [`SOURCE_LABEL`], with both children created up front.
+    ///
+    /// `materialize_unlabeled` cannot reach a labelled vector, because label values are not
+    /// knowable in general — but this domain is exactly {[`CACHE`], [`DB`]} and known right here.
+    /// Left lazy, a counter whose cache path has not run yet exports nothing at all, which reads
+    /// identically to the metric having been deleted: measured 2026-08-28, `contains_blob_state`,
+    /// `contains_certificate` and `read_event_block_height` were absent fleet-wide despite live
+    /// call sites, and `contains_blobs` and `read_blob_state` exported only the `db` side, which
+    /// silently skews any cache-hit ratio built from them.
+    fn register_source_counter(name: &str, description: &str) -> IntCounterVec {
+        let counter = register_int_counter_vec(name, description, &[SOURCE_LABEL]);
+        counter.with_label_values(&[CACHE]);
+        counter.with_label_values(&[DB]);
+        counter
+    }
+
     linera_base::declare_metrics! {
         /// The metric counting how often a blob is tested for existence from storage
         pub(super) static CONTAINS_BLOB_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "contains_blob",
                 "The metric counting how often a blob is tested for existence from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often multiple blobs are tested for existence from storage
         pub(super) static CONTAINS_BLOBS_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "contains_blobs",
                 "The metric counting how often multiple blobs are tested for existence from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a blob state is tested for existence from storage
         pub(super) static CONTAINS_BLOB_STATE_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "contains_blob_state",
                 "The metric counting how often a blob state is tested for existence from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a certificate is tested for existence from storage.
         pub(super) static CONTAINS_CERTIFICATE_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "contains_certificate",
                 "The metric counting how often a certificate is tested for existence from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a hashed certificate value is read from storage.
         #[doc(hidden)]
         pub static READ_CONFIRMED_BLOCK_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_confirmed_block",
                 "The metric counting how often a hashed confirmed block is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often confirmed blocks are read from storage.
         #[doc(hidden)]
         pub(super) static READ_CONFIRMED_BLOCKS_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_confirmed_blocks",
                 "The metric counting how often confirmed blocks are read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a blob is read from storage.
         #[doc(hidden)]
         pub(super) static READ_BLOB_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_blob",
                 "The metric counting how often a blob is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a blob state is read from storage.
         #[doc(hidden)]
         pub(super) static READ_BLOB_STATE_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_blob_state",
                 "The metric counting how often a blob state is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a blob is written to storage.
@@ -142,19 +150,17 @@ pub mod metrics {
         /// The metric counting how often a certificate is read from storage.
         #[doc(hidden)]
         pub static READ_CERTIFICATE_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_certificate",
                 "The metric counting how often a certificate is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often certificates are read from storage.
         #[doc(hidden)]
         pub(super) static READ_CERTIFICATES_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_certificates",
                 "The metric counting how often certificate are read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often a certificate is written to storage.
@@ -178,18 +184,16 @@ pub mod metrics {
         /// The metric counting how often an event is read from storage.
         #[doc(hidden)]
         pub(super) static READ_EVENT_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_event",
                 "The metric counting how often an event is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often an event is tested for existence from storage
         pub(super) static CONTAINS_EVENT_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "contains_event",
                 "The metric counting how often an event is tested for existence from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often an event is written to storage.
@@ -203,28 +207,25 @@ pub mod metrics {
         /// The metric counting how often a block hash is read by height from storage.
         #[doc(hidden)]
         pub(super) static READ_BLOCK_HASH_BY_HEIGHT_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_block_hash_by_height",
                 "The metric counting how often a block hash is read by height from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often an event block height is read from storage.
         #[doc(hidden)]
         pub(super) static READ_EVENT_BLOCK_HEIGHT_COUNTER: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "read_event_block_height",
                 "The metric counting how often an event block height is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often the network description is read from storage.
         #[doc(hidden)]
         pub(super) static READ_NETWORK_DESCRIPTION: IntCounterVec =
-            register_int_counter_vec(
+            register_source_counter(
                 "network_description",
                 "The metric counting how often the network description is read from storage",
-                &[SOURCE_LABEL],
             );
 
         /// The metric counting how often the network description is written to storage.
@@ -1088,6 +1089,42 @@ mod tests {
             hash,
             "Certificate retrieved by height should match original"
         );
+    }
+
+    /// A source-labelled counter must export both children before either path has run, so a
+    /// cold `cache` side cannot be mistaken for a deleted metric and a hit ratio built from
+    /// the two is never missing a denominator.
+    #[cfg(with_metrics)]
+    #[test]
+    fn source_labelled_counters_export_both_sources_before_any_read() {
+        crate::init_metrics();
+
+        let families = prometheus::gather();
+        for name in [
+            "linera_contains_blob_state",
+            "linera_contains_certificate",
+            "linera_read_event_block_height",
+            "linera_contains_blobs",
+            "linera_read_blob_state",
+        ] {
+            let family = families
+                .iter()
+                .find(|family| family.get_name() == name)
+                .unwrap_or_else(|| panic!("{name} must be exported once init_metrics has run"));
+            let mut sources = family
+                .get_metric()
+                .iter()
+                .flat_map(|metric| metric.get_label())
+                .filter(|label| label.get_name() == super::metrics::SOURCE_LABEL)
+                .map(|label| label.get_value())
+                .collect::<Vec<_>>();
+            sources.sort_unstable();
+            assert_eq!(
+                sources,
+                [super::metrics::CACHE, super::metrics::DB],
+                "{name} must export both sources"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Motivation

Backport of #6795 to `testnet_conway`, per that PR's Release Plan.

`SOURCE_LABEL`'s domain is exactly `{CACHE, DB}`, declared three lines above the metrics that use
it, but the children were left lazy — so a counter whose cache path had not run exported nothing
at all, which is indistinguishable from the metric having been deleted.

The conway fleet has the same gap. Measured against Mimir on 2026-08-28, of the 15 source-labelled
counters:

| state | metrics |
|---|---|
| absent fleet-wide, despite live call sites | `linera_contains_blob_state`, `linera_contains_certificate`, `linera_read_event_block_height` |
| only the `db` side exported | `linera_contains_blobs`, `linera_read_blob_state` |
| asymmetric across validators | `read_confirmed_block` (cache 6 / db 10), `read_certificate` (17/21), `read_confirmed_blocks` (35/40) |

The alerting noise is the lesser symptom. The one that matters is that a cache-hit ratio of the
form `cache / (cache + db)` is **silently wrong** wherever a side is missing — the denominator
loses a term rather than the panel going blank, so the number stays plausible and is not.

## Proposal

Identical to #6795: register the source-labelled counters through a helper that creates both
children up front, so all 15 call sites drop their repeated `&[SOURCE_LABEL]` argument.

```rust
fn register_source_counter(name: &str, description: &str) -> IntCounterVec {
    let counter = register_int_counter_vec(name, description, &[SOURCE_LABEL]);
    counter.with_label_values(&[CACHE]);
    counter.with_label_values(&[DB]);
    counter
}
```

Net diff against `testnet_conway` is 67 insertions / 30 deletions — the same shape as on `main`.

### One hand-port correction worth reviewing

`git cherry-pick` reported success, but the result did **not** compile. conway's
`db_storage.rs` has a different layout: `#[cfg(test)] mod tests` sits at line 547, whereas on
`main` it is near the end of the file. The three-way merge matched on trailing context and placed
the new test inside the `impl DbStorage` block instead, which fails with:

```
error: the `#[test]` attribute may only be used on a non-associated function
```

The test has been moved into conway's real `mod tests`. Flagging it because a clean cherry-pick
exit code was not evidence of a correct port here, and the same trap applies to any later backport
touching this file.

## Test Plan

Everything re-run on this branch, not inherited from #6795:

- `cargo test -p linera-storage --features metrics` → **11 passed**, 7 passed, 0 failed (the 11th
  is the new test; conway had 10 before).
- **Positive-controlled on conway specifically**: removing the two `with_label_values` lines makes
  it fail with `linera_contains_blob_state must be exported once init_metrics has run` at
  `db_storage.rs:1111`, and pass again when restored.
- `cargo clippy -p linera-storage --features metrics --all-targets` → no warnings.
- `cargo fmt --all -- --check` → clean.
- Verified no site was missed: the only remaining `&[SOURCE_LABEL]` in the file is inside the
  helper itself, and the 15 names registered through it on conway are exactly the 15 from `main`.

After deploy, the check is that `count by (__name__, source)` over these 15 names returns both
`cache` and `db` for every one, instead of the gaps in the table above.

## Release Plan

- These changes should be backported to the latest `testnet` branch.
  - This **is** that backport; `main` already has it via #6795.

Metrics-only: no protocol, wire-format or storage-format impact, so no new deployment is required
beyond the usual validator image roll.

## Links

- #6795 — the `main` PR this backports.
- linera-infra#1979 — removed the other source of `LineraMetricStoppedReporting` noise (Loki
  log-derived recording rules, whose absence is the healthy state).
