### PR TITLE
Bound the ScyllaDB multi-key read chunk fan-out

### DIFF
--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::num::NonZeroUsize;
+
 use linera_views::{
     lru_prefix_cache::StorageCacheConfig,
     scylla_db::{
@@ -28,6 +30,10 @@ pub struct ScyllaDbConfig {
     /// The maximal number of simultaneous queries to the database
     #[arg(long)]
     max_concurrent_queries: Option<usize>,
+
+    /// The maximal number of chunk queries a single multi-key read sends at once.
+    #[arg(long, default_value_t = DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES)]
+    pub max_concurrent_chunk_queries: NonZeroUsize,
 
     /// The maximal memory used in the storage cache in bytes.
     #[arg(long, default_value = "10000000")]
@@ -104,7 +110,7 @@ impl ScyllaDbRunner {
         let inner_config = ScyllaDbStoreInternalConfig {
             uri: config.client.uri.clone(),
             max_concurrent_queries: config.client.max_concurrent_queries,
-            max_concurrent_chunk_queries: DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES,
+            max_concurrent_chunk_queries: config.client.max_concurrent_chunk_queries,
             replication_factor: config.client.replication_factor,
         };
         let store_config = ScyllaDbStoreConfig {

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -3,7 +3,10 @@
 
 use linera_views::{
     lru_prefix_cache::StorageCacheConfig,
-    scylla_db::{ScyllaDbDatabase, ScyllaDbStoreConfig, ScyllaDbStoreInternalConfig},
+    scylla_db::{
+        ScyllaDbDatabase, ScyllaDbStoreConfig, ScyllaDbStoreInternalConfig,
+        DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES,
+    },
     store::KeyValueDatabase,
 };
 
@@ -101,6 +104,7 @@ impl ScyllaDbRunner {
         let inner_config = ScyllaDbStoreInternalConfig {
             uri: config.client.uri.clone(),
             max_concurrent_queries: config.client.max_concurrent_queries,
+            max_concurrent_chunk_queries: DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES,
             replication_factor: config.client.replication_factor,
         };
         let store_config = ScyllaDbStoreConfig {

--- a/linera-storage-runtime/src/common_options.rs
+++ b/linera-storage-runtime/src/common_options.rs
@@ -1,14 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::num::NonZeroUsize;
-
 use linera_storage::{StorageCacheConfig, DEFAULT_CLEANUP_INTERVAL_SECS};
 use linera_views::lru_prefix_cache::StorageCacheConfig as ViewsStorageCacheConfig;
-#[cfg(feature = "scylladb")]
-use linera_views::scylla_db::DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES;
 #[cfg(feature = "rocksdb")]
 use {linera_views::rocks_db::RocksDbStatisticsLevel, std::str::FromStr as _};
+#[cfg(feature = "scylladb")]
+use {linera_views::scylla_db::DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES, std::num::NonZeroUsize};
 
 /// Command-line options shared by all storage backends, controlling concurrency
 /// limits and cache sizes.

--- a/linera-storage-runtime/src/common_options.rs
+++ b/linera-storage-runtime/src/common_options.rs
@@ -3,6 +3,8 @@
 
 use linera_storage::{StorageCacheConfig, DEFAULT_CLEANUP_INTERVAL_SECS};
 use linera_views::lru_prefix_cache::StorageCacheConfig as ViewsStorageCacheConfig;
+#[cfg(feature = "scylladb")]
+use linera_views::scylla_db::DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES;
 #[cfg(feature = "rocksdb")]
 use {linera_views::rocks_db::RocksDbStatisticsLevel, std::str::FromStr as _};
 
@@ -81,6 +83,13 @@ pub struct CommonStorageOptions {
     /// The replication factor for the keyspace
     #[arg(long, default_value = "1", global = true)]
     pub storage_replication_factor: u32,
+
+    /// The maximal number of chunk queries a single multi-key read sends at once. A large
+    /// read is split into fixed-size chunks; issuing every chunk simultaneously can exhaust
+    /// ScyllaDB's reader-concurrency semaphore and inflate read latency for other callers.
+    #[cfg(feature = "scylladb")]
+    #[arg(long, default_value_t = DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES, global = true)]
+    pub scylladb_max_concurrent_chunk_queries: usize,
 
     /// Enable RocksDB's internal statistics collection and export them as Prometheus
     /// metrics. Off by default; enable it on nodes whose metrics are scraped.

--- a/linera-storage-runtime/src/common_options.rs
+++ b/linera-storage-runtime/src/common_options.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::num::NonZeroUsize;
+
 use linera_storage::{StorageCacheConfig, DEFAULT_CLEANUP_INTERVAL_SECS};
 use linera_views::lru_prefix_cache::StorageCacheConfig as ViewsStorageCacheConfig;
 #[cfg(feature = "scylladb")]
@@ -89,7 +91,7 @@ pub struct CommonStorageOptions {
     /// ScyllaDB's reader-concurrency semaphore and inflate read latency for other callers.
     #[cfg(feature = "scylladb")]
     #[arg(long, default_value_t = DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES, global = true)]
-    pub scylladb_max_concurrent_chunk_queries: usize,
+    pub scylladb_max_concurrent_chunk_queries: NonZeroUsize,
 
     /// Enable RocksDB's internal statistics collection and export them as Prometheus
     /// metrics. Off by default; enable it on nodes whose metrics are scraped.
@@ -185,6 +187,34 @@ mod tests {
             "test",
             "--rocksdb-statistics-level",
             "not-a-level",
+        ])
+        .is_err());
+    }
+}
+
+#[cfg(all(test, feature = "scylladb"))]
+mod scylladb_tests {
+    use clap::Parser as _;
+    use linera_views::scylla_db::DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES;
+
+    use super::CommonStorageOptions;
+
+    #[test]
+    fn chunk_query_bound_defaults_to_the_views_default() {
+        let options = CommonStorageOptions::with_defaults();
+        assert_eq!(
+            options.scylladb_max_concurrent_chunk_queries,
+            DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES,
+        );
+    }
+
+    // `buffered(0)` admits no future and hangs forever, so zero must never reach the store.
+    #[test]
+    fn rejects_a_zero_chunk_query_bound() {
+        assert!(CommonStorageOptions::try_parse_from([
+            "test",
+            "--scylladb-max-concurrent-chunk-queries",
+            "0",
         ])
         .is_err());
     }

--- a/linera-storage-runtime/src/storage_config.rs
+++ b/linera-storage-runtime/src/storage_config.rs
@@ -353,6 +353,7 @@ impl StorageConfig {
                 let inner_config = linera_views::scylla_db::ScyllaDbStoreInternalConfig {
                     uri: uri.clone(),
                     max_concurrent_queries: options.storage_max_concurrent_queries,
+                    max_concurrent_chunk_queries: options.scylladb_max_concurrent_chunk_queries,
                     replication_factor: options.storage_replication_factor,
                 };
                 let config = linera_views::scylla_db::ScyllaDbStoreConfig {
@@ -381,6 +382,7 @@ impl StorageConfig {
                 let inner_config = linera_views::scylla_db::ScyllaDbStoreInternalConfig {
                     uri: uri.clone(),
                     max_concurrent_queries: options.storage_max_concurrent_queries,
+                    max_concurrent_chunk_queries: options.scylladb_max_concurrent_chunk_queries,
                     replication_factor: options.storage_replication_factor,
                 };
                 let second_config = linera_views::scylla_db::ScyllaDbStoreConfig {

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -4,8 +4,8 @@
 //! Implements [`crate::store::KeyValueStore`] for the ScyllaDB database.
 //!
 //! The current connection is done via a Session and a corresponding primary key called
-//! "namespace". The maximum number of concurrent queries is controlled by
-//! `max_concurrent_queries`.
+//! "namespace". `max_concurrent_queries` bounds how many store operations run at once, while
+//! `MAX_CONCURRENT_CHUNK_QUERIES` bounds the chunk queries issued within one multi-key read.
 
 use std::{
     collections::{BTreeSet, HashMap},

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -5,7 +5,7 @@
 //!
 //! The current connection is done via a Session and a corresponding primary key called
 //! "namespace". `max_concurrent_queries` bounds how many store operations run at once, while
-//! `MAX_CONCURRENT_CHUNK_QUERIES` bounds the chunk queries issued within one multi-key read.
+//! `max_concurrent_chunk_queries` bounds the chunk queries issued within one multi-key read.
 
 use std::{
     collections::{BTreeSet, HashMap},
@@ -62,13 +62,13 @@ use crate::{
 /// The limit is in reality 100. But we need one entry for the root key.
 const MAX_MULTI_KEYS: usize = 100 - 1;
 
-/// How many chunk queries a single multi-key read may have in flight at once.
+/// Default for how many chunk queries a single multi-key read may have in flight at once.
 ///
 /// A multi-key read is split into `MAX_MULTI_KEYS`-sized chunks, so one logical read of a large
 /// range expands into many queries against the *same* partition. Issuing them all at once
 /// exhausts ScyllaDB's reader-concurrency semaphore and inflates read latency for every other
 /// caller without buying throughput, so the fan-out is capped instead.
-const MAX_CONCURRENT_CHUNK_QUERIES: usize = 10;
+pub const DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES: usize = 10;
 
 /// The maximal size of an operation on ScyllaDB seems to be 16 MiB
 /// https://www.scylladb.com/2019/03/27/best-practices-for-scylla-applications/
@@ -739,6 +739,8 @@ pub struct ScyllaDbStoreInternal {
     store: Arc<ScyllaDbClient>,
     semaphore: Option<Arc<Semaphore>>,
     root_key: Vec<u8>,
+    /// Upper bound on chunk queries in flight for one multi-key read.
+    max_concurrent_chunk_queries: usize,
     /// Whether this store was opened with `open_exclusive`. When true, `write_batch`
     /// resolves in-batch prefix/insert collisions via per-statement `USING TIMESTAMP`;
     /// when false, it splits the batch into two sequential sub-batches with
@@ -755,6 +757,7 @@ pub struct ScyllaDbStoreInternal {
 pub struct ScyllaDbDatabaseInternal {
     store: Arc<ScyllaDbClient>,
     semaphore: Option<Arc<Semaphore>>,
+    max_concurrent_chunk_queries: usize,
 }
 
 impl WithError for ScyllaDbDatabaseInternal {
@@ -888,7 +891,7 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
             .map(|keys| store.contains_keys_internal(&self.root_key, keys.to_vec()))
             .collect::<Vec<_>>();
         let results: Vec<_> = stream::iter(handles)
-            .buffered(MAX_CONCURRENT_CHUNK_QUERIES)
+            .buffered(self.max_concurrent_chunk_queries)
             .try_collect()
             .await?;
         Ok(results.into_iter().flatten().collect())
@@ -908,7 +911,7 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
             .map(|keys| store.read_multi_values_internal(&self.root_key, keys.to_vec()))
             .collect::<Vec<_>>();
         let results: Vec<_> = stream::iter(handles)
-            .buffered(MAX_CONCURRENT_CHUNK_QUERIES)
+            .buffered(self.max_concurrent_chunk_queries)
             .try_collect()
             .await?;
         Ok(results.into_iter().flatten().collect())
@@ -1053,6 +1056,8 @@ pub struct ScyllaDbStoreInternalConfig {
     pub uri: String,
     /// Maximum number of concurrent database queries allowed for this client.
     pub max_concurrent_queries: Option<usize>,
+    /// Maximum number of chunk queries issued at once by a single multi-key read.
+    pub max_concurrent_chunk_queries: usize,
     /// The replication factor.
     pub replication_factor: u32,
 }
@@ -1076,7 +1081,11 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
         let semaphore = config
             .max_concurrent_queries
             .map(|n| Arc::new(Semaphore::new(n)));
-        Ok(Self { store, semaphore })
+        Ok(Self {
+            store,
+            semaphore,
+            max_concurrent_chunk_queries: config.max_concurrent_chunk_queries,
+        })
     }
 
     fn open_shared(&self, root_key: &[u8]) -> Result<Self::Store, ScyllaDbStoreInternalError> {
@@ -1087,6 +1096,7 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
             store,
             semaphore,
             root_key,
+            max_concurrent_chunk_queries: self.max_concurrent_chunk_queries,
             is_exclusive: false,
             ts_floor: Arc::new(AtomicI64::new(0)),
         })
@@ -1100,6 +1110,7 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
             store,
             semaphore,
             root_key,
+            max_concurrent_chunk_queries: self.max_concurrent_chunk_queries,
             is_exclusive: true,
             ts_floor: Arc::new(AtomicI64::new(0)),
         })
@@ -1322,6 +1333,7 @@ impl TestKeyValueDatabase for JournalingKeyValueDatabase<ScyllaDbDatabaseInterna
         Ok(ScyllaDbStoreInternalConfig {
             uri,
             max_concurrent_queries: Some(10),
+            max_concurrent_chunk_queries: DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES,
             replication_factor: 1,
         })
     }

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use async_lock::{Semaphore, SemaphoreGuard};
-use futures::{future::join_all, StreamExt as _};
+use futures::{stream, StreamExt as _, TryStreamExt as _};
 use linera_base::{ensure, util::future::FutureSyncExt as _};
 use scylla::{
     client::{
@@ -61,6 +61,14 @@ use crate::{
 /// Fundamental constant in ScyllaDB: The maximum size of a multi keys query
 /// The limit is in reality 100. But we need one entry for the root key.
 const MAX_MULTI_KEYS: usize = 100 - 1;
+
+/// How many chunk queries a single multi-key read may have in flight at once.
+///
+/// A multi-key read is split into `MAX_MULTI_KEYS`-sized chunks, so one logical read of a large
+/// range expands into many queries against the *same* partition. Issuing them all at once
+/// exhausts ScyllaDB's reader-concurrency semaphore and inflates read latency for every other
+/// caller without buying throughput, so the fan-out is capped instead.
+const MAX_CONCURRENT_CHUNK_QUERIES: usize = 10;
 
 /// The maximal size of an operation on ScyllaDB seems to be 16 MiB
 /// https://www.scylladb.com/2019/03/27/best-practices-for-scylla-applications/
@@ -877,11 +885,12 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
         let _guard = self.acquire().await;
         let handles = keys
             .chunks(MAX_MULTI_KEYS)
-            .map(|keys| store.contains_keys_internal(&self.root_key, keys.to_vec()));
-        let results: Vec<_> = join_all(handles)
-            .await
-            .into_iter()
-            .collect::<Result<_, _>>()?;
+            .map(|keys| store.contains_keys_internal(&self.root_key, keys.to_vec()))
+            .collect::<Vec<_>>();
+        let results: Vec<_> = stream::iter(handles)
+            .buffered(MAX_CONCURRENT_CHUNK_QUERIES)
+            .try_collect()
+            .await?;
         Ok(results.into_iter().flatten().collect())
     }
 
@@ -896,11 +905,12 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
         let _guard = self.acquire().await;
         let handles = keys
             .chunks(MAX_MULTI_KEYS)
-            .map(|keys| store.read_multi_values_internal(&self.root_key, keys.to_vec()));
-        let results: Vec<_> = join_all(handles)
-            .await
-            .into_iter()
-            .collect::<Result<_, _>>()?;
+            .map(|keys| store.read_multi_values_internal(&self.root_key, keys.to_vec()))
+            .collect::<Vec<_>>();
+        let results: Vec<_> = stream::iter(handles)
+            .buffered(MAX_CONCURRENT_CHUNK_QUERIES)
+            .try_collect()
+            .await?;
         Ok(results.into_iter().flatten().collect())
     }
 

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -9,6 +9,7 @@
 
 use std::{
     collections::{BTreeSet, HashMap},
+    num::NonZeroUsize,
     ops::Deref,
     sync::{
         atomic::{AtomicI64, Ordering},
@@ -68,7 +69,9 @@ const MAX_MULTI_KEYS: usize = 100 - 1;
 /// range expands into many queries against the *same* partition. Issuing them all at once
 /// exhausts ScyllaDB's reader-concurrency semaphore and inflates read latency for every other
 /// caller without buying throughput, so the fan-out is capped instead.
-pub const DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES: usize = 10;
+///
+/// Non-zero because `buffered(0)` admits no future and would hang forever.
+pub const DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES: NonZeroUsize = NonZeroUsize::new(10).unwrap();
 
 /// The maximal size of an operation on ScyllaDB seems to be 16 MiB
 /// https://www.scylladb.com/2019/03/27/best-practices-for-scylla-applications/
@@ -740,7 +743,7 @@ pub struct ScyllaDbStoreInternal {
     semaphore: Option<Arc<Semaphore>>,
     root_key: Vec<u8>,
     /// Upper bound on chunk queries in flight for one multi-key read.
-    max_concurrent_chunk_queries: usize,
+    max_concurrent_chunk_queries: NonZeroUsize,
     /// Whether this store was opened with `open_exclusive`. When true, `write_batch`
     /// resolves in-batch prefix/insert collisions via per-statement `USING TIMESTAMP`;
     /// when false, it splits the batch into two sequential sub-batches with
@@ -757,7 +760,7 @@ pub struct ScyllaDbStoreInternal {
 pub struct ScyllaDbDatabaseInternal {
     store: Arc<ScyllaDbClient>,
     semaphore: Option<Arc<Semaphore>>,
-    max_concurrent_chunk_queries: usize,
+    max_concurrent_chunk_queries: NonZeroUsize,
 }
 
 impl WithError for ScyllaDbDatabaseInternal {
@@ -891,7 +894,7 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
             .map(|keys| store.contains_keys_internal(&self.root_key, keys.to_vec()))
             .collect::<Vec<_>>();
         let results: Vec<_> = stream::iter(handles)
-            .buffered(self.max_concurrent_chunk_queries)
+            .buffered(self.max_concurrent_chunk_queries.get())
             .try_collect()
             .await?;
         Ok(results.into_iter().flatten().collect())
@@ -911,7 +914,7 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
             .map(|keys| store.read_multi_values_internal(&self.root_key, keys.to_vec()))
             .collect::<Vec<_>>();
         let results: Vec<_> = stream::iter(handles)
-            .buffered(self.max_concurrent_chunk_queries)
+            .buffered(self.max_concurrent_chunk_queries.get())
             .try_collect()
             .await?;
         Ok(results.into_iter().flatten().collect())
@@ -1057,7 +1060,7 @@ pub struct ScyllaDbStoreInternalConfig {
     /// Maximum number of concurrent database queries allowed for this client.
     pub max_concurrent_queries: Option<usize>,
     /// Maximum number of chunk queries issued at once by a single multi-key read.
-    pub max_concurrent_chunk_queries: usize,
+    pub max_concurrent_chunk_queries: NonZeroUsize,
     /// The replication factor.
     pub replication_factor: u32,
 }

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -454,7 +454,10 @@ where
 {
     let mut rng = make_deterministic_rng();
     let namespace = generate_test_namespace();
-    let store = D::connect(&config, &namespace).await.unwrap();
+    // The namespace is freshly generated, so it has to be created before it can be opened.
+    let store = D::maybe_create_and_connect(&config, &namespace)
+        .await
+        .unwrap();
     let store = store.open_exclusive(&[]).unwrap();
     let key_prefix = vec![42, 54];
     let mut batch = Batch::new();

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -39,6 +39,17 @@ async fn test_read_multi_values_scylla_db() {
     big_read_multi_values::<ScyllaDbDatabase>(config, 22200000, 200).await;
 }
 
+// More chunks than the concurrent-chunk-query bound, so the fan-out has to run several waves:
+// the only regime whose behaviour differs from issuing every chunk at once. Small values keep
+// it cheap enough to run unignored.
+#[cfg(with_scylladb)]
+#[tokio::test]
+async fn test_multi_wave_read_multi_values_scylla_db() {
+    use linera_views::scylla_db::ScyllaDbDatabase;
+    let config = ScyllaDbDatabase::new_test_config().await.unwrap();
+    big_read_multi_values::<ScyllaDbDatabase>(config, 100, 2000).await;
+}
+
 #[tokio::test]
 async fn test_reads_test_memory() {
     for scenario in get_random_test_scenarios() {


### PR DESCRIPTION
## Motivation

A single logical multi-key read against ScyllaDB is split into `MAX_MULTI_KEYS` (99) sized chunks,
and every chunk query was then issued at once via `join_all`. One large read therefore expands into
hundreds of simultaneous queries against the *same* partition.

On `testnet_conway` this is what turns a routine PM worker restart into a fleet-wide latency event.
A restarting worker's background certificate sync asks each validator for its `received_log`
(`chain_worker/state.rs`, bounded by `CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES` = 20,000). That single
`LogView::read` becomes ~202 concurrent ScyllaDB queries, all hitting the one
`RootKey::ChainState(chain_id)` partition. Reader permits are exhausted and every other caller on
that validator pays for it.

Measured on V1/V3 around the 2026-08-12 20:29:53 UTC restart of `pm-infra-worker-1`:

| signal | baseline | during |
|---|---|---|
| coordinator read p99 | ~4 ms | **5.2 s** (histogram ceiling) |
| `linera_block_execution_latency` p99 | 90 ms | **10 s** |
| `linera_server_request_latency` p99 | 151-260 ms | **5 s** |
| `scylla_database_active_reads` | 8 | 101 (V1) / 180 (V3) |
| `scylla_database_sstables_read` | 0/s | 22-27/s |
| avg keys per `read_multi_values` (server) | 8 | **6,970** |

Onset was 7 s after the pod started; it held ~40 min and cleared on its own. V1 alone spent ~17 h
above 2 s p99 over 30 days across ~47 worker restarts.

Two details worth calling out, because they made this hard to see:

- The *number* of storage operations never changed (11-18/s throughout). Only their size did. Every
  operation-count metric looks flat during the event, which is why cold-chain-load and row-cache
  eviction both looked plausible and were both wrong: `linera_load_chain_latency_count` stays below
  1/s and `scylla_cache_row_evictions` peaks at 5.9/s.
- Row misses rise 10-20x while *partition* misses stay flat - the signature of reading many uncached
  rows inside an already-cached partition, not of cache displacement.

This also matches the `reader_concurrency_semaphore ... timed out` messages seen in the earlier
`process-inbox` latency reports.

## Proposal

Cap how many chunk queries one multi-key read keeps in flight, in `read_multi_values_bytes` and
`contains_keys` (the two `join_all` sites in the ScyllaDB backend).

`buffered` is used rather than `buffer_unordered`: both functions must return results positionally
aligned with the input keys, and only `buffered` preserves that order.

Deliberately *not* changed: `CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES`. Its documentation says it "should
generally only be increased from the default value" - the large batch is intended, the unbounded
fan-out is not. This keeps the request/response contract identical and fixes the problem at the
storage layer, so every large multi-key read benefits, not just `received_log`.

The cap is a ceiling, not a rate limit: an otherwise idle store still runs the fan-out at full width
until it reaches the limit in flight.

It is exposed as a storage option rather than a hardcoded constant, so different values can be tried
against a real workload without a rebuild: `--scylladb-max-concurrent-chunk-queries` on
`CommonStorageOptions`, and `--max-concurrent-chunk-queries` on the indexer's own `ScyllaDbConfig`
(whose sibling fields `max_concurrent_queries` and `replication_factor` are already CLI-driven, so
hardcoding this one there would have left indexer operators unable to tune it). Both default to
`DEFAULT_MAX_CONCURRENT_CHUNK_QUERIES` = 10. The value is threaded through
`ScyllaDbStoreInternalConfig` to `ScyllaDbDatabaseInternal` and on to `ScyllaDbStoreInternal`, and set
at all four config construction sites (both branches in `storage_config.rs`, the indexer, and the test
config). The `CommonStorageOptions` flag is gated on the `scylladb` feature, matching the existing
`rocksdb_*` options; `scylladb` is not in `linera`'s default features, so `CLI.md` is unchanged
(verified by running the `check-outdated-cli-md` command itself).

**The bound is `NonZeroUsize`, not `usize`, and that is load-bearing.** `buffered(0)` admits no future
and never registers a waker, so it parks the task forever - verified empirically: `buffered(1)` and
`buffered(10)` complete, `buffered(0)` times out with no panic and no error. Worse, both call sites
take the `max_concurrent_queries` semaphore permit *before* the buffered stream, and that semaphore is
shared by `Arc` across every store opened from the database. A hung read would hold its permit
forever, so after `max_concurrent_queries` such reads every operation on every root key would block in
`acquire()` - a whole-process storage deadlock from an operator typo, with no diagnostics. Typing the
value non-zero makes that unrepresentable at every construction site rather than guarding one of them,
and a unit test pins that `--scylladb-max-concurrent-chunk-queries 0` is rejected at parse time.

**Blast radius is bounded by construction.** `buffered(10)` with 10 or fewer futures polls them all
concurrently, exactly as `join_all` did. At 99 keys per chunk that means **any multi-key read of up to
990 keys behaves identically to before** - normal chain-state loads (a few dozen keys) are untouched.
Only genuinely large reads, like the 20,000-entry `received_log`, are throttled.

**One deliberate semantic change:** `try_collect` short-circuits on the first chunk error, whereas
`join_all` awaited every chunk before collecting the `Result`. Both changed methods are pure reads, so
abandoning the outstanding futures has no side effects, and no caller can depend on *which* error
surfaces when several chunks fail. The cancel-safety concerns in this crate are on the write path,
which this PR does not touch.

The second commit corrects the module doc, which claimed `max_concurrent_queries` controls "the
maximum number of concurrent queries". It never did - it bounds logical store *calls*, and each call
could fan out to hundreds of queries. That wording is part of why this was hard to spot.

## Test Plan

- `test_reads_scylla_db` (runs in the `scylladb` workflow against `scylladb/scylla:6.1`) covers
  ordering across chunks: `get_random_test_scenarios()` includes a 150 key-value scenario, which
  exceeds the 99-key chunk size, and `run_reads` asserts `assert_eq!(values, values_read)` for
  `read_multi_values_bytes` and `assert_eq!(values_read_stat, test_exists_direct)` for
  `contains_keys` - both order-sensitive, over both changed functions.
- That is necessary but not sufficient: 150 keys is only 2 chunks, which is under the bound, so every
  chunk still runs concurrently and the path is indistinguishable from the old `join_all`. The only
  regime whose behaviour actually changes is *more chunks than the bound*, and nothing covered it -
  the one large-read test, `test_read_multi_values_scylla_db`, is `#[ignore]`d and never runs.
  `test_multi_wave_read_multi_values_scylla_db` closes that: 2000 keys = 21 chunks against a bound of
  10, so the fan-out must run several waves, and `big_read_multi_values` asserts the whole vector
  positionally. Small values keep it cheap enough to run unignored.
- Ordering was additionally confirmed with a scratch test (not committed) showing `buffered` returns
  input order while `buffer_unordered` does not, so the ordering hazard in this change is real and
  is ruled out by the combinator choice.
- `cargo clippy -p linera-views --features scylladb --all-targets` is clean.
- Adversarial self-review over the diff (lens agents + 3 independent skeptics per candidate) returned
  no confirmed defects. The single candidate raised - that the added `.collect::<Vec<_>>()` breaks
  compilation with `FnOnce is not general enough` - was refuted by experiment: removing that
  `.collect()` reproduces exactly that error at exactly those two lines, so it is the fix for the
  lifetime problem, not the cause of one.

**Known property of `buffered`, worth a reviewer's attention.** `Buffered` refills its window only
while `in_progress_queue.len() < max`, and `FuturesOrdered::len()` counts futures that have completed
but are still waiting on an earlier one. A chunk that finished behind a slower predecessor therefore
still occupies a slot, so the bound is an upper limit rather than a steady occupancy - a sliding
prefix barrier. This only bites when the chunk count exceeds the bound (>990 keys), which is exactly
the regime this PR introduces.

It is not a regression against what this PR actually replaces (unbounded `join_all`) - under-filling
errs toward the goal of not exhausting the reader-concurrency semaphore - and it is not avoidable by
switching to `buffer_unordered`, which returns results in completion order and would silently mispair
them with keys. The prefix barrier is inseparable from order preservation. Operators wanting more in
flight can raise the flag.

Not yet verified, and the reason this is opened as a draft: the expectation that the bounded path is
*no slower* end to end. The argument is that 202-way fan-out is past the congestion knee - it
delivered 212 coordinator reads/s at 180 concurrent, while the same validator serves ~4 ms reads at
8 concurrent - so bounding should raise throughput rather than lower it. That deserves a before/after
measurement on the next worker restart rather than being taken on faith. Note the affected read is a
`Task::spawn` background sync that `listen()` never awaits, so it is not on the block-producing path
either way.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

