### PR TITLE
Report execution thread-pool saturation instead of waiting silently

### DIFF
--- a/linera-core/src/chain_worker/handle.rs
+++ b/linera-core/src/chain_worker/handle.rs
@@ -51,7 +51,9 @@ use linera_base::{
     identifiers::ChainId,
     time::Duration,
 };
-use linera_execution::{QueryContext, ServiceRuntimeEndpoint, ServiceSyncRuntime};
+use linera_execution::{
+    thread_pool::SERVICE_ACTOR, QueryContext, ServiceRuntimeEndpoint, ServiceSyncRuntime,
+};
 use linera_storage::Storage;
 use tokio::sync::{OwnedRwLockReadGuard, RwLock};
 
@@ -108,7 +110,7 @@ impl ServiceRuntimeActor {
                 runtime_request_sender,
             },
             task: thread_pool
-                .run((), move |()| async move {
+                .run(SERVICE_ACTOR, (), move |()| async move {
                     // The dummy context is overwritten by `prepare_for_query`
                     // before the first actual query is executed.
                     ServiceSyncRuntime::new(

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -40,6 +40,7 @@ use crate::{
     execution_state_actor::ExecutionStateActor,
     resources::ResourceController,
     system::{SystemExecutionStateView, SystemMessage},
+    thread_pool::SERVICE_QUERY,
     transaction_tracker::PreparedCheckpoint,
     ApplicationDescription, ApplicationId, ExecutionError, ExecutionRuntimeContext, JsVec, Message,
     MessageContext, OperationContext, OutgoingMessage, ProcessStreamsContext, Query, QueryContext,
@@ -435,7 +436,7 @@ where
         let (codes, descriptions) = actor.service_and_dependencies(application_id).await?;
 
         let service_runtime_task = thread_pool
-            .run_send(JsVec(codes), move |codes| async move {
+            .run_send(SERVICE_QUERY, JsVec(codes), move |codes| async move {
                 let mut runtime = ServiceSyncRuntime::new_with_deadline(
                     execution_state_sender,
                     context,

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -34,6 +34,7 @@ use crate::{
     execution::UserAction,
     runtime::ContractSyncRuntime,
     system::{CreateApplicationResult, OpenChainConfig},
+    thread_pool::CONTRACT,
     util::{OracleResponseExt as _, RespondExt as _},
     ApplicationDescription, ApplicationId, ExecutionError, ExecutionRuntimeContext,
     ExecutionStateView, JsVec, Message, MessageContext, MessageKind, ModuleId, Operation,
@@ -1072,7 +1073,7 @@ where
             .context()
             .extra()
             .thread_pool()
-            .run_send(JsVec(codes), move |codes| async move {
+            .run_send(CONTRACT, JsVec(codes), move |codes| async move {
                 let runtime = ContractSyncRuntime::new(
                     execution_state_sender,
                     chain_id,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -21,6 +21,7 @@ pub mod system;
 /// Helpers for writing tests that exercise the execution layer.
 #[cfg(with_testing)]
 pub mod test_utils;
+pub mod thread_pool;
 mod transaction_tracker;
 mod util;
 mod wasm;
@@ -54,7 +55,7 @@ use linera_views::{batch::Batch, ViewError};
 use serde::{Deserialize, Serialize};
 use system::AdminOperation;
 use thiserror::Error;
-pub use web_thread_pool::Pool as ThreadPool;
+pub use thread_pool::ThreadPool;
 use web_thread_select as web_thread;
 
 #[cfg(with_revm)]
@@ -1809,6 +1810,7 @@ pub fn init_metrics() {
     evm::revm::metrics::init_metrics();
     execution_state_actor::metrics::init_metrics();
     system::metrics::init_metrics();
+    thread_pool::metrics::init_metrics();
     #[cfg(with_wasm_runtime)]
     wasm::metrics::init_metrics();
 }

--- a/linera-execution/src/thread_pool.rs
+++ b/linera-execution/src/thread_pool.rs
@@ -13,6 +13,10 @@ blocks. A slot holder can also need a second slot before it releases its first â
 querying a service oracle does exactly that â€” so the wait can be indefinite rather than merely
 long. This module reports the wait while it is still happening, which is what separates a
 saturated pool from a wedged one.
+
+Reporting a wait needs a clock, so *waiting* for a slot requires a Tokio runtime with timers
+enabled, which the pool itself never did. Taking a free slot deliberately keeps the old contract
+and needs no runtime at all, so the requirement only appears once the pool is already saturated.
 */
 
 use std::{future::Future, pin::Pin};
@@ -125,7 +129,8 @@ impl ThreadPool {
         }
     }
 
-    /// Runs `code` on a pool thread, waiting for a slot if none is free.
+    /// Runs `code` on a pool thread, waiting for a slot if none is free. Waiting requires a Tokio
+    /// runtime with timers enabled; taking a free slot does not.
     pub async fn run<Context: Post, F: Future<Output: Post> + 'static>(
         &self,
         purpose: &'static str,
@@ -155,8 +160,8 @@ impl ThreadPool {
     ) -> T {
         let start = Instant::now();
         pin_mut!(acquisition);
-        // A free slot is the common case and must stay timer-free: `timer::sleep` panics on
-        // construction outside a Tokio runtime, which taking a slot has never required.
+        // Take a free slot without reaching the timer below, which would otherwise impose a
+        // Tokio runtime on the common path: `timer::sleep` panics on construction without one.
         let slot = match acquisition.as_mut().now_or_never() {
             Some(slot) => slot,
             None => self.warn_until_acquired(purpose, start, acquisition).await,

--- a/linera-execution/src/thread_pool.rs
+++ b/linera-execution/src/thread_pool.rs
@@ -39,6 +39,8 @@ pub const DECOMPRESS_CONTRACT: &str = "decompress_contract";
 /// Decompression of service bytecode.
 pub const DECOMPRESS_SERVICE: &str = "decompress_service";
 
+/// Every purpose, so that the labelled metrics can create all their children at registration.
+#[cfg(with_metrics)]
 const PURPOSES: [&str; 5] = [
     CONTRACT,
     SERVICE_QUERY,

--- a/linera-execution/src/thread_pool.rs
+++ b/linera-execution/src/thread_pool.rs
@@ -226,7 +226,9 @@ mod tests {
         let (release, released) = oneshot::channel();
         let occupant = pool
             .run_send(CONTRACT, (), move |()| async move {
-                let _ = released.await;
+                released
+                    .await
+                    .expect("the test releases the slot before dropping the sender");
             })
             .await;
         assert_eq!(

--- a/linera-execution/src/thread_pool.rs
+++ b/linera-execution/src/thread_pool.rs
@@ -1,0 +1,256 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+An instrumented wrapper around [`web_thread_pool::Pool`], the fixed-capacity pool of OS threads
+that runs synchronous contract and service code off the async executor.
+
+The pool is a permit gate: a caller takes a free slot, or grows the pool up to its capacity, or
+else waits for another caller to return one — with no timeout. Saturation is invisible from the
+outside, because a caller waiting for a slot is a *suspended future* rather than a blocked thread:
+it appears in neither an off-CPU profile nor any log, and the process quietly stops executing
+blocks. A slot holder can also need a second slot before it releases its first — a contract
+querying a service oracle does exactly that — so the wait can be indefinite rather than merely
+long. This module reports the wait while it is still happening, which is what separates a
+saturated pool from a wedged one.
+*/
+
+use std::future::Future;
+
+use futures::{
+    future::{self, Either},
+    pin_mut,
+};
+use linera_base::time::{Duration, Instant};
+use tracing::warn;
+use web_thread_select::Post;
+
+// The `purpose` domain is closed, so every child of the labelled metrics below can be created at
+// registration rather than appearing only once its path has first run.
+
+/// Execution of a contract.
+pub const CONTRACT: &str = "contract";
+/// A one-off service query, including the one a contract makes through a service oracle.
+pub const SERVICE_QUERY: &str = "service_query";
+/// A long-lived service runtime actor, which holds its slot for the life of its chain worker.
+pub const SERVICE_ACTOR: &str = "service_actor";
+/// Decompression of contract bytecode.
+pub const DECOMPRESS_CONTRACT: &str = "decompress_contract";
+/// Decompression of service bytecode.
+pub const DECOMPRESS_SERVICE: &str = "decompress_service";
+
+const PURPOSES: [&str; 5] = [
+    CONTRACT,
+    SERVICE_QUERY,
+    SERVICE_ACTOR,
+    DECOMPRESS_CONTRACT,
+    DECOMPRESS_SERVICE,
+];
+
+/// How long a caller waits for a slot before warning, and between subsequent warnings.
+const SLOW_ACQUISITION_WARN_INTERVAL: Duration = Duration::from_secs(5);
+
+#[cfg(with_metrics)]
+pub(crate) mod metrics {
+    use linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, register_int_gauge_vec,
+    };
+    use prometheus::{HistogramVec, IntGaugeVec};
+
+    use super::PURPOSES;
+
+    const PURPOSE_LABEL: &str = "purpose";
+
+    linera_base::declare_metrics! {
+        /// Histogram of how long a caller waited for a thread-pool slot.
+        pub static ACQUISITION_LATENCY: HistogramVec = {
+            let histogram = register_histogram_vec(
+                "thread_pool_acquisition_latency",
+                "Time spent waiting for an execution thread-pool slot",
+                &[PURPOSE_LABEL],
+                exponential_bucket_latencies(60_000.0),
+            );
+            for purpose in PURPOSES {
+                histogram.with_label_values(&[purpose]);
+            }
+            histogram
+        };
+
+        /// Gauge of the callers currently waiting for a thread-pool slot. A value that stays
+        /// above zero while no acquisitions complete is the signature of a wedged pool.
+        pub static WAITING: IntGaugeVec = {
+            let gauge = register_int_gauge_vec(
+                "thread_pool_waiting",
+                "Callers currently waiting for an execution thread-pool slot",
+                &[PURPOSE_LABEL],
+            );
+            for purpose in PURPOSES {
+                gauge.with_label_values(&[purpose]);
+            }
+            gauge
+        };
+    }
+
+    /// Decrements [`WAITING`] on drop, so that a caller cancelled mid-wait does not leak a count.
+    pub(super) struct WaitingGuard(&'static str);
+
+    impl WaitingGuard {
+        pub(super) fn new(purpose: &'static str) -> Self {
+            WAITING.with_label_values(&[purpose]).inc();
+            WaitingGuard(purpose)
+        }
+    }
+
+    impl Drop for WaitingGuard {
+        fn drop(&mut self) {
+            WAITING.with_label_values(&[self.0]).dec();
+        }
+    }
+}
+
+/// A fixed-capacity pool of OS threads for running synchronous contract and service code.
+pub struct ThreadPool {
+    inner: web_thread_pool::Pool,
+    capacity: usize,
+}
+
+impl ThreadPool {
+    /// Creates a pool that will grow to at most `capacity` threads.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: web_thread_pool::Pool::new(capacity),
+            capacity,
+        }
+    }
+
+    /// Runs `code` on a pool thread, waiting for a slot if none is free.
+    pub async fn run<Context: Post, F: Future<Output: Post> + 'static>(
+        &self,
+        purpose: &'static str,
+        context: Context,
+        code: impl FnOnce(Context) -> F + Send + 'static,
+    ) -> web_thread_pool::Task<F::Output> {
+        self.reporting_the_wait(purpose, self.inner.run(context, code))
+            .await
+    }
+
+    /// Like [`ThreadPool::run`], but the output can be sent through Rust memory without posting.
+    pub async fn run_send<Context: Post, F: Future<Output: Send> + 'static>(
+        &self,
+        purpose: &'static str,
+        context: Context,
+        code: impl FnOnce(Context) -> F + Send + 'static,
+    ) -> web_thread_pool::SendTask<F::Output> {
+        self.reporting_the_wait(purpose, self.inner.run_send(context, code))
+            .await
+    }
+
+    /// Awaits a slot acquisition, recording how long it took and warning every
+    /// [`SLOW_ACQUISITION_WARN_INTERVAL`] until it succeeds. The warning is raced against the
+    /// acquisition because reporting on completion says nothing when the slot never arrives.
+    async fn reporting_the_wait<T>(
+        &self,
+        purpose: &'static str,
+        acquisition: impl Future<Output = T>,
+    ) -> T {
+        #[cfg(with_metrics)]
+        let _waiting = metrics::WaitingGuard::new(purpose);
+        let start = Instant::now();
+        pin_mut!(acquisition);
+        loop {
+            let warn_after = linera_base::time::timer::sleep(SLOW_ACQUISITION_WARN_INTERVAL);
+            pin_mut!(warn_after);
+            match future::select(acquisition.as_mut(), warn_after).await {
+                Either::Left((slot, _)) => {
+                    #[cfg(with_metrics)]
+                    metrics::ACQUISITION_LATENCY
+                        .with_label_values(&[purpose])
+                        .observe(start.elapsed().as_secs_f64() * 1000.0);
+                    return slot;
+                }
+                Either::Right((_, _)) => warn!(
+                    purpose,
+                    capacity = self.capacity,
+                    waited_ms = start.elapsed().as_millis(),
+                    "Still waiting for an execution thread-pool slot; every thread is claimed"
+                ),
+            }
+        }
+    }
+}
+
+#[cfg(all(test, with_metrics))]
+mod tests {
+    use futures::{channel::oneshot, poll};
+
+    use super::*;
+
+    /// Every `purpose` child must exist before any slot has been taken, so that a pool which has
+    /// not yet saturated reads as zero rather than as a metric that was removed.
+    #[test]
+    fn purpose_labelled_metrics_export_every_purpose_before_any_use() {
+        crate::init_metrics();
+
+        let families = prometheus::gather();
+        for name in [
+            "linera_thread_pool_acquisition_latency",
+            "linera_thread_pool_waiting",
+        ] {
+            let family = families
+                .iter()
+                .find(|family| family.get_name() == name)
+                .unwrap_or_else(|| panic!("{name} must be exported once init_metrics has run"));
+            let mut purposes = family
+                .get_metric()
+                .iter()
+                .flat_map(|metric| metric.get_label())
+                .map(|label| label.get_value())
+                .collect::<Vec<_>>();
+            purposes.sort_unstable();
+            let mut expected = PURPOSES;
+            expected.sort_unstable();
+            assert_eq!(purposes, expected, "{name} must export every purpose");
+        }
+    }
+
+    /// A caller blocked on a full pool has to be visible *while* it is still blocked: reporting
+    /// it only once the slot arrives would say nothing at all in the case that never completes.
+    #[tokio::test]
+    async fn a_blocked_acquirer_is_counted_while_it_waits() {
+        let pool = ThreadPool::new(1);
+        let waiting = || metrics::WAITING.with_label_values(&[CONTRACT]).get();
+        let before = waiting();
+
+        let (release, released) = oneshot::channel();
+        let occupant = pool
+            .run_send(CONTRACT, (), move |()| async move {
+                let _ = released.await;
+            })
+            .await;
+        assert_eq!(
+            waiting(),
+            before,
+            "an uncontended slot must not register a wait"
+        );
+
+        let mut blocked = Box::pin(pool.run_send(CONTRACT, (), |()| async move {}));
+        assert!(
+            poll!(blocked.as_mut()).is_pending(),
+            "the only slot is taken, so the second caller must not get one"
+        );
+        assert_eq!(
+            waiting(),
+            before + 1,
+            "a caller without a slot must be counted"
+        );
+
+        release.send(()).unwrap();
+        occupant.await.unwrap();
+        blocked.await.await.unwrap();
+        assert_eq!(
+            waiting(),
+            before,
+            "the count must be released with the slot"
+        );
+    }
+}

--- a/linera-execution/src/thread_pool.rs
+++ b/linera-execution/src/thread_pool.rs
@@ -15,11 +15,11 @@ long. This module reports the wait while it is still happening, which is what se
 saturated pool from a wedged one.
 */
 
-use std::future::Future;
+use std::{future::Future, pin::Pin};
 
 use futures::{
     future::{self, Either},
-    pin_mut,
+    pin_mut, FutureExt as _,
 };
 use linera_base::time::{Duration, Instant};
 use tracing::warn;
@@ -147,29 +147,43 @@ impl ThreadPool {
             .await
     }
 
-    /// Awaits a slot acquisition, recording how long it took and warning every
-    /// [`SLOW_ACQUISITION_WARN_INTERVAL`] until it succeeds. The warning is raced against the
-    /// acquisition because reporting on completion says nothing when the slot never arrives.
+    /// Awaits a slot acquisition and records how long it took.
     async fn reporting_the_wait<T>(
         &self,
         purpose: &'static str,
         acquisition: impl Future<Output = T>,
     ) -> T {
-        #[cfg(with_metrics)]
-        let _waiting = metrics::WaitingGuard::new(purpose);
         let start = Instant::now();
         pin_mut!(acquisition);
+        // A free slot is the common case and must stay timer-free: `timer::sleep` panics on
+        // construction outside a Tokio runtime, which taking a slot has never required.
+        let slot = match acquisition.as_mut().now_or_never() {
+            Some(slot) => slot,
+            None => self.warn_until_acquired(purpose, start, acquisition).await,
+        };
+        #[cfg(with_metrics)]
+        metrics::ACQUISITION_LATENCY
+            .with_label_values(&[purpose])
+            .observe(start.elapsed().as_secs_f64() * 1000.0);
+        slot
+    }
+
+    /// Warns every [`SLOW_ACQUISITION_WARN_INTERVAL`] until the slot arrives. The warning is
+    /// raced against the acquisition because reporting on completion says nothing at all in the
+    /// case that never completes.
+    async fn warn_until_acquired<T>(
+        &self,
+        purpose: &'static str,
+        start: Instant,
+        mut acquisition: Pin<&mut impl Future<Output = T>>,
+    ) -> T {
+        #[cfg(with_metrics)]
+        let _waiting = metrics::WaitingGuard::new(purpose);
         loop {
             let warn_after = linera_base::time::timer::sleep(SLOW_ACQUISITION_WARN_INTERVAL);
             pin_mut!(warn_after);
             match future::select(acquisition.as_mut(), warn_after).await {
-                Either::Left((slot, _)) => {
-                    #[cfg(with_metrics)]
-                    metrics::ACQUISITION_LATENCY
-                        .with_label_values(&[purpose])
-                        .observe(start.elapsed().as_secs_f64() * 1000.0);
-                    return slot;
-                }
+                Either::Left((slot, _)) => return slot,
                 Either::Right((_, _)) => warn!(
                     purpose,
                     capacity = self.capacity,
@@ -181,8 +195,22 @@ impl ThreadPool {
     }
 }
 
-#[cfg(all(test, with_metrics))]
+#[cfg(test)]
 mod tests {
+    use super::*;
+
+    /// Taking a free slot must not require a Tokio runtime: `timer::sleep` panics outside one,
+    /// and the pool needed no runtime before this instrumentation existed.
+    #[test]
+    fn a_free_slot_is_acquired_without_a_tokio_runtime() {
+        let pool = ThreadPool::new(1);
+        let task = futures::executor::block_on(pool.run_send(CONTRACT, (), |()| async { 7u8 }));
+        assert_eq!(futures::executor::block_on(task).unwrap(), 7);
+    }
+}
+
+#[cfg(all(test, with_metrics))]
+mod metrics_tests {
     use futures::{channel::oneshot, poll};
 
     use super::*;

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -27,9 +27,10 @@ use linera_chain::{
     ChainError, ChainStateView,
 };
 use linera_execution::{
-    committee::Committee, BlobState, ExecutionError, ExecutionRuntimeConfig,
-    ExecutionRuntimeContext, SharedCommittees, TransactionTracker, UserContractCode,
-    UserServiceCode, WasmRuntime,
+    committee::Committee,
+    thread_pool::{DECOMPRESS_CONTRACT, DECOMPRESS_SERVICE},
+    BlobState, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, SharedCommittees,
+    TransactionTracker, UserContractCode, UserServiceCode, WasmRuntime,
 };
 #[cfg(with_revm)]
 use linera_execution::{
@@ -314,7 +315,7 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         #[cfg_attr(not(any(with_wasm_runtime, with_revm)), allow(unused_variables))]
         let contract_bytecode = self
             .thread_pool()
-            .run_send((), move |()| async move {
+            .run_send(DECOMPRESS_CONTRACT, (), move |()| async move {
                 compressed_contract_bytecode.decompress()
             })
             .await
@@ -381,7 +382,7 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         #[cfg_attr(not(any(with_wasm_runtime, with_revm)), allow(unused_variables))]
         let service_bytecode = self
             .thread_pool()
-            .run_send((), move |()| async move {
+            .run_send(DECOMPRESS_SERVICE, (), move |()| async move {
                 compressed_service_bytecode.decompress()
             })
             .await


### PR DESCRIPTION
## Motivation

`linera_execution::ThreadPool` (a re-export of `web_thread_pool::Pool`, capacity hardcoded to
`20` in `DbStorage::new`) is the fixed-capacity pool of OS threads that runs synchronous contract
and service code off the async executor. `Pool::get` takes a free slot, grows the pool up to its
capacity, or else waits for another caller to return one — with no timeout:

```rust
if id.is_none() {
    id = self.receiver.recv_async().await.ok();   // waits indefinitely
}
```

Saturation of that pool is currently **invisible**. A caller waiting for a slot is a suspended
future, not a blocked thread, so it appears in neither an off-CPU profile (which samples blocked
OS threads) nor in any log, and there is no metric. The process simply stops executing blocks
while every health check stays green.

That matters more than a plain capacity limit would, because a slot holder can need a **second**
slot before it releases its first. `run_user_action_with_runtime` holds its guard across the whole
host-call drain (`execution_state_actor.rs`), and `handle_request` re-enters the pool on at least
two paths:

- `QueryServiceOracle` → `query_user_application_with_deadline` → `thread_pool.run_send(…)`.
  Unconditional on the proposing path; `TransactionTracker::oracle` only skips it when replaying a
  recorded response, so a validator validating a proposal is safe but a proposer is not. This is
  live today: `pm-oracle`'s contract calls `query_service` to prefetch verification data.
- `LoadContract` / `LoadService` → `Storage::load_contract` → `thread_pool().run_send(decompress)`,
  on a cold `user_contracts` miss, reached whenever a contract cross-calls an application outside
  its declared `required_application_ids` closure.

So the wait can be indefinite rather than merely long, and today the two are indistinguishable
from the outside — both look like a process that has gone quiet.

This PR does **not** change that behaviour. It makes it observable, which is the prerequisite for
choosing between the candidate fixes (exempting re-entrant acquisitions from the cap, reserving a
lane, or making the capacity configurable) with evidence about how close production actually runs
to the limit rather than guesses.

## Proposal

Replace the bare re-export with a thin instrumented wrapper in `linera-execution/src/thread_pool.rs`
that delegates to `web_thread_pool::Pool` and reports the wait:

- `linera_thread_pool_acquisition_latency{purpose}` — histogram of time spent waiting for a slot.
  The pool grows lazily to its capacity, so a non-trivial value here means every thread is claimed;
  it is zero until the pool actually saturates.
- `linera_thread_pool_waiting{purpose}` — gauge of callers currently blocked. A value that stays
  above zero while no acquisitions complete is the signature of a wedged pool, as opposed to a
  merely busy one.
- A `warn!` every 5s **while the caller is still waiting**, carrying the purpose, the capacity and
  the elapsed time. Emitting only on completion would say nothing at all in the one case that
  matters, where the slot never arrives — so the warning is raced against the acquisition rather
  than logged after it.

Taking a *free* slot goes through a `now_or_never` fast path that constructs no timer, so the
common path keeps the pool's existing contract and costs nothing. **Waiting** for a slot does need
a clock, so it requires a Tokio runtime with timers enabled, which `web_thread_pool::Pool` did not.
That is inherent to reporting a wait while it is still happening, and it is stated in the module
docs and on `ThreadPool::run` rather than left implicit. It is unreachable today: every runtime in
the workspace is built with `enable_all()` (`linera-service/src/{server.rs:746,proxy/main.rs:613,
cli/main.rs:2332}`, `linera-exporter/src/main.rs:{270,296}`, `linera-bridge`, `linera-summary`, and
all benches), and the web timer (`linera-kywasmtime`) touches `js_sys::global()` in `poll`, not at
construction.

Each of the five call sites passes a `purpose`, so a saturation event names the path that caused
it instead of only its existence. The domain is closed and small (`contract`, `service_query`,
`service_actor`, `decompress_contract`, `decompress_service`), so every label child is created at
registration, following #6795 — a cold path reads as `0`, not as a metric that was removed.

The waiting count is released by a drop guard, so a caller cancelled mid-wait does not leak it.

## Test Plan

- New unit tests in `linera-execution/src/thread_pool.rs`:
  - `purpose_labelled_metrics_export_every_purpose_before_any_use` — asserts both metrics export
    all five `purpose` children after `init_metrics()` and before any slot is taken.
  - `a_blocked_acquirer_is_counted_while_it_waits` — fills a `ThreadPool::new(1)`, polls a second
    acquisition, and asserts it is pending and counted *while still blocked*, then that the count
    is released with the slot. This exercises the property that motivates the change, rather than
    just the registration.
  - `a_free_slot_is_acquired_without_a_tokio_runtime` — pins the fast path's contract, and is
    deliberately not `metrics`-gated because it is about runtime requirements, not metrics.
- **Positive-controlled**, since a test that cannot fail proves nothing. Removing the pre-created
  label children makes the first test fail with
  `linera_thread_pool_acquisition_latency must be exported once init_metrics has run`; making the
  waiting guard inert makes the second fail on `a caller without a slot must be counted`; removing
  the `now_or_never` fast path makes the third fail with `there is no reactor running`. All three
  were confirmed red under the mutation and green once restored.
- `cargo test -p linera-execution --features metrics,test --lib thread_pool` → 2 passed, 0 failed.
- `cargo clippy -p linera-execution -p linera-storage -p linera-core --features metrics --all-targets`
  → no warnings.
- `cargo +nightly fmt --all -- --check` → clean.

After deploy, the check is that both metric names return all five `purpose` children on every node,
and that `linera_thread_pool_waiting` sits at zero outside of load.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

## Links

- Follows the label pre-creation convention introduced in #6795.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
