### PR TITLE
Restate dependency recovery around block-proposal validity

### DIFF
--- a/linera-core/src/proof/availability.rs
+++ b/linera-core/src/proof/availability.rs
@@ -193,7 +193,7 @@ pub trait LockingBlobsTravelWithTheLock: CorrectValidator + CorrectValidatorAvai
 ///
 /// This is what makes the retry loops in `linera_core::updater` converge rather than spin, and it
 /// is the substance behind [`ValidationQuorumForms`]'s claim that a step completes in `2Δ`: a
-/// straggler is not waited out, it is *supplied*.
+/// straggler is not waited out, it is *supplied*, by the party that already holds what it lacks.
 ///
 /// *Proof.* The classes are exactly the errors those loops match, and the recovery route differs
 /// by where the data originates:
@@ -208,29 +208,43 @@ pub trait LockingBlobsTravelWithTheLock: CorrectValidator + CorrectValidatorAvai
 /// | `WrongRound`, `UnexpectedBlockHeight` — validator behind | acceptance | consensus state for this chain | pushed by `send_chain_information` |
 /// | `WrongRound`, `UnexpectedBlockHeight` — *requester* behind | acceptance | nothing; the requester is wrong | pulled: `sync_remote_if_needed` reports [`LocalNodeLagging`] and the client synchronizes |
 ///
-/// All but `MissingCrossChainUpdates` and `EventsNotFound` are *self-suppliable*: the requester
-/// holds the data already, so the push cannot fail for want of it. Usually that is by
-/// construction, because it built the block or verified the certificate. The one case where it is
-/// not is a lock the requester is *recovering* rather than one it created: there the blobs were
-/// collected during synchronization, by [`LockingBlobsTravelWithTheLock`]. Either way these
-/// classes cannot stall. ∎
+/// **Every class is self-suppliable.** In each row the requester already holds what the validator
+/// lacks, so the push cannot fail for want of the data, and no class waits on a third party. The
+/// pushes read local storage and nothing else: `read_certificates_for_heights` for chain
+/// information, `read_blobs_from_storage` for blobs, `get_next_height_to_preprocess` to decide how
+/// far to send a publishing chain.
 ///
-/// **Those two are not, and that is where general liveness is weakest.** Their data originates
-/// on a *third* chain. A client that does not follow the sending or publishing chain cannot push
-/// what the validator is missing, and the push simply fails.
+/// *Why the requester holds it.* Two arguments, one per operation.
 ///
-/// There is a second, independent route for them, which is why this is a weakness rather than a
-/// hole: the validator's own worker for the sending chain populates the inbox as it processes that
-/// chain ([`IncomingBundlesAreSelfDerived`]), and events likewise arrive as the publishing chain
-/// is processed. So the data reaches the validator either because someone pushes it or because the
-/// validator catches up on the originating chain — and progress on *this* chain waits on whichever
-/// happens first.
+/// * *Accepting a proposal.* The requester built the proposal, which means its own local node
+///   executed the block. Execution consumes exactly these dependencies, so holding them is a
+///   precondition of having a proposal to send. `linera_core::updater` states the messaging case as
+///   an invariant of local storage: it is "guaranteed to hold every block we needed to build a
+///   proposal", because a bundle can only be consumed after its ordered message-bearing
+///   predecessors were downloaded. The same holds of an event a block reads — the block could not
+///   have executed without it, and having it means having processed the publishing chain's block.
+/// * *Executing a certified block.* The block is certified, so its dependencies are retrievable by
+///   [`CertifiedBlockIsAvailable`], and a requester that processed the certificate wrote them as it
+///   went ([`BlockOutputsArePersisted`]). The blob arm says so outright — "the certificate is
+///   confirmed, so the blobs must be in storage" — and treats a miss as an error rather than a
+///   condition to wait out.
 ///
-/// Neither route is bounded by anything the specification currently states.
-/// [`ValidationQuorumForms`] assumes the proposal is accepted once every correct validator is in
-/// the round; for a block consuming a message from a chain that some validator has not yet
-/// processed, that is an additional condition, and no assumption in
-/// [`super::assumptions`] supplies it.
+/// The one case where holding the data is not immediate is a lock the requester is *recovering*
+/// rather than one it created: there the blobs were collected during synchronization, by
+/// [`LockingBlobsTravelWithTheLock`]. ∎
+///
+/// **A requester need not follow a whole chain to supply what came from it.** This is what makes
+/// the argument hold for the two classes whose data originates on a third chain. A chain the
+/// requester merely *receives* from is stored only at its message-bearing heights, and
+/// `send_chain_information` pushes exactly those, skipping heights it does not have; the validator
+/// executes the contiguous prefix and *preprocesses* any block above a gap, which is enough to
+/// deliver that block's bundles. So the requester supplies a sparse chain it never fully held, and
+/// the validator is still able to act.
+///
+/// This is also why the set to push is derived from local storage rather than from the error.
+/// `MissingCrossChainUpdates` names only the bundles the current proposal needs and omits
+/// already-consumed ancestors that the validator must execute first; `send_chain_information`
+/// sends the whole locally-held range instead, so the omission does not matter.
 ///
 /// **Why the pushes terminate.** Each class carries a well-founded measure.
 /// `send_confirmed_certificate` latches `sent_admin_chain` / `sent_blobs` / `sent_blocks`, so each

--- a/linera-core/src/proof/availability.rs
+++ b/linera-core/src/proof/availability.rs
@@ -208,13 +208,17 @@ pub trait LockingBlobsTravelWithTheLock: CorrectValidator + CorrectValidatorAvai
 /// | `WrongRound`, `UnexpectedBlockHeight` — validator behind | acceptance | consensus state for this chain | pushed by `send_chain_information` |
 /// | `WrongRound`, `UnexpectedBlockHeight` — *requester* behind | acceptance | nothing; the requester is wrong | pulled: `sync_remote_if_needed` reports [`LocalNodeLagging`] and the client synchronizes |
 ///
-/// **Every class is self-suppliable.** In each row the requester already holds what the validator
-/// lacks, so the push cannot fail for want of the data, and no class waits on a third party. The
-/// pushes read local storage and nothing else: `read_certificates_for_heights` for chain
+/// **Every dependency is already available at the requester.** In each row the requester holds what
+/// the validator lacks, so the push cannot fail for want of the data, and no class waits on a third
+/// party. The pushes read local storage and nothing else: `read_certificates_for_heights` for chain
 /// information, `read_blobs_from_storage` for blobs, `get_next_height_to_preprocess` to decide how
 /// far to send a publishing chain.
 ///
-/// *Why the requester holds it.* Two arguments, one per operation.
+/// This is a *local* availability claim, and it is stronger than the network-wide one:
+/// [`CertifiedBlockIsAvailable`] says the data can be obtained from some quorum, whereas here it is
+/// already in the hand of the party that needs to supply it.
+///
+/// *Why it is available there.* Two arguments, one per operation.
 ///
 /// * *Accepting a proposal.* The requester built the proposal, which means its own local node
 ///   executed the block. Execution consumes exactly these dependencies, so holding them is a
@@ -229,11 +233,11 @@ pub trait LockingBlobsTravelWithTheLock: CorrectValidator + CorrectValidatorAvai
 ///   confirmed, so the blobs must be in storage" — and treats a miss as an error rather than a
 ///   condition to wait out.
 ///
-/// The one case where holding the data is not immediate is a lock the requester is *recovering*
-/// rather than one it created: there the blobs were collected during synchronization, by
+/// The one case where availability is not immediate is a lock the requester is *recovering* rather
+/// than one it created: there the blobs were collected during synchronization, by
 /// [`LockingBlobsTravelWithTheLock`]. ∎
 ///
-/// **A requester need not follow a whole chain to supply what came from it.** This is what makes
+/// **A requester need not follow a whole chain to make its blocks available.** This is what makes
 /// the argument hold for the two classes whose data originates on a third chain. A chain the
 /// requester merely *receives* from is stored only at its message-bearing heights, and
 /// `send_chain_information` pushes exactly those, skipping heights it does not have; the validator

--- a/linera-core/src/proof/availability.rs
+++ b/linera-core/src/proof/availability.rs
@@ -186,69 +186,98 @@ pub trait BoundedCatchUp: CertifiedBlockIsAvailable + BoundedRecovery {}
 /// [`ValidatedBlockCertificate`]: linera_chain::types::ValidatedBlockCertificate
 pub trait LockingBlobsTravelWithTheLock: CorrectValidator + CorrectValidatorAvailability {}
 
-/// **Lemma (Missing dependencies are recoverable).** A validator needs data in hand for either of
-/// two operations: *accepting a block proposal*, which means executing it, and *executing a
-/// certified block*. When it lacks that data, what is missing falls into a closed set of classes,
-/// each with a route by which it arrives.
+/// **Lemma (A client can obtain everything a submission depends on).** A client can always find, on
+/// the network, the data it needs in order to submit
 ///
-/// This is what makes the retry loops in `linera_core::updater` converge rather than spin, and it
-/// is the substance behind [`ValidationQuorumForms`]'s claim that a step completes in `2Δ`: a
-/// straggler is not waited out, it is *supplied*, by the party that already holds what it lacks.
+/// 1. a **valid block proposal** — one every correct validator will accept — or
+/// 2. a **confirmed certificate**, to a validator that does not yet have it;
 ///
-/// *Proof.* The classes are exactly the errors those loops match, and the recovery route differs
-/// by where the data originates:
+/// and having found it, it can hand that data to any validator that is missing it.
 ///
-/// | class | blocks | what is missing | route |
+/// The two halves are *discovery* and *supply*, and they are separate claims. Discovery is what a
+/// client does before it has a block at all; supply is what happens when a validator turns out to
+/// be behind. The second is easy once the first has happened, because building the proposal is what
+/// puts the data in the client's own storage.
+///
+/// # What a valid proposal requires
+///
+/// Validity is not one condition, so the dependencies are not one kind. `try_handle_block_proposal`
+/// checks the following in order, and each check is a demand on data the validator must already
+/// hold. The right-hand column is how a client comes to hold it too.
+///
+/// | the proposal is valid only if | the validator needs | error when it lacks it | how a client finds it |
 /// |---|---|---|---|
-/// | `BlobsNotFound` | both | a blob the block publishes or reads | pushed by the requester: `send_pending_blobs` when accepting a proposal, `upload_blobs` from local storage when executing a certified block |
-/// | `EventsNotFound` | both | an event the block read | the **publishing** chain's certificates; the admin chain is special-cased for epoch events |
-/// | `BlocksNotFound` | execution | ancestor block bytes a checkpoint trust-marked | pushed from the requester's storage |
-/// | `MissingCrossChainUpdates` | acceptance | the incoming bundles the block consumes | the **sending** chains' certificates |
-/// | `InactiveChain` | acceptance | the chain does not exist at that validator | pushed with the chain's creation |
-/// | `WrongRound`, `UnexpectedBlockHeight` — validator behind | acceptance | consensus state for this chain | pushed by `send_chain_information` |
-/// | `WrongRound`, `UnexpectedBlockHeight` — *requester* behind | acceptance | nothing; the requester is wrong | pulled: `sync_remote_if_needed` reports [`LocalNodeLagging`] and the client synchronizes |
+/// | the chain exists at all | the chain description blob | `InactiveChain` | from the creating chain's block |
+/// | its height and parent hash continue the chain (`verify_block_chaining`) | that chain's certified prefix | `UnexpectedBlockHeight` | `ChainClient::synchronize_chain_state` |
+/// | its round is one this validator can accept ([`ProposalGate`]) | the consensus state at that height | `WrongRound` | the same, plus `ChainClient::prepare_chain` |
+/// | it declares the chain's current epoch (`check_block_epoch`) | the committee for that epoch, hence the admin chain's epoch event | `EventsNotFound` on the epoch stream | by following the admin chain, which every client does |
+/// | every incoming bundle it consumes is present in the inbox, equal, and in cursor order | the *sending* chains' message-bearing blocks, already delivered into that inbox | `MissingCrossChainUpdates` | `ChainClient::find_received_certificates` |
+/// | its transactions execute correctly | every blob the block publishes or reads, and every event it reads | `BlobsNotFound`, `EventsNotFound` | `download_blob` / `download_pending_blob`, and `Client::sync_events_from_node` |
 ///
-/// **Every dependency is already available at the requester.** In each row the requester holds what
-/// the validator lacks, so the push cannot fail for want of the data, and no class waits on a third
-/// party. The pushes read local storage and nothing else: `read_certificates_for_heights` for chain
-/// information, `read_blobs_from_storage` for blobs, `get_next_height_to_preprocess` to decide how
-/// far to send a publishing chain.
+/// The inbox row is the one that needs care, because "valid" there means more than "the bundle
+/// exists". `remove_bundles_from_inboxes` runs with `must_be_present = true`, so the bundle must
+/// already be in *that validator's* inbox and equal to what it holds
+/// ([`IncomingBundlesAreSelfDerived`]); and consumption must respect cursor order, skipping only
+/// bundles every message of which is skippable ([`DeliveryAndConsumptionAreOrdered`]). A client
+/// therefore cannot make a proposal valid by supplying a bundle in isolation: it supplies the
+/// sending chain's blocks, and the validator derives the inbox from them itself.
+///
+/// # Discovery
+///
+/// Each row's last column is a request to the network, not a lookup in something the client is
+/// assumed to have. The client learns of incoming messages by asking validators for their received
+/// logs (`find_received_certificates`), of blobs by downloading them, of events by
+/// `sync_events_from_node`, and of its own chain's state by synchronizing it.
+///
+/// *This half is quorum-dependent, and the code says so.* `find_received_certificates` is
+/// documented as best effort: it finds only certificates confirmed among sufficiently many
+/// validators of the sending chain's *current* committee — which holds "whenever a sender's chain
+/// is still in use and is regularly upgraded to new committees". A message from a chain that has
+/// since gone quiet across a reconfiguration is the case that is not covered, which is the
+/// availability question in [`super::assumptions::BlobRetention`]'s family rather than a defect in
+/// the supply argument below.
+///
+/// # Supply
+///
+/// *Every dependency is by then available at the requester, locally.* Building the proposal means
+/// the client's own local node executed the block, and execution consumes exactly the data in the
+/// table; so holding it is a precondition of having a proposal to submit, not a coincidence.
+/// `linera_core::updater` states the messaging case as an invariant of local storage: it is
+/// "guaranteed to hold every block we needed to build a proposal", because a bundle can only be
+/// consumed after its ordered message-bearing predecessors were downloaded.
+///
+/// For case (2) the argument is shorter: the block is certified, so its dependencies are
+/// retrievable at all ([`CertifiedBlockIsAvailable`]), and a client that processed the certificate
+/// wrote them as it went ([`BlockOutputsArePersisted`]). The blob arm of `send_confirmed_certificate`
+/// says so outright — "the certificate is confirmed, so the blobs must be in storage" — and treats
+/// a miss as an error rather than something to wait for.
 ///
 /// This is a *local* availability claim, and it is stronger than the network-wide one:
 /// [`CertifiedBlockIsAvailable`] says the data can be obtained from some quorum, whereas here it is
-/// already in the hand of the party that needs to supply it.
+/// already in the hand of the party that must supply it. That is why the pushes read local storage
+/// and nothing else — `read_certificates_for_heights`, `read_blobs_from_storage`,
+/// `get_next_height_to_preprocess` — and why no class waits on a third party. ∎
 ///
-/// *Why it is available there.* Two arguments, one per operation.
+/// The one case where local availability is not immediate is a lock the client is *recovering*
+/// rather than one it created: there the blobs were collected during synchronization, by
+/// [`LockingBlobsTravelWithTheLock`].
 ///
-/// * *Accepting a proposal.* The requester built the proposal, which means its own local node
-///   executed the block. Execution consumes exactly these dependencies, so holding them is a
-///   precondition of having a proposal to send. `linera_core::updater` states the messaging case as
-///   an invariant of local storage: it is "guaranteed to hold every block we needed to build a
-///   proposal", because a bundle can only be consumed after its ordered message-bearing
-///   predecessors were downloaded. The same holds of an event a block reads — the block could not
-///   have executed without it, and having it means having processed the publishing chain's block.
-/// * *Executing a certified block.* The block is certified, so its dependencies are retrievable by
-///   [`CertifiedBlockIsAvailable`], and a requester that processed the certificate wrote them as it
-///   went ([`BlockOutputsArePersisted`]). The blob arm says so outright — "the certificate is
-///   confirmed, so the blobs must be in storage" — and treats a miss as an error rather than a
-///   condition to wait out.
+/// # Two things this makes possible
 ///
-/// The one case where availability is not immediate is a lock the requester is *recovering* rather
-/// than one it created: there the blobs were collected during synchronization, by
-/// [`LockingBlobsTravelWithTheLock`]. ∎
+/// **A client need not follow a whole chain to supply what came from it.** A chain it merely
+/// receives from is stored only at its message-bearing heights, and `send_chain_information` pushes
+/// exactly those, silently skipping heights it does not have; the validator executes the contiguous
+/// prefix and *preprocesses* any block above a gap, which is enough to deliver that block's
+/// bundles. So a sparse chain the client never fully held is still enough to make the inbox row
+/// true at the validator.
 ///
-/// **A requester need not follow a whole chain to make its blocks available.** This is what makes
-/// the argument hold for the two classes whose data originates on a third chain. A chain the
-/// requester merely *receives* from is stored only at its message-bearing heights, and
-/// `send_chain_information` pushes exactly those, skipping heights it does not have; the validator
-/// executes the contiguous prefix and *preprocesses* any block above a gap, which is enough to
-/// deliver that block's bundles. So the requester supplies a sparse chain it never fully held, and
-/// the validator is still able to act.
-///
-/// This is also why the set to push is derived from local storage rather than from the error.
+/// **The set to push is derived from local storage, not from the error.**
 /// `MissingCrossChainUpdates` names only the bundles the current proposal needs and omits
-/// already-consumed ancestors that the validator must execute first; `send_chain_information`
-/// sends the whole locally-held range instead, so the omission does not matter.
+/// already-consumed ancestors the validator must execute first, so deriving the push from it would
+/// be unreliable; `send_chain_information` sends the whole locally-held range instead.
+///
+/// [`ProposalGate`]: linera_chain::manager::proof::voting::ProposalGate
+/// [`DeliveryAndConsumptionAreOrdered`]: super::availability::DeliveryAndConsumptionAreOrdered
 ///
 /// **Why the pushes terminate.** Each class carries a well-founded measure.
 /// `send_confirmed_certificate` latches `sent_admin_chain` / `sent_blobs` / `sent_blocks`, so each

--- a/linera-core/src/proof/storage.rs
+++ b/linera-core/src/proof/storage.rs
@@ -143,9 +143,9 @@ pub trait AdmissionChecksTheValidityProof:
 }
 
 /// **Invariant (Derived state agrees with the certified prefix).** The parts of a chain's state that
-/// are neither self-verifying nor quorum-attested — the block-height indexes, the outbox counters
-/// and queues, the inbox cursors — are functions of that chain's committed blocks, and equal the
-/// value that recomputing them from those blocks would give.
+/// are not certified — the block-height indexes, the outbox counters and queues, the inbox cursors —
+/// are functions of that chain's committed blocks, and equal the value that recomputing them from
+/// those blocks would give.
 ///
 /// **This is the class with no validity proof.** A wrong index or a wrong counter is not detectable
 /// by rehashing or by re-verifying signatures, because nobody attested it and nothing determines it

--- a/linera-spec/src/lib.rs
+++ b/linera-spec/src/lib.rs
@@ -153,18 +153,12 @@
 //!
 //! # Known gaps
 //!
-//! Three places where the implementation does not deliver what a proof wants. Each needs a change
+//! Two places where the implementation does not deliver what a proof wants. Each needs a change
 //! to the code, or a weaker result, to close; none is closed by rereading.
 //!
 //! * [`FullReachability`] — the lock-recovery step wants the proposer to reach *every* correct
 //!   validator, while `synchronize_chain_state` guarantees only a quorum plus a grace period.
 //!   Affects liveness only.
-//! * [`MissingDependenciesAreRecoverable`] — a block that consumes a message or reads an event
-//!   depends on data originating on a *third* chain. Blobs, ancestors and chain state are
-//!   self-suppliable, so a lagging validator is simply handed them; these two classes are not. If
-//!   the proposer does not follow the sending or publishing chain either, the validator waits on
-//!   its own catch-up of that chain, which no assumption bounds — so
-//!   [`ValidationQuorumForms`]'s `2Δ` step does not apply to such blocks. Affects liveness only.
 //! * [`AccountabilityScope`] — incorrect block execution is not attributable, and its effects are
 //!   not confined to one chain: a wrong `messages` or `events` field is consumed by other chains
 //!   whose resulting blocks are themselves properly certified. The protections are
@@ -266,7 +260,6 @@
 //! [`BlockOutputsArePersisted`]: linera_core::proof::availability::BlockOutputsArePersisted
 //! [`InboxHoldsOnlySentBundles`]: linera_core::proof::availability::InboxHoldsOnlySentBundles
 //! [`BundleConsumedAtMostOnce`]: linera_core::proof::availability::BundleConsumedAtMostOnce
-//! [`ValidationQuorumForms`]: linera_core::proof::progress::ValidationQuorumForms
 //! [`FastRetryPreservesBlock`]: linera_chain::manager::proof::safety::FastRetryPreservesBlock
 //! [`ProposalGate`]: linera_chain::manager::proof::voting::ProposalGate
 //! [`VoteConstructionSites`]: linera_chain::manager::proof::voting::VoteConstructionSites


### PR DESCRIPTION
## Motivation

`MissingDependenciesAreRecoverable` (#6692) classified `MissingCrossChainUpdates` and `EventsNotFound` as data a client might not be able to supply, because it originates on a third chain. It called this "where general liveness is weakest" and concluded that `ValidationQuorumForms`'s `2Δ` step does not apply to blocks that consume messages or read events. That was carried into the index as a known gap.

**It is wrong.** The protocol does guarantee a client can obtain a block's dependencies, and the implementation says so in its own words. From `linera_core::updater`:

> Because our local storage is **guaranteed to hold every block we needed to build a proposal** (a bundle can only be consumed after its ordered message-bearing predecessors were downloaded), this is the reliable way to catch a validator up.

and on the certificate path:

> The certificate is confirmed, so **the blobs must be in storage**.

A client cannot have a proposal to submit without its own local node having executed the block, and execution consumes exactly the dependencies in question.

The statement had a second problem: it derived its taxonomy from the *error enum*, so a reader had no way to tell whether the list of classes was complete.

## Proposal

Restate the lemma around what makes a submission valid, rather than around which errors the retry loops match.

**The claim.** A client can always find, on the network, the data it needs to submit (1) a valid block proposal or (2) a confirmed certificate — and having found it, can hand that data to any validator missing it. These are two separate claims, *discovery* and *supply*, and the statement now treats them separately: discovery is what a client does before it has a block at all; supply is what happens when a validator turns out to be behind.

**Validity is not one condition, so the dependencies are not one kind.** The table now follows `try_handle_block_proposal`'s actual check order, so each row is a validity condition rather than an error code — which is what makes the set closed:

| valid only if | the validator needs | how a client finds it |
|---|---|---|
| the chain exists | the chain description blob | from the creating chain's block |
| height and parent hash continue the chain | that chain's certified prefix | `synchronize_chain_state` |
| the round is one the validator accepts | consensus state at that height | `prepare_chain` |
| it declares the chain's current epoch | that epoch's committee, via the admin chain's event | following the admin chain |
| incoming bundles match the inbox, in order | the *sending* chains' message-bearing blocks | `find_received_certificates` |
| transactions execute correctly | blobs published/read, events read | `download_blob`, `sync_events_from_node` |

The inbox row needs the most care, and the statement says why: `must_be_present = true` means the bundle must already be in *that validator's* inbox and equal to what it holds, and consumption must respect cursor order. So a client cannot make a proposal valid by supplying a bundle in isolation — it supplies the sending chain's blocks and the validator derives the inbox itself.

**Supply.** Every dependency is by then available at the client, locally — a *stronger* claim than the network-wide `CertifiedBlockIsAvailable`, since the data is already in the hand of the party that must supply it. That is why every push reads local storage and nothing else: `read_certificates_for_heights`, `read_blobs_from_storage`, `get_next_height_to_preprocess`.

Two supporting facts that were missing, and that explain why the design works:

- **A client need not follow a whole chain to supply what came from it.** A chain it merely receives from is stored only at message-bearing heights; `send_chain_information` pushes exactly those and skips the rest, and the validator preprocesses blocks above a gap — enough to deliver their bundles. This is the deliberate design of #4181, which the old text mistook for a shortfall.
- **The push set is derived from local storage, not from the error**, precisely because `MissingCrossChainUpdates` omits already-consumed ancestors and would be unreliable as a source.

### A discovery-side caveat, newly recorded

`find_received_certificates` documents itself as best effort: it finds only certificates confirmed among sufficiently many validators of the sending chain's *current* committee, which holds "whenever a sender's chain is still in use and is regularly upgraded to new committees". The uncovered case is a message from a chain that has gone quiet across a reconfiguration — an availability/retention question, not a defect in the supply argument.

### Terminology

The first draft of this PR coined "self-suppliable". The module is called `availability` and already has `CertifiedBlockIsAvailable`, so the existing concept covers it; new jargon for a concept two lines above is a poor trade. Also aligns one leftover in `proof::storage`: `DerivedStateAgreesWithCertifiedPrefix` described its subject as "neither self-verifying nor quorum-attested", vocabulary the module header dropped when #6796 separated blob integrity from blob validity. It now says "not certified", matching the table.

### Index

The corresponding "known gaps" entry is removed, leaving two: `FullReachability` and `AccountabilityScope`. The now-orphaned `ValidationQuorumForms` link definition goes with it.

## Test Plan

CI. Documentation-only: no trait is added, removed or renamed, and no supertrait changes. `cargo doc --all-features` under `-D warnings`, `cargo +nightly fmt --check` and `cargo clippy --all-features` are clean.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6692 — introduced the statement corrected here.
- #6799 — the genuine delivery weakness, which is validator-side retry rather than availability to clients.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
