### PR TITLE
Skip the test suite for specification-only pull requests

### DIFF
--- a/.github/workflows/bridge-check.yml
+++ b/.github/workflows/bridge-check.yml
@@ -60,6 +60,15 @@ jobs:
               # Workflow-only PRs don't need heavy code tests; merge to main
               # validates the workflow itself by running it for real.
               - '!.github/workflows/**'
+              # Specification-only changes: doc comments on marker traits with no
+              # members, implementors or call sites. rust.yml still runs clippy,
+              # cargo doc and cargo fmt on them, which is all that can fail.
+              - '!linera-spec/**'
+              - '!linera-chain/src/proof/**'
+              - '!linera-chain/src/manager/proof/**'
+              - '!linera-chain/src/data_types/proof/**'
+              - '!linera-chain/src/justification/proof.rs'
+              - '!linera-core/src/proof/**'
   bridge-check:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -48,6 +48,15 @@ jobs:
               # Workflow-only PRs don't need heavy code tests; merge to main
               # validates the workflow itself by running it for real.
               - '!.github/workflows/**'
+              # Specification-only changes: doc comments on marker traits with no
+              # members, implementors or call sites. rust.yml still runs clippy,
+              # cargo doc and cargo fmt on them, which is all that can fail.
+              - '!linera-spec/**'
+              - '!linera-chain/src/proof/**'
+              - '!linera-chain/src/manager/proof/**'
+              - '!linera-chain/src/data_types/proof/**'
+              - '!linera-chain/src/justification/proof.rs'
+              - '!linera-core/src/proof/**'
 
   test:
     needs: changed-files

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -54,6 +54,15 @@ jobs:
               # Workflow-only PRs don't need heavy code tests; merge to main
               # validates the workflow itself by running it for real.
               - '!.github/workflows/**'
+              # Specification-only changes: doc comments on marker traits with no
+              # members, implementors or call sites. rust.yml still runs clippy,
+              # cargo doc and cargo fmt on them, which is all that can fail.
+              - '!linera-spec/**'
+              - '!linera-chain/src/proof/**'
+              - '!linera-chain/src/manager/proof/**'
+              - '!linera-chain/src/data_types/proof/**'
+              - '!linera-chain/src/justification/proof.rs'
+              - '!linera-core/src/proof/**'
 
   indexer-check:
     needs: changed-files

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -53,6 +53,15 @@ jobs:
               # Workflow-only PRs don't need heavy code tests; merge to main
               # validates the workflow itself by running it for real.
               - '!.github/workflows/**'
+              # Specification-only changes: doc comments on marker traits with no
+              # members, implementors or call sites. rust.yml still runs clippy,
+              # cargo doc and cargo fmt on them, which is all that can fail.
+              - '!linera-spec/**'
+              - '!linera-chain/src/proof/**'
+              - '!linera-chain/src/manager/proof/**'
+              - '!linera-chain/src/data_types/proof/**'
+              - '!linera-chain/src/justification/proof.rs'
+              - '!linera-core/src/proof/**'
 
   check-all-features-partition:
     needs: changed-files

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
+      should-run-code: ${{ steps.files-changed.outputs.code }}
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -61,9 +62,36 @@ jobs:
               # Workflow-only PRs don't need heavy code tests; merge to main
               # validates the workflow itself by running it for real.
               - '!.github/workflows/**'
+            # Same as `paths`, and additionally excluding the correctness
+            # specification. Those files hold only marker traits: public traits
+            # with no members, no implementors and no call sites, carrying the
+            # specification in their doc comments. Nothing observable at runtime
+            # can change there, so the test suite cannot fail on an edit the
+            # clippy, doc and fmt lints pass. Those lints keep running: they are
+            # what catches a supertrait cycle (E0391), a broken intra-doc link,
+            # or misformatted doc prose.
+            #
+            # A PR touching any other file -- including Cargo.lock -- still runs
+            # everything, because `predicate-quantifier: every` keeps a file only
+            # when it matches all patterns.
+            code:
+              - '!docker/**'
+              - '!configuration/**'
+              - '!docs/**'
+              - '!mdbook/**'
+              - '!CONTRIBUTING.md'
+              - '!INSTALL.md'
+              - '!README.md'
+              - '!.github/workflows/**'
+              - '!linera-spec/**'
+              - '!linera-chain/src/proof/**'
+              - '!linera-chain/src/manager/proof/**'
+              - '!linera-chain/src/data_types/proof/**'
+              - '!linera-chain/src/justification/proof.rs'
+              - '!linera-core/src/proof/**'
   execution-wasmtime-test:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: needs.changed-files.outputs.should-run-code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -76,7 +104,7 @@ jobs:
 
   bridge-tests:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: needs.changed-files.outputs.should-run-code == 'true'
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 25
 
@@ -141,7 +169,7 @@ jobs:
 
   metrics-test:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: needs.changed-files.outputs.should-run-code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -154,7 +182,7 @@ jobs:
 
   wasm-application-test:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: needs.changed-files.outputs.should-run-code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -173,7 +201,7 @@ jobs:
 
   linera-sdk-tests-fixtures:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: needs.changed-files.outputs.should-run-code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -197,7 +225,7 @@ jobs:
 
   default-features-and-witty-integration-test:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: needs.changed-files.outputs.should-run-code == 'true'
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
 
@@ -219,7 +247,7 @@ jobs:
 
   check-outdated-cli-md:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: needs.changed-files.outputs.should-run-code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -239,7 +267,7 @@ jobs:
 
   ethereum-tests:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: needs.changed-files.outputs.should-run-code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -303,7 +331,7 @@ jobs:
 
   storage-service-tests:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: needs.changed-files.outputs.should-run-code == 'true'
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
     steps:
@@ -353,6 +381,18 @@ jobs:
       run: |
         ./scripts/check_chain_loads.sh
 
+  lint-spec-modules:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+    - name: Check that specification modules contain only marker traits
+      run: |
+        ./scripts/check_spec_modules.sh
+
   lint-metrics-registration:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
@@ -367,7 +407,7 @@ jobs:
 
   lint-metrics-features:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: needs.changed-files.outputs.should-run-code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -476,7 +516,7 @@ jobs:
 
   lint-wasm-applications:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: needs.changed-files.outputs.should-run-code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -540,7 +580,7 @@ jobs:
 
   lint-check-linera-service-graphql-schema:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true'
+    if: needs.changed-files.outputs.should-run-code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -58,6 +58,15 @@ jobs:
               # Workflow-only PRs don't need heavy code tests; merge to main
               # validates the workflow itself by running it for real.
               - '!.github/workflows/**'
+              # Specification-only changes: doc comments on marker traits with no
+              # members, implementors or call sites. rust.yml still runs clippy,
+              # cargo doc and cargo fmt on them, which is all that can fail.
+              - '!linera-spec/**'
+              - '!linera-chain/src/proof/**'
+              - '!linera-chain/src/manager/proof/**'
+              - '!linera-chain/src/data_types/proof/**'
+              - '!linera-chain/src/justification/proof.rs'
+              - '!linera-core/src/proof/**'
 
   web:
     needs: changed-files

--- a/scripts/check_spec_modules.sh
+++ b/scripts/check_spec_modules.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Check that the correctness-specification modules contain only marker traits.
+#
+# CI skips the test suite for pull requests that touch nothing but these paths (see the `code`
+# filter in .github/workflows/rust.yml). That is safe precisely because the files hold no
+# executable code: every item is a public trait with no members, no implementors and no call
+# sites, carrying the specification in its doc comments. Compilation, rustdoc link checking and
+# formatting still run, and they are the only things such an edit can break.
+#
+# If real code ever lands under one of these paths, that reasoning stops holding and the tests
+# would silently stop covering it. This check turns that into a build failure instead.
+
+set -euo pipefail
+
+# Make sure we're at the root of the repo.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+SPEC_PATHS=(
+    linera-spec/src
+    linera-chain/src/proof
+    linera-chain/src/manager/proof
+    linera-chain/src/data_types/proof
+    linera-chain/src/justification/proof.rs
+    linera-core/src/proof
+)
+
+FOUND=0
+
+for path in "${SPEC_PATHS[@]}"; do
+    [ -e "$path" ] || continue
+    # Executable items: an `impl` block, a function, a `const`/`static`, or a `struct`/`enum`.
+    # Doc comments and `//` comments are stripped first so that prose mentioning these words
+    # does not trip the check.
+    while IFS= read -r hit; do
+        echo "unexpected code in a specification module: $hit"
+        FOUND=1
+    done < <(
+        grep -rn --include='*.rs' -E '^[[:space:]]*(pub[[:space:]]+)?(impl|fn|const|static|struct|enum|macro_rules!)[[:space:]!]' "$path" \
+            | grep -v -E ':[[:space:]]*(///|//!|//)' \
+            || true
+    )
+done
+
+if [ "$FOUND" -ne 0 ]; then
+    cat <<'EOF'
+
+The specification modules are expected to contain only marker traits, `use` statements and
+module declarations. CI relies on this: a pull request touching only these paths skips the
+test suite, on the grounds that nothing there can change runtime behaviour.
+
+Either move the code elsewhere, or remove the affected path from the `code` filter in
+.github/workflows/rust.yml (and the matching exclusions in the other workflows) so that the
+tests run for it again.
+EOF
+    exit 1
+fi
+
+echo "specification modules contain only marker traits"


### PR DESCRIPTION
## Motivation

Pull requests that change only the correctness specification run the full test suite for no benefit. Measured on #6802, which changed one doc comment in `linera-spec/src/lib.rs`: **34 jobs, ~209 runner-minutes.** The expensive ones were `storage-service-tests` (28m), `ethereum-tests` (23m), `web` (23m), `default-features-and-witty-integration-test` (22m), `bridge-check` (18m).

Those files hold only marker traits: public traits with no members, no implementors and no call sites, carrying the specification in their doc comments. Nothing observable at runtime can change there, so no test can fail on an edit that compiles.

## Proposal

Add a second path filter, `code`, alongside the existing `paths` filter in `rust.yml`. It is the same exclude-list plus the specification paths, and it gates the jobs a doc-comment edit cannot break.

**What still runs**, because these are exactly what such an edit *can* break:

| job | why it must stay |
|---|---|
| `lint-cargo-clippy` | `--all-features --all-targets --workspace`; this is the compile check, and catches a supertrait cycle (E0391) |
| `lint-cargo-doc` | `-D warnings` with `rustdoc::broken_intra_doc_links` — the specification is one dense citation graph |
| `lint-cargo-fmt` | pinned nightly, and `rustfmt.toml` sets `format_code_in_doc_comments`, which touches spec prose directly |
| `lint-check-copyright-headers`, `lint-cargo-machete`, `lint-taplo-fmt`, `lint-check-for-outdated-readme`, and the two 2-minute script lints | cheap, and a new spec file needs a header and a `Cargo.toml` entry |

**What stops running for spec-only PRs:** `execution-wasmtime-test`, `bridge-tests`, `metrics-test`, `wasm-application-test`, `linera-sdk-tests-fixtures`, `default-features-and-witty-integration-test`, `check-outdated-cli-md`, `ethereum-tests`, `storage-service-tests`, `lint-metrics-features`, `lint-wasm-applications`, `lint-check-linera-service-graphql-schema`; plus the filters in `web.yml`, `indexer.yml`, `bridge-check.yml`, `explorer.yml` and `lint-check-all-features.yml`.

`lint-check-all-features` runs `cargo hack check --each-feature` across a 6-way matrix. It is excluded because the specification modules contain **no `cfg` attributes at all**, so per-feature variation cannot affect them, and `lint-cargo-clippy --all-features` already compiles them.

Estimated effect: **~209 min → ~17 min** for a specification-only pull request.

## Test Plan

The failure mode that matters is a filter that silently skips tests on a *code* PR, so I simulated the matcher against representative change sets rather than trusting the pattern list by eye:

| changed files | lint jobs | heavy jobs |
|---|---|---|
| spec only | run | **skipped** |
| spec + any real code | run | run |
| spec + `Cargo.lock` | run | run |
| `linera-chain/src/justification/proof.rs` | run | **skipped** |
| `linera-chain/src/justification/mod.rs` | run | run |
| real code only | run | run |
| docs only | skipped | skipped (unchanged) |

The fifth row matters: `justification/mod.rs` carries intra-doc links into `proof::`, and it is correctly treated as code.

This is the safe direction by construction. `predicate-quantifier: 'every'` keeps a changed file only when it matches every pattern, and the output is true when any file survives — so the suite is skipped only if *every* changed file is a specification file. All six workflow files were checked to parse, and the `code` filter was verified to be a strict superset of `paths`.

### Guarding the assumption

The reasoning above holds only while those paths really do contain nothing but marker traits. If code ever lands there, the tests would silently stop covering it — a quiet failure, which is the main risk of this change.

`scripts/check_spec_modules.sh` turns that into a build failure: it rejects any `impl`, `fn`, `const`, `static`, `struct`, `enum` or `macro_rules!` under the specification paths, and its error message points at the filter that depends on it. It runs as `lint-spec-modules`, a 2-minute job gated on the *unrestricted* filter so it runs on spec PRs too. Verified both ways — passes on the tree as it stands, and fails with the offending `file:line` when a function is added to `linera-core/src/proof/storage.rs`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6802, #6804, #6796 — recent specification-only pull requests, the workload this targets.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
