### PR TITLE
Backport #6785 to testnet_conway: describe faucet request failures without the JavaScript stack

### DIFF
--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -29,10 +29,10 @@ pub enum Error {
     #[error("GraphQL error: {0:?}")]
     GraphQl(Vec<serde_json::Value>),
     /// An HTTP request to the faucet failed.
-    #[error("HTTP error: {0:?}")]
+    #[error("{}", describe_http_failure(.0))]
     Http(#[from] reqwest::Error),
     /// A GraphQL query could not be sent to the faucet.
-    #[error("failed to execute query {query:?}: {source}")]
+    #[error("failed to execute query {query:?}: {}", describe_http_failure(.source))]
     Query {
         /// The query that could not be sent.
         query: String,
@@ -40,6 +40,32 @@ pub enum Error {
         #[source]
         source: reqwest::Error,
     },
+}
+
+/// Describes a `reqwest` failure without reproducing its source.
+///
+/// On wasm that source is built with `format!("{js_val:?}")`, which embeds the JavaScript
+/// stack trace of the failed `fetch`. The trace differs per browser and per bundle hash, so
+/// carrying it splits one underlying failure across many distinct-looking reports. It buys
+/// little in exchange: browsers deliberately report CORS rejections, offline and DNS
+/// failures as the same opaque `TypeError`, so the text that varies is mostly the browser's
+/// own phrasing. The error is still available through `source()` for anything that wants it.
+fn describe_http_failure(error: &reqwest::Error) -> String {
+    let where_ = match error.url() {
+        Some(url) => format!(" at {url}"),
+        None => String::new(),
+    };
+    if let Some(status) = error.status() {
+        format!("the faucet{where_} returned {status}")
+    } else if error.is_timeout() {
+        format!("the request to the faucet{where_} timed out")
+    } else if error.is_decode() {
+        format!("could not decode the faucet's response{where_}")
+    } else if error.is_body() {
+        format!("the request body sent to the faucet{where_} was rejected")
+    } else {
+        format!("could not reach the faucet{where_}")
+    }
 }
 
 /// The result of a successful claim mutation.


### PR DESCRIPTION
## Motivation

Backport of #6785 to `testnet_conway`.

The faucet being unreachable is the top wasm-related error in the web client's Sentry project — roughly 13,200 events across 5 separate issues in 90 days. All five are the same failure, split because the message carries a JavaScript stack trace that differs per browser and per bundle hash.

The trace is not framing a format specifier can strip. `reqwest` builds its wasm source with `format!("{js_val:?}")` (`reqwest-0.11.27/src/error.rs:283-285`), and wasm-bindgen's `debugString` renders an `Error` as `` `${val.name}: ${val.message}\n${val.stack}` ``, so the trace is baked into a `String` before `reqwest` formats anything. Both `Display` and `Debug` then append it.

This branch has both affected variants: `Http`, which uses `{0:?}`, and `Query`, which uses `{source}` and leaks the same way through `Display`.

## Proposal

Cherry-pick of bd551561cc, unmodified — it applies cleanly, since the only divergence in this file is `main`'s extra `ArithmeticError` variant, which the change does not touch.

Failures are rendered from `reqwest`'s own predicates, with the source dropped from the message. The error remains reachable through `source()`; only what we print changes.

On wasm the production case becomes `could not reach the faucet at https://faucet.testnet-conway.linera.net/`, identical in every browser and every build.

### What this gives up

On wasm essentially every network failure renders the same way: `is_connect()` is `#[cfg(not(target_arch = "wasm32"))]` and does not exist there, and a failed `fetch` carries no status, so the predicates cannot separate DNS failure from a CORS rejection from being offline.

That is less than it appears — browsers deliberately collapse those into one opaque `TypeError` so pages cannot distinguish them. What the old message varied by was the browser's phrasing (`Failed to fetch`, `NetworkError when attempting to fetch resource.`, `Load failed`) plus the bundle hash in the stack. Status-bearing and timeout failures still render distinctly.

## Test Plan

`cargo clippy -p linera-faucet-client --all-targets` and `cargo fmt -- --check` on this branch's pinned nightly, both clean.

The rendered output was verified on `main` against real `reqwest` errors — a refused connection and a timeout — rather than reasoned from the branches:

```
before : error sending request for url (http://127.0.0.1:1/graphql): error trying to connect: …
after  : could not reach the faucet at http://127.0.0.1:1/graphql
after  : the request to the faucet at http://10.255.255.1/graphql timed out
```

## Release Plan

- These changes should be backported to the latest `testnet` branch — this is that backport.

User-visible error text changes; no API change.

## Links

- #6785 — the same change on `main`.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
