### PR TITLE
Give the rethrown error the frames of the throw it came from

### DIFF
--- a/web/@linera/client/src/error/mod.rs
+++ b/web/@linera/client/src/error/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
+use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
 use crate::lock;
 
@@ -24,7 +24,7 @@ extern "C" {
 
 pub enum Error {
     Lock(lock::Error),
-    Other(JsError),
+    Other(js_sys::Error),
 }
 
 impl From<lock::Error> for Error {
@@ -33,16 +33,16 @@ impl From<lock::Error> for Error {
     }
 }
 
-impl<E: std::error::Error> From<E> for Error {
+impl<E: std::error::Error + 'static> From<E> for Error {
     fn from(error: E) -> Self {
-        Self::Other(error.into())
+        Self::Other(to_js_error(&error))
     }
 }
 
 impl Error {
     #[must_use]
     pub fn new(message: &str) -> Self {
-        Self::Other(JsError::new(message))
+        Self::Other(js_sys::Error::new(message))
     }
 }
 
@@ -55,6 +55,38 @@ impl From<Error> for JsValue {
     }
 }
 
+/// Builds the JavaScript `Error` thrown in place of a Rust error.
+///
+/// Each layer of a Rust error chain prints the layer below it, so the message already
+/// carries the whole chain. What it cannot carry is where the failure happened in
+/// JavaScript: the error constructed here records only the wasm frames that built it. So
+/// the `source` chain is walked for the first [`Thrown`], and its stack is used instead,
+/// pointing at the code that actually threw.
+///
+/// The stack's first line is replaced with this error's own message, because JavaScript
+/// tooling — the browser console, and Sentry — reads a stack as `Name: message` followed by
+/// frames, and would otherwise report a message contradicting `.message`.
+fn to_js_error(error: &(dyn std::error::Error + 'static)) -> js_sys::Error {
+    let js_error = js_sys::Error::new(&error.to_string());
+
+    let mut next = Some(error);
+    while let Some(error) = next {
+        if let Some(stack) = error.downcast_ref::<Thrown>().and_then(Thrown::stack) {
+            let frames = stack.split_once('\n').map_or("", |(_, frames)| frames);
+            let rewritten = format!("Error: {}\n{frames}", js_error.message());
+            let _ = js_sys::Reflect::set(
+                &js_error,
+                &JsValue::from_str("stack"),
+                &JsValue::from_str(&rewritten),
+            );
+            break;
+        }
+        next = error.source();
+    }
+
+    js_error
+}
+
 /// The depth at which a `cause` chain stops being followed. A chain can be cyclic, since
 /// nothing stops JavaScript from making an error its own cause.
 const MAX_CAUSE_DEPTH: usize = 8;
@@ -62,8 +94,8 @@ const MAX_CAUSE_DEPTH: usize = 8;
 /// A value thrown by JavaScript, captured on the Rust side.
 ///
 /// JavaScript can throw any value at all, so rather than mapping the throw onto a fixed
-/// set of Rust variants this records what it carried: its `name` and `message`, and its
-/// `cause`, recursively. Properties are read reflectively, so `DOMException`s,
+/// set of Rust variants this records what it carried: its `name` and `message`, its stack
+/// trace, and its `cause`, recursively. Properties are read reflectively, so `DOMException`s,
 /// user-defined error classes and errors thrown in another realm are captured too — none
 /// of those are `instanceof Error` on this side.
 ///
@@ -72,10 +104,17 @@ const MAX_CAUSE_DEPTH: usize = 8;
 #[derive(Debug)]
 pub struct Thrown {
     description: String,
+    stack: Option<String>,
     cause: Option<Box<Thrown>>,
 }
 
 impl Thrown {
+    /// The JavaScript stack trace of the thrown value, if it carried one.
+    #[must_use]
+    pub fn stack(&self) -> Option<&str> {
+        self.stack.as_deref()
+    }
+
     fn capture(value: &JsValue, depth: usize) -> Self {
         let property = |key: &str| {
             js_sys::Reflect::get(value, &JsValue::from_str(key))
@@ -102,6 +141,7 @@ impl Thrown {
             } else {
                 description
             },
+            stack: property("stack").and_then(|stack| stack.as_string()),
             cause: property("cause").map(|cause| {
                 Box::new(if depth < MAX_CAUSE_DEPTH {
                     Self::capture(&cause, depth + 1)
@@ -115,6 +155,7 @@ impl Thrown {
     fn leaf(description: String) -> Self {
         Self {
             description,
+            stack: None,
             cause: None,
         }
     }

--- a/web/@linera/client/tests/SignerError.test.ts
+++ b/web/@linera/client/tests/SignerError.test.ts
@@ -50,6 +50,21 @@ test("reports the message of a thrown `Error`", async () => {
   expect(error.message).toContain("the vault is on fire");
 }, 150000);
 
+test("carries the frames of the throw, not the frames that rebuilt it", async () => {
+  const original = new Error("the vault is on fire");
+  const error = await refusing(original);
+
+  // The frames must come from this file, where the signer threw, rather than from the
+  // wasm boundary that constructed the error JavaScript actually receives.
+  const frames = (error.stack ?? "").split("\n").slice(1).join("\n");
+  const originalFrames = (original.stack ?? "").split("\n").slice(1).join("\n");
+  expect(frames).toBe(originalFrames);
+  expect(frames).not.toContain("linera_web.wasm");
+
+  // The first line is rewritten to agree with `message`, as JavaScript tooling expects.
+  expect(error.stack?.split("\n")[0]).toBe(`Error: ${error.message}`);
+}, 150000);
+
 test("reports the `name` of a thrown error that is not a plain `Error`", async () => {
   const error = await refusing(
     new DOMException("the user said no", "NotAllowedError"),


### PR DESCRIPTION
## Motivation

When a JavaScript signer throws, the error the application eventually catches is not the object it threw. wasm-bindgen catches the throw, `error::Thrown` copies out what it carried, the failure travels up as a Rust error gaining context at each layer, and at the boundary we construct a **new** JavaScript `Error` from the accumulated message.

V8 fills in `.stack` at construction, so that new error's stack describes where Rust built it. This is the contrast, taken from a CI assertion diff:

```
  Error: the vault is on fire                                  ← what the signer threw
      at .../tests/SignerError.test.ts:41:20
      at .../@vitest/runner/dist/chunk-hooks.js:155:11

  Error: chain client error: signer error: the vault is on fire ← what the app receives
      at imports.wbg.__wbg_new_c68d7209be747379 (.../wasm/index.js:1692:21)
      at linera_web.wasm.<js_sys::Error>::new (...)
      at linera_web.wasm.linera_web::error::to_js_error (...)
      at linera_web.wasm.wasm_bindgen_futures::future_to_promise::<...add_owner...>
```

Every frame in the second is our marshalling layer. For someone debugging their own signer it never mentions their code.

#6722 attempted this and removed it again: the walk that locates the original throw goes through `source()`, and `linera_client::Error` truncated its own chain to a single node, so the walk died at the first hop. #6747 fixed that, and the chain is now walkable — verified end to end, four hops from the outermost error down to the `Thrown`.

## Proposal

`Thrown` captures the `stack` property alongside `name`/`message`/`cause`. At the boundary, `error::Error::Other` holds a `js_sys::Error` built by `to_js_error`, which walks the `source` chain for the first `Thrown` and assigns its stack to the outgoing error.

`.message` is unchanged and still carries the full chain; only `.stack` differs.

### Two decisions worth reviewing

**The stack's first line is rewritten.** JavaScript tooling reads a stack as `Name: message` followed by frames — the browser console renders it that way, and Sentry parses it. Copying the original verbatim would leave `.stack` announcing `Error: the vault is on fire` while `.message` says `chain client error: signer error: the vault is on fire`. The frames are preserved exactly; only that first line is replaced, so the two agree.

**The stack is captured eagerly.** Reading `.stack` is a lazy getter in V8 that formats the trace on access, so this is not free. It is paid once per *caught throw*, which is an error path rather than a hot one — a signer that is working never reaches it. Capturing lazily would mean holding the `JsValue` in `Thrown`, which would cost it `Send + Sync` and the `TaskSendable` bound that holds on both sides of the `cfg(web)` split. Eager capture keeps the type owned.

## Test Plan

`SignerError.test.ts` gains a case asserting the frames are the signer's, that they contain no `linera_web.wasm` frame, and that the rewritten first line agrees with `.message`. The other five cases are unchanged.

Comparing frames rather than whole stacks is deliberate: the first line is expected to differ, and asserting the whole string is what made the earlier version of this test look like it was passing for the wrong reason.

Verified locally: `cargo clippy --workspace --all-targets`, the `wasm32` build of `linera-web` on the pinned nightly, `wasm-bindgen 0.2.100` glue generation, and `cargo fmt --check`.

## Release Plan

- These changes follow the usual release cycle.

Should be backported to `testnet_conway` alongside, once reviewed.

## Links

- #6722 introduced `Thrown` and deferred this.
- #6747 removed the `source()` truncation that blocked it.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
