### PR TITLE
Backport #6729 to testnet_conway: batch the ByteMapView entries resolver into a single multi_get

### DIFF
--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -2119,15 +2119,13 @@ mod graphql {
                 self.keys().await?
             };
 
-            let mut entries = vec![];
-            for key in keys {
-                entries.push(Entry {
-                    value: self.get(&key).await?,
-                    key,
-                })
-            }
+            let values = self.multi_get(keys.clone()).await?;
 
-            Ok(entries)
+            Ok(keys
+                .into_iter()
+                .zip(values)
+                .map(|(key, value)| Entry { key, value })
+                .collect())
         }
     }
 


### PR DESCRIPTION
## Motivation

Backport of #6729 to `testnet_conway`.

The GraphQL `entries` resolver on `ByteMapView` fetches one key at a time:

```rust
for key in keys {
    entries.push(Entry { value: self.get(&key).await?, key })
}
```

Each `get` that misses the in-memory updates issues its own `read_value_bytes`, so a query for N
keys costs N storage round trips. `multi_get` already exists on the same type and resolves the
whole set with a single `read_multi_values_bytes`.

This matters on a deployed branch because the resolver is on a live path: the node service and
the explorer expose views over GraphQL, so a wide `entries` query is N sequential round trips
against ScyllaDB today.

## Proposal

Use `multi_get` and zip the results back onto the keys. `multi_get` returns values in the order
of the keys it was given, so the pairing is positional.

Clean cherry-pick of `a813ba10f2` with no adjustments — this branch already has
`ByteMapView::multi_get` and the resolver's bounds already include `DeserializeOwned + Clone`.

## Test Plan

On this branch's pinned toolchains (Rust 1.86, nightly-2025-04-03), not `main`'s:

- `cargo clippy -p linera-views --features metrics --all-targets -- -D warnings` — clean.
- `cargo test -p linera-views --features metrics --lib` — 132 passing.
- `cargo +nightly-2025-04-03 fmt --all -- --check`.

`with_graphql` is on by default off the web target, so the resolver is covered by the ordinary
build.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- #6729 — the `main` PR this backports.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
