### PR TITLE
Backport #6731 to testnet_conway: rename KeyValueStoreView::count to iterative_count

### DIFF
--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -604,11 +604,11 @@ impl<C: Context> KeyValueStoreView<C> {
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
     /// view.insert(vec![0, 1], vec![0]).unwrap();
     /// view.insert(vec![0, 2], vec![0]).unwrap();
-    /// let count = view.count().await.unwrap();
+    /// let count = view.iterative_count().await.unwrap();
     /// assert_eq!(count, 2);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
         let mut count = 0;
         self.for_each_index(|_index| {
             count += 1;

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -159,7 +159,7 @@ async fn key_value_store_view_mutability() -> Result<()> {
         let mut new_state_vec = state_vec.clone();
         for _ in 0..count_oper {
             let choice = rng.gen_range(0..5);
-            let entry_count = view.store.count().await?;
+            let entry_count = view.store.iterative_count().await?;
             if choice == 0 {
                 // inserting random stuff
                 let n_ins = rng.gen_range(0..10);


### PR DESCRIPTION
## Motivation

Backport of #6731 to `testnet_conway`.

`KeyValueStoreView::count()` is not a cheap accessor. It runs `for_each_index`, which issues a
full `find_keys_by_prefix` against storage and transfers every key's bytes, only to increment a
counter. Its name suggests otherwise.

The rest of the crate already distinguishes the two on this branch as well: `SetView`,
`MapView`, `CollectionView` and `ReentrantCollectionView` all expose this operation as
`iterative_count()`, while the genuinely O(1) accessors on `LogView`, `QueueView` and
`BucketQueueView` — which read a stored counter — keep the plain name `count()`.
`KeyValueStoreView` is the sole outlier, sitting on the expensive side of that line with the
cheap name.

## Proposal

Rename `KeyValueStoreView::count` to `iterative_count`, matching the existing convention.

Two adjustments were needed relative to `main`:

- The doc example keeps this branch's **synchronous** `insert`; `main` has since made it
  `async`.
- `main`'s call site in `execution_state_actor.rs` does not exist here — the `HasEmptyStorage`
  handler landed after this branch was cut — so that hunk resolves to no change at all.

The result touches two files: the definition and its doc example, and one randomized test.

## Note for the release

This renames a **public method** on `linera-views`. Nothing in-tree calls it on this branch
besides the test above, but an SDK consumer that does will need the new name. It is a rename
only — no behaviour changes, and nothing is fixed operationally — so it is reasonable to drop
this backport if the release would rather not carry an API break. #6809 (the `entries` batching)
is independent and does not have that property.

## Test Plan

On this branch's pinned toolchains (Rust 1.86, nightly-2025-04-03), not `main`'s:

- `cargo clippy --locked --all-targets --all-features --workspace --exclude linera-web` — clean.
  The exclusion is not related to this change: `linera-web` cannot build for a native target with
  all features on this branch, and fails identically without this commit.
- `cargo test -p linera-views --features metrics --lib` — 132 passing.
- `cargo +nightly-2025-04-03 fmt --all -- --check`.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- #6731 — the `main` PR this backports.
- #6809 — the other `linera-views` backport in this batch.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
