### PR TITLE
State that a voter resolves event reads against its own storage

### DIFF
--- a/linera-chain/src/justification/proof.rs
+++ b/linera-chain/src/justification/proof.rs
@@ -35,7 +35,7 @@ use crate::{
     },
     manager::proof::{
         commit::{
-            CertifiedBlockWasExecuted, CommitRestsOnValidation, IncomingBundlesAreSelfDerived,
+            CertifiedBlockWasExecuted, CommitRestsOnValidation, IncomingBundlesMatchTheLocalInbox,
         },
         locking::{
             ConfirmedVoteRoundMonotone, OneConfirmationVotePerRound, OneValidationVotePerRound,
@@ -515,7 +515,7 @@ pub trait AccountableSafety:
 ///   certificate; and the `execution_state_cache` hit path skips re-execution.
 ///
 ///   The properties that do protect against a bad outcome are [`CertifiedBlockWasExecuted`] and,
-///   for the cross-chain component, [`IncomingBundlesAreSelfDerived`]. Unlike everything else in
+///   for the cross-chain component, [`IncomingBundlesMatchTheLocalInbox`]. Unlike everything else in
 ///   this module both need
 ///   [`MaxByzantineWeight`](crate::manager::proof::model::MaxByzantineWeight): validity degrades
 ///   above the fault bound with no forensic residue, whereas agreement degrades with one.
@@ -530,12 +530,12 @@ pub trait AccountableSafety:
 /// [`ChainError::CorruptedChainState`]: crate::ChainError::CorruptedChainState
 /// [`extract_equivocations`]: crate::justification::extract_equivocations
 /// [`CertifiedBlockWasExecuted`]: crate::manager::proof::commit::CertifiedBlockWasExecuted
-/// [`IncomingBundlesAreSelfDerived`]: crate::manager::proof::commit::IncomingBundlesAreSelfDerived
+/// [`IncomingBundlesMatchTheLocalInbox`]: crate::manager::proof::commit::IncomingBundlesMatchTheLocalInbox
 pub trait AccountabilityScope:
     AccountableSafety
     + DoubleValidationCompleteness
     + CertifiedBlockWasExecuted
-    + IncomingBundlesAreSelfDerived
+    + IncomingBundlesMatchTheLocalInbox
     + CommitRestsOnValidation
 {
 }

--- a/linera-chain/src/manager/proof/commit.rs
+++ b/linera-chain/src/manager/proof/commit.rs
@@ -214,3 +214,54 @@ pub trait CertifiedBlockWasExecuted:
 /// [`MaxByzantineWeight`]: crate::manager::proof::model::MaxByzantineWeight
 /// [`AccountabilityScope`]: crate::justification::proof::AccountabilityScope
 pub trait IncomingBundlesAreSelfDerived: ProposalGate + CertifiedBlockWasExecuted {}
+
+/// **Lemma (An event a block reads is matched against the validator's own storage).** A correct
+/// validator casts a validation or fast-confirmation vote for a block that reads an event only if
+/// that event is in its own storage under the exact [`EventId`] the block cites, and the bytes it
+/// votes for are the bytes it holds.
+///
+/// This is the event counterpart of [`IncomingBundlesAreSelfDerived`], and it carries the same
+/// weight: it is what stands between a proposer and a block that claims to have read something no
+/// one published.
+///
+/// *Code correspondence.*
+///
+/// | | |
+/// |---|---|
+/// | transition | the event oracle in `ExecutionStateActor`, reached from `ChainWorkerState::execute_block` during `try_handle_block_proposal` |
+/// | reads | the validator's own event storage, through `ExecutionRuntimeContext::get_event` |
+/// | writes | the block's `oracle_responses`, appending `OracleResponse::Event` |
+/// | precondition | none beyond [`ProposalGate`] |
+///
+/// *Proof.* Validating a proposal executes the block afresh, with no recorded outcome to replay
+/// ([`CertifiedBlockWasExecuted`]). `TransactionTracker::oracle` therefore finds no replayed
+/// response and runs its closure, which calls `get_event` on this validator's own storage and
+/// fails with `ExecutionError::EventsNotFound` when the event is absent. The value recorded in the
+/// block is the value that came back. So a validator cannot vote for a block whose event it does
+/// not hold, and cannot vote for content differing from its own. ∎
+///
+/// **Replay checks the identifier, not the content.** When a block *does* carry a recorded outcome
+/// — a regular retry, or a certified block being applied — `oracle` returns the recorded response
+/// without consulting storage, and `to_event` only checks that the recorded [`EventId`] matches the
+/// one requested, returning `ExecutionError::OracleResponseMismatch` otherwise. The bytes are taken
+/// as given.
+///
+/// That asymmetry is the same one [`IncomingBundlesAreSelfDerived`] records for
+/// `must_be_present = false`, and it is deliberate for the same reason: by the time a block is
+/// certified, a quorum has already voted, and this lemma has done its work at voting time. It is
+/// also why a fabricated `events` field is beyond [`AccountabilityScope`] — the fabrication is
+/// caught by the voters or not at all, and leaves no evidence afterwards.
+///
+/// **What this does not say.** That the event was legitimately published by the chain the
+/// [`EventId`] names is not checked here; it follows from how the event entered storage in the
+/// first place, which is `linera_core::proof::storage::AdmissionChecksTheValidityProof` — events
+/// are written only in the branch guarded by `certificate.check`, so they inherit the publishing
+/// block's certification rather than carrying a proof of their own. Nor does it say the event is
+/// still *readable*: a checkpoint may have pruned it below the stream's floor
+/// ([`EventFloorTracksCheckpoints`]).
+///
+/// [`EventId`]: linera_base::identifiers::EventId
+/// [`ProposalGate`]: crate::manager::proof::voting::ProposalGate
+/// [`AccountabilityScope`]: crate::justification::proof::AccountabilityScope
+/// [`EventFloorTracksCheckpoints`]: crate::proof::checkpoints::EventFloorTracksCheckpoints
+pub trait EventReadsAreSelfDerived: ProposalGate + CertifiedBlockWasExecuted {}

--- a/linera-chain/src/manager/proof/commit.rs
+++ b/linera-chain/src/manager/proof/commit.rs
@@ -215,14 +215,25 @@ pub trait CertifiedBlockWasExecuted:
 /// [`AccountabilityScope`]: crate::justification::proof::AccountabilityScope
 pub trait IncomingBundlesAreSelfDerived: ProposalGate + CertifiedBlockWasExecuted {}
 
-/// **Lemma (An event a block reads is matched against the validator's own storage).** A correct
-/// validator casts a validation or fast-confirmation vote for a block that reads an event only if
-/// that event is in its own storage under the exact [`EventId`] the block cites, and the bytes it
-/// votes for are the bytes it holds.
+/// **Lemma (Event reads resolve against the validator's own storage).** When a correct validator
+/// votes on a proposal that reads an event, the value it votes for is the one in *its own* storage
+/// under the [`EventId`] the block cites — resolved locally, exactly as an oracle call is, and
+/// never taken from the proposer.
 ///
-/// This is the event counterpart of [`IncomingBundlesAreSelfDerived`], and it carries the same
-/// weight: it is what stands between a proposer and a block that claims to have read something no
-/// one published.
+/// This is what stands between a proposer and a block that claims to have read something nobody
+/// published. It is the event analogue of [`IncomingBundlesAreSelfDerived`], but the mechanism is
+/// not the same one, and the difference decides how a discrepancy shows up.
+///
+/// *A bundle is checked; an event is produced.* A [`ProposedBlock`] names the incoming bundles it
+/// consumes, so a validator can compare them against its inbox and reject on mismatch. It carries
+/// no `oracle_responses` — those exist only in [`BlockExecutionOutcome`] — so there is nothing to
+/// compare an event against. The validator simply reads its own storage and records what it finds.
+///
+/// So the two fail differently. A wrong bundle is *rejected*: `remove_bundles_from_inboxes` requires
+/// presence and equality. A wrong event is not rejected at all — the validator computes a different
+/// outcome, hence a different [`Block`], and votes for that instead. The proposer's intended block
+/// simply never gathers a quorum. Both keep a fabricated value out of a certificate; only the first
+/// produces an error anyone can point at.
 ///
 /// *Code correspondence.*
 ///
@@ -236,9 +247,9 @@ pub trait IncomingBundlesAreSelfDerived: ProposalGate + CertifiedBlockWasExecute
 /// *Proof.* Validating a proposal executes the block afresh, with no recorded outcome to replay
 /// ([`CertifiedBlockWasExecuted`]). `TransactionTracker::oracle` therefore finds no replayed
 /// response and runs its closure, which calls `get_event` on this validator's own storage and
-/// fails with `ExecutionError::EventsNotFound` when the event is absent. The value recorded in the
-/// block is the value that came back. So a validator cannot vote for a block whose event it does
-/// not hold, and cannot vote for content differing from its own. ∎
+/// fails with `ExecutionError::EventsNotFound` when the event is absent. The value it records is
+/// the value that came back. So a validator cannot vote for a block whose event it does not hold,
+/// nor for content differing from its own. ∎
 ///
 /// **Replay checks the identifier, not the content.** When a block *does* carry a recorded outcome
 /// — a regular retry, or a certified block being applied — `oracle` returns the recorded response
@@ -246,7 +257,7 @@ pub trait IncomingBundlesAreSelfDerived: ProposalGate + CertifiedBlockWasExecute
 /// one requested, returning `ExecutionError::OracleResponseMismatch` otherwise. The bytes are taken
 /// as given.
 ///
-/// That asymmetry is the same one [`IncomingBundlesAreSelfDerived`] records for
+/// That asymmetry matches the one [`IncomingBundlesAreSelfDerived`] records for
 /// `must_be_present = false`, and it is deliberate for the same reason: by the time a block is
 /// certified, a quorum has already voted, and this lemma has done its work at voting time. It is
 /// also why a fabricated `events` field is beyond [`AccountabilityScope`] — the fabrication is
@@ -261,7 +272,10 @@ pub trait IncomingBundlesAreSelfDerived: ProposalGate + CertifiedBlockWasExecute
 /// ([`EventFloorTracksCheckpoints`]).
 ///
 /// [`EventId`]: linera_base::identifiers::EventId
+/// [`ProposedBlock`]: crate::data_types::ProposedBlock
+/// [`BlockExecutionOutcome`]: crate::data_types::BlockExecutionOutcome
+/// [`Block`]: crate::block::Block
 /// [`ProposalGate`]: crate::manager::proof::voting::ProposalGate
 /// [`AccountabilityScope`]: crate::justification::proof::AccountabilityScope
 /// [`EventFloorTracksCheckpoints`]: crate::proof::checkpoints::EventFloorTracksCheckpoints
-pub trait EventReadsAreSelfDerived: ProposalGate + CertifiedBlockWasExecuted {}
+pub trait EventReadsResolveLocally: ProposalGate + CertifiedBlockWasExecuted {}

--- a/linera-chain/src/manager/proof/commit.rs
+++ b/linera-chain/src/manager/proof/commit.rs
@@ -198,7 +198,7 @@ pub trait CertifiedBlockWasExecuted:
 ///
 /// * if it **executed** the sender's block, `execute_contiguous_block` re-executed it and rejected
 ///   a mismatch against the certificate ([`CertifiedBlockWasExecuted`] and the note there), so the
-///   bundles are self-derived;
+///   bundles are the validator's own work;
 /// * if it only **preprocessed** the sender's block, `preprocess_certified_block` updated outboxes
 ///   and event streams *without executing*, so the bundles are taken from the sender's certificate
 ///   at face value.
@@ -213,7 +213,7 @@ pub trait CertifiedBlockWasExecuted:
 /// [`ChainError::MissingCrossChainUpdates`]: crate::ChainError::MissingCrossChainUpdates
 /// [`MaxByzantineWeight`]: crate::manager::proof::model::MaxByzantineWeight
 /// [`AccountabilityScope`]: crate::justification::proof::AccountabilityScope
-pub trait IncomingBundlesAreSelfDerived: ProposalGate + CertifiedBlockWasExecuted {}
+pub trait IncomingBundlesMatchTheLocalInbox: ProposalGate + CertifiedBlockWasExecuted {}
 
 /// **Lemma (Event reads resolve against the validator's own storage).** When a correct validator
 /// votes on a proposal that reads an event, the value it votes for is the one in *its own* storage
@@ -221,7 +221,7 @@ pub trait IncomingBundlesAreSelfDerived: ProposalGate + CertifiedBlockWasExecute
 /// never taken from the proposer.
 ///
 /// This is what stands between a proposer and a block that claims to have read something nobody
-/// published. It is the event analogue of [`IncomingBundlesAreSelfDerived`], but the mechanism is
+/// published. It is the event analogue of [`IncomingBundlesMatchTheLocalInbox`], but the mechanism is
 /// not the same one, and the difference decides how a discrepancy shows up.
 ///
 /// *A bundle is checked; an event is produced.* A [`ProposedBlock`] names the incoming bundles it
@@ -257,7 +257,7 @@ pub trait IncomingBundlesAreSelfDerived: ProposalGate + CertifiedBlockWasExecute
 /// one requested, returning `ExecutionError::OracleResponseMismatch` otherwise. The bytes are taken
 /// as given.
 ///
-/// That asymmetry matches the one [`IncomingBundlesAreSelfDerived`] records for
+/// That asymmetry matches the one [`IncomingBundlesMatchTheLocalInbox`] records for
 /// `must_be_present = false`, and it is deliberate for the same reason: by the time a block is
 /// certified, a quorum has already voted, and this lemma has done its work at voting time. It is
 /// also why a fabricated `events` field is beyond [`AccountabilityScope`] — the fabrication is

--- a/linera-chain/src/manager/proof/model.rs
+++ b/linera-chain/src/manager/proof/model.rs
@@ -252,7 +252,7 @@ pub trait DurablePersistence {}
 /// storage" but "no reading another chain's state": a cross-chain dependency is either delivered
 /// as a message or read from one of those two stores, never observed in the producing chain's
 /// [`ChainManager`](crate::manager::ChainManager) or inboxes.
-/// [`IncomingBundlesAreSelfDerived`] is the form that takes for the message case.
+/// [`IncomingBundlesMatchTheLocalInbox`] is the form that takes for the message case.
 ///
 /// The specification relies on the composition whenever it reasons about "the state immediately
 /// before" a vote — for instance in [`UnlockingJustification`], where the guard evaluated by
@@ -265,7 +265,7 @@ pub trait DurablePersistence {}
 /// chain; in both cases they compute the same owner and write the same shared keys. Nothing in
 /// the code detects either, so this is a deployment obligation, not an enforced invariant.
 ///
-/// [`IncomingBundlesAreSelfDerived`]: crate::manager::proof::commit::IncomingBundlesAreSelfDerived
+/// [`IncomingBundlesMatchTheLocalInbox`]: crate::manager::proof::commit::IncomingBundlesMatchTheLocalInbox
 /// [`UnlockingJustification`]: crate::manager::proof::safety::UnlockingJustification
 /// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
 /// [`ChainManager::create_vote`]: crate::manager::ChainManager::create_vote

--- a/linera-core/src/proof/availability.rs
+++ b/linera-core/src/proof/availability.rs
@@ -11,7 +11,7 @@
 //! [`CommitAgreement`]: linera_chain::manager::proof::safety::CommitAgreement
 
 use linera_chain::manager::proof::{
-    commit::{CommittedBlock, IncomingBundlesAreSelfDerived},
+    commit::{CommittedBlock, IncomingBundlesMatchTheLocalInbox},
     model::{CorrectValidator, SequentialChainState, StorageAtomicity},
 };
 
@@ -217,7 +217,7 @@ pub trait LockingBlobsTravelWithTheLock: CorrectValidator + CorrectValidatorAvai
 /// The inbox row is the one that needs care, because "valid" there means more than "the bundle
 /// exists". `remove_bundles_from_inboxes` runs with `must_be_present = true`, so the bundle must
 /// already be in *that validator's* inbox and equal to what it holds
-/// ([`IncomingBundlesAreSelfDerived`]); and consumption must respect cursor order, skipping only
+/// ([`IncomingBundlesMatchTheLocalInbox`]); and consumption must respect cursor order, skipping only
 /// bundles every message of which is skippable ([`DeliveryAndConsumptionAreOrdered`]). A client
 /// therefore cannot make a proposal valid by supplying a bundle in isolation: it supplies the
 /// sending chain's blocks, and the validator derives the inbox from them itself.
@@ -288,7 +288,7 @@ pub trait LockingBlobsTravelWithTheLock: CorrectValidator + CorrectValidatorAvai
 /// dependency that nobody can supply therefore surfaces as an error rather than looping.
 ///
 /// [`LocalNodeLagging`]: crate::client::chain_client::Error::LocalNodeLagging
-/// [`IncomingBundlesAreSelfDerived`]: linera_chain::manager::proof::commit::IncomingBundlesAreSelfDerived
+/// [`IncomingBundlesMatchTheLocalInbox`]: linera_chain::manager::proof::commit::IncomingBundlesMatchTheLocalInbox
 /// [`ValidationQuorumForms`]: super::progress::ValidationQuorumForms
 pub trait MissingDependenciesAreRecoverable:
     LockingBlobsTravelWithTheLock + CorrectValidatorAvailability + EventualSynchrony
@@ -353,7 +353,7 @@ pub trait EffectsSurviveRestart:
 /// chain's inboxes. `select_message_bundles` additionally drops bundles whose epoch has been
 /// revoked, unless they were already anticipated. ∎
 ///
-/// This is the premise [`IncomingBundlesAreSelfDerived`] leaves open: that lemma proves a voter
+/// This is the premise [`IncomingBundlesMatchTheLocalInbox`] leaves open: that lemma proves a voter
 /// matches consumed bundles against its own inbox, which is worth exactly as much as the inbox's
 /// own provenance.
 ///
@@ -381,7 +381,7 @@ pub trait InboxHoldsOnlySentBundles: CorrectValidator + SequentialChainState {}
 ///   part of the restored state.
 ///
 /// Consumption itself removes the bundle: `remove_bundles_from_inboxes` pops it from
-/// `added_bundles`, and by [`IncomingBundlesAreSelfDerived`] a correct validator does not vote for
+/// `added_bundles`, and by [`IncomingBundlesMatchTheLocalInbox`] a correct validator does not vote for
 /// a block consuming a bundle that is not there. ∎
 ///
 /// **Scoped to one validator.** Every clause above is about one validator's own inboxes. That all
@@ -392,7 +392,7 @@ pub trait InboxHoldsOnlySentBundles: CorrectValidator + SequentialChainState {}
 /// [`Cursor`]: linera_base::data_types::Cursor
 /// [`UniqueChain`]: linera_chain::manager::proof::safety::UniqueChain
 pub trait BundleConsumedAtMostOnce:
-    InboxHoldsOnlySentBundles + EffectsSurviveRestart + IncomingBundlesAreSelfDerived
+    InboxHoldsOnlySentBundles + EffectsSurviveRestart + IncomingBundlesMatchTheLocalInbox
 {
 }
 

--- a/linera-spec/src/lib.rs
+++ b/linera-spec/src/lib.rs
@@ -241,8 +241,8 @@
 //!   [`ConsensusInstance`] records what is assumed about it.
 //! * **Resource control and fees** — metering, declared block limits, and fee conservation.
 //! * **Event streams** — the reader side is covered, the publisher side is not. A voter resolves
-//!   every event a block reads against its own storage, at the exact identifier cited
-//!   ([`EventReadsAreSelfDerived`]); an event is written only under the publishing block's
+//!   every event a block reads against its own storage rather than trusting the proposer
+//!   ([`EventReadsResolveLocally`]); an event is written only under the publishing block's
 //!   certification, so it inherits that proof rather than carrying one
 //!   ([`AdmissionChecksTheValidityProof`]); and a stream's readable indices across a checkpoint are
 //!   fixed by [`EventFloorTracksCheckpoints`], with summarization by
@@ -268,7 +268,7 @@
 //! [`CertifiedBlockIsAvailable`]: linera_core::proof::availability::CertifiedBlockIsAvailable
 //! [`StorageConvergesAtEqualHeights`]: linera_core::proof::storage::StorageConvergesAtEqualHeights
 //! [`EventFloorTracksCheckpoints`]: linera_chain::proof::checkpoints::EventFloorTracksCheckpoints
-//! [`EventReadsAreSelfDerived`]: linera_chain::manager::proof::commit::EventReadsAreSelfDerived
+//! [`EventReadsResolveLocally`]: linera_chain::manager::proof::commit::EventReadsResolveLocally
 //! [`AdmissionChecksTheValidityProof`]: linera_core::proof::storage::AdmissionChecksTheValidityProof
 //! [`CheckpointSummarizesUserStreams`]: linera_chain::proof::checkpoints::CheckpointSummarizesUserStreams
 //! [`DeliveryAndConsumptionAreOrdered`]: linera_core::proof::availability::DeliveryAndConsumptionAreOrdered

--- a/linera-spec/src/lib.rs
+++ b/linera-spec/src/lib.rs
@@ -218,11 +218,19 @@
 //!   Safety reaches into execution in exactly one place: [`FastRetryPreservesBlock`] closes the
 //!   step from "same proposal" to "same block" with [`DeterministicExecution`] rather than a
 //!   runtime check at the retry. Everywhere else the two are kept apart.
-//! * **Cross-chain messaging** as a subsystem — delivery in particular: nothing states that an
-//!   outbox is ever drained, so no bundle is guaranteed to arrive. What *is* stated is that an
-//!   inbox holds only bundles its origin really sent ([`InboxHoldsOnlySentBundles`]), that no two
-//!   blocks consume the same bundle ([`BundleConsumedAtMostOnce`]), and that each chain's own
-//!   block sequence is unique ([`UniqueChain`]).
+//! * **Cross-chain messaging** — largely covered, except for unconditional delivery. An inbox holds
+//!   only bundles its origin really sent ([`InboxHoldsOnlySentBundles`]); a voter matches every
+//!   consumed bundle against its own inbox ([`IncomingBundlesAreSelfDerived`]); no two blocks
+//!   consume the same bundle ([`BundleConsumedAtMostOnce`]); delivery and consumption follow cursor
+//!   order, and only an entirely skippable bundle may be passed over
+//!   ([`DeliveryAndConsumptionAreOrdered`]); a sender may drop what its recipient has checkpointed
+//!   ([`AcknowledgedMessagesMayBeForgotten`]), though inbox entries themselves are never reclaimed
+//!   ([`InboxEntriesAreNeverReclaimed`]).
+//!
+//!   What is *not* guaranteed is that a bundle arrives at all. A sender's effort is bounded and a
+//!   recipient must ask for what it needs ([`DeliveryIsRepairedOnDemand`]); an idle sending chain
+//!   never retries a failed delivery, which is
+//!   [issue #6799](https://github.com/linera-io/linera-protocol/issues/6799).
 //! * **Committee reconfiguration** — partly covered now. [`CommitteeKnowledgeIsWellFounded`] fixes
 //!   where a node's knowledge of a committee comes from, and [`MaxByzantineWeight`] is assumed of
 //!   every epoch whose committee has not been revoked, so the fault bound accumulates as epochs are
@@ -232,9 +240,17 @@
 //! * **Chain ownership and lifecycle** — who may propose at a height, and how that changes;
 //!   [`ConsensusInstance`] records what is assumed about it.
 //! * **Resource control and fees** — metering, declared block limits, and fee conservation.
-//! * **Event streams** as a subsystem — append-only-ness and the publisher-side guarantees behind
-//!   a cross-chain `OracleResponse::Event` read. What is stated concerns only the checkpoint
-//!   boundary: [`EventFloorTracksCheckpoints`] says which indices stay readable across one.
+//! * **Event streams** — the reader side is covered, the publisher side is not. A voter resolves
+//!   every event a block reads against its own storage, at the exact identifier cited
+//!   ([`EventReadsAreSelfDerived`]); an event is written only under the publishing block's
+//!   certification, so it inherits that proof rather than carrying one
+//!   ([`AdmissionChecksTheValidityProof`]); and a stream's readable indices across a checkpoint are
+//!   fixed by [`EventFloorTracksCheckpoints`], with summarization by
+//!   [`CheckpointSummarizesUserStreams`].
+//!
+//!   Unstated: that a stream is append-only and gap-free in general — contiguity is claimed only
+//!   from a stream's floor upward — and what an application may assume about the *ordering* of
+//!   events it subscribes to across chains.
 //!
 //! [`CommitAgreement`]: linera_chain::manager::proof::safety::CommitAgreement
 //! [`UniqueChain`]: linera_chain::manager::proof::safety::UniqueChain
@@ -252,6 +268,13 @@
 //! [`CertifiedBlockIsAvailable`]: linera_core::proof::availability::CertifiedBlockIsAvailable
 //! [`StorageConvergesAtEqualHeights`]: linera_core::proof::storage::StorageConvergesAtEqualHeights
 //! [`EventFloorTracksCheckpoints`]: linera_chain::proof::checkpoints::EventFloorTracksCheckpoints
+//! [`EventReadsAreSelfDerived`]: linera_chain::manager::proof::commit::EventReadsAreSelfDerived
+//! [`AdmissionChecksTheValidityProof`]: linera_core::proof::storage::AdmissionChecksTheValidityProof
+//! [`CheckpointSummarizesUserStreams`]: linera_chain::proof::checkpoints::CheckpointSummarizesUserStreams
+//! [`DeliveryAndConsumptionAreOrdered`]: linera_core::proof::availability::DeliveryAndConsumptionAreOrdered
+//! [`DeliveryIsRepairedOnDemand`]: linera_core::proof::availability::DeliveryIsRepairedOnDemand
+//! [`AcknowledgedMessagesMayBeForgotten`]: linera_chain::proof::checkpoints::AcknowledgedMessagesMayBeForgotten
+//! [`InboxEntriesAreNeverReclaimed`]: linera_core::proof::storage::InboxEntriesAreNeverReclaimed
 //! [`ConsensusInstance`]: linera_chain::manager::proof::model::ConsensusInstance
 //! [`CertifiedBlockWasExecuted`]: linera_chain::manager::proof::commit::CertifiedBlockWasExecuted
 //! [`IncomingBundlesAreSelfDerived`]: linera_chain::manager::proof::commit::IncomingBundlesAreSelfDerived

--- a/linera-spec/src/lib.rs
+++ b/linera-spec/src/lib.rs
@@ -162,7 +162,7 @@
 //! * [`AccountabilityScope`] — incorrect block execution is not attributable, and its effects are
 //!   not confined to one chain: a wrong `messages` or `events` field is consumed by other chains
 //!   whose resulting blocks are themselves properly certified. The protections are
-//!   [`CertifiedBlockWasExecuted`] and [`IncomingBundlesAreSelfDerived`], and unlike the
+//!   [`CertifiedBlockWasExecuted`] and [`IncomingBundlesMatchTheLocalInbox`], and unlike the
 //!   accountability results both need [`MaxByzantineWeight`]. Tracked in
 //!   [issue #6675](https://github.com/linera-io/linera-protocol/issues/6675).
 //!
@@ -210,7 +210,7 @@
 //!   [`DeterministicExecution`] is assumed rather than proved, and *termination* of execution is
 //!   not stated at all. What is guaranteed is that a certified block was executed by some correct
 //!   validator ([`CertifiedBlockWasExecuted`]), that a voter matched every consumed bundle against
-//!   its own inbox ([`IncomingBundlesAreSelfDerived`]), and that the inputs execution needs can be
+//!   its own inbox ([`IncomingBundlesMatchTheLocalInbox`]), and that the inputs execution needs can be
 //!   supplied to a validator lacking them ([`MissingDependenciesAreRecoverable`]), and that its
 //!   outputs — published blobs, events and the certificate — reach storage before the block counts
 //!   as processed ([`BlockOutputsArePersisted`]).
@@ -220,7 +220,7 @@
 //!   runtime check at the retry. Everywhere else the two are kept apart.
 //! * **Cross-chain messaging** — largely covered, except for unconditional delivery. An inbox holds
 //!   only bundles its origin really sent ([`InboxHoldsOnlySentBundles`]); a voter matches every
-//!   consumed bundle against its own inbox ([`IncomingBundlesAreSelfDerived`]); no two blocks
+//!   consumed bundle against its own inbox ([`IncomingBundlesMatchTheLocalInbox`]); no two blocks
 //!   consume the same bundle ([`BundleConsumedAtMostOnce`]); delivery and consumption follow cursor
 //!   order, and only an entirely skippable bundle may be passed over
 //!   ([`DeliveryAndConsumptionAreOrdered`]); a sender may drop what its recipient has checkpointed
@@ -277,7 +277,7 @@
 //! [`InboxEntriesAreNeverReclaimed`]: linera_core::proof::storage::InboxEntriesAreNeverReclaimed
 //! [`ConsensusInstance`]: linera_chain::manager::proof::model::ConsensusInstance
 //! [`CertifiedBlockWasExecuted`]: linera_chain::manager::proof::commit::CertifiedBlockWasExecuted
-//! [`IncomingBundlesAreSelfDerived`]: linera_chain::manager::proof::commit::IncomingBundlesAreSelfDerived
+//! [`IncomingBundlesMatchTheLocalInbox`]: linera_chain::manager::proof::commit::IncomingBundlesMatchTheLocalInbox
 //! [`FullReachability`]: linera_core::proof::assumptions::FullReachability
 //! [`MissingDependenciesAreRecoverable`]: linera_core::proof::availability::MissingDependenciesAreRecoverable
 //! [`BlockOutputsArePersisted`]: linera_core::proof::availability::BlockOutputsArePersisted


### PR DESCRIPTION
## Motivation

The index's `Coverage` section still described cross-chain messaging and event streams as essentially uncovered. Both claims are now stale, and checking them turned up one genuine gap worth closing.

**Messaging** was described as "delivery in particular: nothing states that an outbox is ever drained", listing three statements. There are now nine touching messaging, and delivery itself is characterized rather than absent — `DeliveryIsRepairedOnDemand` says what actually holds (bounded sender effort, recipient-forced repair), with #6799 tracking the weakness.

**Event streams** was described as covered "only [at] the checkpoint boundary". That was true when written, but `AdmissionChecksTheValidityProof` (#6796) added a general claim: events are written only inside the branch guarded by `certificate.check`, so they inherit the publishing block's certification.

The real gap was on the **reader** side, and nothing stated it.

## Proposal

### `EventReadsResolveLocally` (new)

A correct validator votes for a block that reads an event only if that event is in **its own storage**, under the exact `EventId` cited, with the bytes it votes for being the bytes it holds.

It is what stands between a proposer and a block claiming to have read something nobody published — the event analogue of the inbox lemma, though **the mechanism is not the same**, and the difference decides how a discrepancy surfaces.

**A bundle is checked; an event is produced.** A `ProposedBlock` names the incoming bundles it consumes, so a validator can compare them against its inbox and reject on mismatch. It carries no `oracle_responses` — those exist only in `BlockExecutionOutcome` — so there is nothing to compare an event against. The validator reads its own storage and records what it finds.

So the two fail differently. A wrong bundle is *rejected*: `remove_bundles_from_inboxes` requires presence and equality. A wrong event is not rejected at all — the validator computes a different outcome, hence a different `Block`, and votes for that instead; the proposer's intended block simply never gathers a quorum. Both keep a fabricated value out of a certificate, but only the first produces a diagnosable error.

*Proof.* Validating a proposal executes the block afresh, with no recorded outcome to replay. `TransactionTracker::oracle` therefore finds no replayed response and runs its closure, which calls `get_event` against this validator's own storage and fails with `EventsNotFound` when absent. The value recorded in the block is the value that came back.

**Replay checks the identifier, not the content.** When a block *does* carry a recorded outcome — a regular retry, or a certified block being applied — `oracle` returns the recorded response without consulting storage, and `to_event` only checks that the recorded `EventId` matches the one requested. The bytes are taken as given.

That is precisely the asymmetry `IncomingBundlesAreSelfDerived` records for `must_be_present = false`, and it is deliberate for the same reason: by the time a block is certified a quorum has voted, and the lemma has done its work at voting time. It is also why a fabricated `events` field is beyond `AccountabilityScope` — caught by the voters or not at all, leaving no evidence afterwards.

### Coverage, corrected

**Messaging** now reads as largely covered, listing what holds — provenance, voter-side matching, at-most-once consumption, cursor ordering with the skippability rule, and sender-side reclamation — and separating the one thing that does not: unconditional delivery, with #6799 named.

**Event streams** now says the reader side is covered and the publisher side is not, and names what remains unstated: that a stream is append-only and gap-free in general (contiguity is claimed only from a stream's floor upward), and what an application may assume about the ordering of events it subscribes to across chains.

### Renamed for accuracy

`IncomingBundlesAreSelfDerived` → **`IncomingBundlesMatchTheLocalInbox`**. Its own headline already read "Incoming bundles are matched against the validator's own inbox", so only the trait name was vague — a mismatch the specification's own convention ("its name is its identity") should not tolerate. "Self-derived" was also doing double duty: for bundles it referred to the *inbox* being self-derived, for events it would refer to the *value*. The pair now reads `IncomingBundlesMatchTheLocalInbox` / `EventReadsResolveLocally`, where the verb carries the check-versus-resolve distinction above. 19 references across 5 files, all compiler- or rustdoc-checked.

One prose use of "self-derived" survives in `commit.rs`, where it genuinely means "computed by the validator itself" in contrast to a preprocessed block taken at face value; it now says "the validator's own work" to match that sentence's own framing.

## Test Plan

CI. Documentation-only: marker traits with no members, implementors or call sites. `cargo doc --all-features` under `-D warnings`, `cargo +nightly fmt --check` and `cargo clippy --all-features` are clean, as is `scripts/check_spec_modules.sh`.

This should be the first pull request to take the cheaper specification-only CI path added in #6805 — it touches only `linera-chain/src/manager/proof/` and `linera-spec/`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6796 — `AdmissionChecksTheValidityProof`, the general event guarantee the old bullet predated.
- #6799 — an idle sending chain never retries a failed delivery; the one messaging gap that remains.
- #6805 — the specification-only CI path this exercises.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
