### PR TITLE
Wait out a detached task's cancellation instead of reporting it as a panic

### DIFF
--- a/linera-base/src/task.rs
+++ b/linera-base/src/task.rs
@@ -71,16 +71,21 @@ where
 
 /// Awaits a detached task, propagating its panic but not its cancellation.
 ///
-/// [`run_detached`] never lets the `JoinHandle` escape, so nothing can abort the task and a
-/// cancellation can only mean the runtime is shutting down. There is no value left to return and
-/// this future is about to be dropped with everything else, so it waits rather than reporting a
-/// teardown as a failure.
+/// [`run_detached`] never lets the `JoinHandle` escape, so nothing can abort the task: a
+/// cancellation means `spawn` bound the task to an already-closed runtime, which hands back a
+/// handle that is dead on arrival. There is no value left to return and the shutdown that closed
+/// that list is about to drop this future too, so it waits rather than reporting a teardown as a
+/// failure — but it says so first, because that reasoning only holds while the awaiting task
+/// lives on the runtime that died.
 #[cfg(not(web))]
 async fn join_detached<R>(handle: tokio::task::JoinHandle<R>) -> R {
     match handle.await {
         Ok(output) => output,
         Err(error) if error.is_panic() => std::panic::resume_unwind(error.into_panic()),
-        Err(_) => future::pending().await,
+        Err(error) => {
+            tracing::warn!(%error, "detached task cancelled; waiting for the shutdown that caused it");
+            future::pending().await
+        }
     }
 }
 

--- a/linera-base/src/task.rs
+++ b/linera-base/src/task.rs
@@ -54,9 +54,7 @@ where
     // fire-and-forget, so we deliver the output through a oneshot channel.
     #[cfg(not(web))]
     {
-        tokio::task::spawn(future)
-            .await
-            .unwrap_or_else(|e| std::panic::resume_unwind(e.into_panic()))
+        join_detached(tokio::task::spawn(future)).await
     }
     #[cfg(web)]
     {
@@ -68,6 +66,21 @@ where
         });
         rx.await
             .expect("spawned task dropped without sending its result")
+    }
+}
+
+/// Awaits a detached task, propagating its panic but not its cancellation.
+///
+/// [`run_detached`] never lets the `JoinHandle` escape, so nothing can abort the task and a
+/// cancellation can only mean the runtime is shutting down. There is no value left to return and
+/// this future is about to be dropped with everything else, so it waits rather than reporting a
+/// teardown as a failure.
+#[cfg(not(web))]
+async fn join_detached<R>(handle: tokio::task::JoinHandle<R>) -> R {
+    match handle.await {
+        Ok(output) => output,
+        Err(error) if error.is_panic() => std::panic::resume_unwind(error.into_panic()),
+        Err(_) => future::pending().await,
     }
 }
 
@@ -142,5 +155,45 @@ impl<R: 'static> std::future::IntoFuture for Task<R> {
     fn into_future(self) -> Self::IntoFuture {
         self.output
             .map(|result| result.expect("we have the only AbortHandle"))
+    }
+}
+
+#[cfg(all(test, not(web)))]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    /// A cancelled detached task must not be reported as a panic.
+    ///
+    /// Cancellation is provoked with `abort` because the runtime shutdown that causes it in
+    /// production cannot be staged inside a test that still needs the runtime alive. Reverting
+    /// `join_detached` to `into_panic` makes this fail with "`JoinError` reason is not a panic".
+    #[tokio::test]
+    async fn a_cancelled_detached_task_waits_instead_of_panicking() {
+        let handle = tokio::task::spawn(future::pending::<()>());
+        handle.abort();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), join_detached(handle))
+                .await
+                .is_err(),
+            "a cancelled task has no value to yield, so joining it must not resolve",
+        );
+    }
+
+    /// The panic of a detached task must still reach whoever awaited it.
+    #[tokio::test]
+    async fn a_panicking_detached_task_still_propagates() {
+        let joined = tokio::task::spawn(async {
+            run_detached(async { panic!("the detached task failed") }).await
+        })
+        .await;
+        let error = joined.expect_err("the panic must not be swallowed");
+        let payload = error.into_panic();
+        assert_eq!(
+            payload.downcast_ref::<&str>().copied(),
+            Some("the detached task failed"),
+            "the original panic payload must survive the join",
+        );
     }
 }


### PR DESCRIPTION
## Motivation

`run_detached` awaits a spawned task and unwraps any `JoinError` with `into_panic()`. A `JoinError`
has exactly two shapes — `Cancelled` and `Panic` (tokio `runtime/task/error.rs:15-18`) — and
`into_panic()` is only valid on the second. On the first it panics with its own message, so a task
that was merely cancelled is reported as:

```
thread 'tokio-runtime-worker' panicked at linera-base/src/task.rs:59:61:
`JoinError` reason is not a panic.: JoinError::Cancelled(Id(113606))
```

Cancellation is not a failure here. `run_detached` consumes the `JoinHandle` immediately and never
lets it escape, so nothing can `abort()` the task — the only remaining source is runtime shutdown,
where "tasks spawned through `Runtime::spawn` keep running until they yield. Then they are dropped"
(tokio `runtime/runtime.rs:35-37`). So this fires when a detached task is still in flight as the
runtime goes away, which is ordinary teardown.

It is reachable from the two production call sites — `linera-core/src/worker.rs:1014` and
`linera-core/src/chain_worker/handle.rs:176`, both on the storage-write path — and it surfaces as
flaky CI. Observed on `storage-service-tests`, `test_end_to_end_benchmark::storage_service_grpc`,
which passed on a rerun of the identical commit.

## Proposal

Distinguish the two cases. A panic still propagates unchanged; a cancellation waits instead:

```rust
async fn join_detached<R>(handle: tokio::task::JoinHandle<R>) -> R {
    match handle.await {
        Ok(output) => output,
        Err(error) if error.is_panic() => std::panic::resume_unwind(error.into_panic()),
        Err(_) => future::pending().await,
    }
}
```

Waiting is the honest answer rather than a workaround: there is no `R` to return, and the future is
about to be dropped along with the runtime that cancelled the task. Panicking instead reports a
teardown as a failure, and choosing any other value would be inventing one.

It is a separate function so the cancelled branch is reachable from a test — `run_detached` alone
cannot be driven into it, because the handle it would need to cancel is private to it.

## Test Plan

`cargo test -p linera-base --lib task` — two tests, verified to fail for the right reason:

- **`a_cancelled_detached_task_waits_instead_of_panicking`** asserts the join does not resolve, not
  merely that nothing panicked. Reverting `join_detached` to the single `into_panic` arm makes it
  fail with the exact CI message: ``` `JoinError` reason is not a panic.: JoinError::Cancelled(Id(3)) ```
- **`a_panicking_detached_task_still_propagates`** is the control: it drives `run_detached` itself
  and asserts the original payload survives the join, so the fix cannot pass by swallowing panics.
  It still passes under the mutation above, which is what makes the first test the discriminating
  one.

Also `cargo clippy -p linera-base --all-targets` (clean) and `cargo +nightly fmt --all -- --check`.

**No wasm target compiles this code, so the web path cannot be affected — and no wasm check can
verify it either.** `linera-base/src/lib.rs:44` gates the module `#[cfg(not(chain))]`, and
`build.rs:6-7` defines `chain = wasm32 && !web`, so plain `--target wasm32-unknown-unknown` drops
the module entirely; under `--features web` the new `join_detached` is itself `#[cfg(not(web))]`.
Measured, rather than assumed: with a deliberate type error injected into `join_detached`, both
`cargo check -p linera-base --target wasm32-unknown-unknown` and the same with `--features web`
exit **0**, while the native `cargo check -p linera-base` exits **101**. An earlier revision of
this Test Plan cited the wasm check as evidence; it is not, and the native build is what covers
this change.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

The same code is byte-identical on `testnet_conway`, where the flake has already cost a CI run.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

