### PR TITLE
Wait out a detached task's cancellation instead of reporting it as a panic (backport #6812)

### DIFF
--- a/linera-base/src/task.rs
+++ b/linera-base/src/task.rs
@@ -54,9 +54,7 @@ where
     // fire-and-forget, so we deliver the output through a oneshot channel.
     #[cfg(not(web))]
     {
-        tokio::task::spawn(future)
-            .await
-            .unwrap_or_else(|e| std::panic::resume_unwind(e.into_panic()))
+        join_detached(tokio::task::spawn(future)).await
     }
     #[cfg(web)]
     {
@@ -68,6 +66,26 @@ where
         });
         rx.await
             .expect("spawned task dropped without sending its result")
+    }
+}
+
+/// Awaits a detached task, propagating its panic but not its cancellation.
+///
+/// [`run_detached`] never lets the `JoinHandle` escape, so nothing can abort the task: a
+/// cancellation means `spawn` bound the task to an already-closed runtime, which hands back a
+/// handle that is dead on arrival. There is no value left to return and the shutdown that closed
+/// that list is about to drop this future too, so it waits rather than reporting a teardown as a
+/// failure — but it says so first, because that reasoning only holds while the awaiting task
+/// lives on the runtime that died.
+#[cfg(not(web))]
+async fn join_detached<R>(handle: tokio::task::JoinHandle<R>) -> R {
+    match handle.await {
+        Ok(output) => output,
+        Err(error) if error.is_panic() => std::panic::resume_unwind(error.into_panic()),
+        Err(error) => {
+            tracing::warn!(%error, "detached task cancelled; waiting for the shutdown that caused it");
+            future::pending().await
+        }
     }
 }
 
@@ -142,5 +160,45 @@ impl<R: 'static> std::future::IntoFuture for Task<R> {
     fn into_future(self) -> Self::IntoFuture {
         self.output
             .map(|result| result.expect("we have the only AbortHandle"))
+    }
+}
+
+#[cfg(all(test, not(web)))]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    /// A cancelled detached task must not be reported as a panic.
+    ///
+    /// Cancellation is provoked with `abort` because the runtime shutdown that causes it in
+    /// production cannot be staged inside a test that still needs the runtime alive. Reverting
+    /// `join_detached` to `into_panic` makes this fail with "`JoinError` reason is not a panic".
+    #[tokio::test]
+    async fn a_cancelled_detached_task_waits_instead_of_panicking() {
+        let handle = tokio::task::spawn(future::pending::<()>());
+        handle.abort();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), join_detached(handle))
+                .await
+                .is_err(),
+            "a cancelled task has no value to yield, so joining it must not resolve",
+        );
+    }
+
+    /// The panic of a detached task must still reach whoever awaited it.
+    #[tokio::test]
+    async fn a_panicking_detached_task_still_propagates() {
+        let joined = tokio::task::spawn(async {
+            run_detached(async { panic!("the detached task failed") }).await
+        })
+        .await;
+        let error = joined.expect_err("the panic must not be swallowed");
+        let payload = error.into_panic();
+        assert_eq!(
+            payload.downcast_ref::<&str>().copied(),
+            Some("the detached task failed"),
+            "the original panic payload must survive the join",
+        );
     }
 }


### PR DESCRIPTION
Backport of [#6812](https://github.com/linera-io/linera-protocol/pull/6812) to `testnet_conway`.

## Motivation

`run_detached` awaits a spawned task and unwraps any `JoinError` with `into_panic()`, which is only
valid on the panic case — on a cancelled task it panics with its own message:

```
thread 'tokio-runtime-worker' panicked at linera-base/src/task.rs:59:61:
`JoinError` reason is not a panic.: JoinError::Cancelled(Id(113606))
```

Cancellation is not a failure here. As @ma2bd pinned down on #6812, the path that actually fires is
`tokio::spawn` binding to a runtime whose task list is already closed: `OwnedTasks::bind_inner`
checks the `closed` flag under the shard lock and calls `task.shutdown()`, so the handle comes back
dead and `handle.await` resolves `Err(Cancelled)` synchronously on the first poll — on the worker
thread, which is what the reported message says. (Plain runtime teardown cannot produce it: the
awaiting task is dropped in the same sweep, so nobody observes the `Err`.)

**This branch is where it actually bit us** — the flake failed `storage-service-tests` on
[#6803](https://github.com/linera-io/linera-protocol/pull/6803), and passed on a rerun of the
identical commit. The code is byte-identical on both branches, so `main` alone would have left
conway flaking.

## Proposal

Straight cherry-pick of `17981d853dd`, no adaptation. A panic still propagates unchanged; a
cancellation logs and then waits, because there is no value left to return and the shutdown that
closed the task list is about to drop this future too.

The `warn!` is @ma2bd's review point and is the reason it is not silent: waiting is only correct
while the awaiting task lives on the runtime that died. A `block_on` outliving it, or a future
entered into runtime A via `Handle::enter()` but polled by runtime B, would wait forever with no
trace. Nothing in the repo does that today, so it is not a blocker — but the log is the difference
between a greppable line and a silently stuck chain worker if that invariant ever stops holding.

## Test Plan

**Verified byte-identical to the approved `main` version** — this is the check that matters for a
backport, and it is why no separate review pass was run:

- `diff` of `linera-base/src/task.rs` against `upstream/main` → identical
- `diff` of the applied patch against `17981d853dd`'s → identical

Gates re-run on this branch, because the surrounding tree differs:

- `cargo test -p linera-base --lib task` — 2 passed
- **Mutation test on this branch**: collapsing the two `Err` arms back to a single
  `resume_unwind(error.into_panic())` makes `a_cancelled_detached_task_waits_instead_of_panicking`
  fail with the exact CI message, while `a_panicking_detached_task_still_propagates` stays green —
  so the two tests are independent and the cancelled one is the discriminating test.
- `cargo clippy -p linera-base --all-targets` — clean
- `cargo +nightly fmt --all -- --check` — clean

## Release Plan

- These changes are already on `main`; this is the `testnet_conway` backport, and
    - can ride the next validator release.

## Links

- [#6812](https://github.com/linera-io/linera-protocol/pull/6812) — the `main` PR, approved by @ma2bd.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
