### PR TITLE
Make decoded application payloads usable from JavaScript

### DIFF
--- a/linera-sdk/src/formats.rs
+++ b/linera-sdk/src/formats.rs
@@ -9,10 +9,8 @@ use serde_reflection::{
         DeserializationContext, DeserializationEnvironment, SerializationContext,
         SerializationEnvironment, SymbolTableEnvironment,
     },
-    Format, Registry,
+    Format, Registry, Samples, Tracer, TracerConfig,
 };
-#[cfg(not(target_arch = "wasm32"))]
-use serde_reflection::{Samples, Tracer, TracerConfig};
 
 /// The serde formats used by an application. The exact serde encoding in use must be
 /// known separately.
@@ -45,7 +43,6 @@ pub trait BcsApplication {
     /// pruned from the registry (see [`Formats::prune_known_primitives`]) so that they
     /// decode to their human-readable form via [`LineraEnvironment`]. This is the form
     /// meant to be published to a formats registry.
-    #[cfg(not(target_arch = "wasm32"))]
     fn pruned_formats() -> Result<Formats, PruneError> {
         let mut formats = Self::formats()?;
         formats.prune_known_primitives()?;
@@ -167,7 +164,6 @@ macro_rules! known_human_readable_primitives {
 
         /// Traces the canonical BCS format of every known primitive, used to verify
         /// the correspondence before pruning.
-        #[cfg(not(target_arch = "wasm32"))]
         fn expected_primitive_registry() -> serde_reflection::Result<Registry> {
             let mut tracer = Tracer::new(
                 TracerConfig::default()
@@ -205,7 +201,6 @@ known_human_readable_primitives! {
 }
 
 /// An error raised while pruning known primitives from a [`Formats`] registry.
-#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, thiserror::Error)]
 pub enum PruneError {
     /// The canonical formats of the known primitives could not be computed.
@@ -282,7 +277,11 @@ impl Formats {
     /// This is meant to be called from snapshot tests (and any other code that
     /// generates the stored [`Formats`]) so that the human-readable rendering is baked
     /// into the published formats.
-    #[cfg(not(target_arch = "wasm32"))]
+    ///
+    /// A reader can also call it on formats it has just fetched. Registry entries are
+    /// immutable, so formats that were published unpruned would otherwise render their
+    /// primitives structurally forever; pruning on the way in repairs them for every
+    /// reader, without republishing anything.
     pub fn prune_known_primitives(&mut self) -> Result<(), PruneError> {
         let expected = expected_primitive_registry()?;
         // Verify everything first so a mismatch never leaves the registry half-pruned.

--- a/web/@linera/client/src/formats.rs
+++ b/web/@linera/client/src/formats.rs
@@ -12,10 +12,23 @@
 //! this network it is served by a formats-registry application, which
 //! [`Application::query`](crate::chain::Application::query) can already read.
 
+use serde::ser::Serialize as _;
+use serde_wasm_bindgen::Serializer;
 use wasm_bindgen::prelude::*;
 use web_sys::wasm_bindgen;
 
 use crate::Result;
+
+/// The conversion every decoded payload goes through.
+///
+/// Application types carry `u64` and `u128` amounts that a JavaScript number
+/// cannot hold, and structs that should arrive as plain objects. The default
+/// conversion does neither: it fails outright on a large integer, and turns
+/// every struct into a `Map` that `JSON.stringify` renders as `{}`. This
+/// mirrors `linera-explorer`'s own serializer.
+const SER: Serializer = Serializer::new()
+    .serialize_large_number_types_as_bigints(true)
+    .serialize_maps_as_objects(true);
 
 /// A decoder for one application's operation, message, response and event payloads.
 #[wasm_bindgen]
@@ -39,9 +52,7 @@ impl Formats {
     /// If the bytes don't match the application's operation format.
     #[wasm_bindgen(js_name = decodeOperation)]
     pub fn decode_operation(&self, bytes: &[u8]) -> Result<JsValue> {
-        Ok(serde_wasm_bindgen::to_value(
-            &self.0.decode_operation(bytes)?,
-        )?)
+        Ok(self.0.decode_operation(bytes)?.serialize(&SER)?)
     }
 
     /// Decodes the bytes of an operation's result into a plain JavaScript value.
@@ -50,9 +61,7 @@ impl Formats {
     /// If the bytes don't match the application's response format.
     #[wasm_bindgen(js_name = decodeResponse)]
     pub fn decode_response(&self, bytes: &[u8]) -> Result<JsValue> {
-        Ok(serde_wasm_bindgen::to_value(
-            &self.0.decode_response(bytes)?,
-        )?)
+        Ok(self.0.decode_response(bytes)?.serialize(&SER)?)
     }
 
     /// Decodes the bytes of a cross-chain message into a plain JavaScript value.
@@ -61,9 +70,7 @@ impl Formats {
     /// If the bytes don't match the application's message format.
     #[wasm_bindgen(js_name = decodeMessage)]
     pub fn decode_message(&self, bytes: &[u8]) -> Result<JsValue> {
-        Ok(serde_wasm_bindgen::to_value(
-            &self.0.decode_message(bytes)?,
-        )?)
+        Ok(self.0.decode_message(bytes)?.serialize(&SER)?)
     }
 
     /// Decodes the bytes of an event into a plain JavaScript value.
@@ -72,8 +79,6 @@ impl Formats {
     /// If the bytes don't match the application's event format.
     #[wasm_bindgen(js_name = decodeEventValue)]
     pub fn decode_event_value(&self, bytes: &[u8]) -> Result<JsValue> {
-        Ok(serde_wasm_bindgen::to_value(
-            &self.0.decode_event_value(bytes)?,
-        )?)
+        Ok(self.0.decode_event_value(bytes)?.serialize(&SER)?)
     }
 }

--- a/web/@linera/client/src/formats.rs
+++ b/web/@linera/client/src/formats.rs
@@ -43,7 +43,14 @@ impl Formats {
     /// If the bytes are not a BCS-encoded `Formats`.
     #[wasm_bindgen(js_name = fromBytes)]
     pub fn from_bytes(bytes: &[u8]) -> Result<Formats> {
-        Ok(Formats(linera_sdk::bcs::from_bytes(bytes)?))
+        let mut formats: linera_sdk::formats::Formats = linera_sdk::bcs::from_bytes(bytes)?;
+        // Formats published without pruning define the well-known linera-base
+        // primitives themselves, which shadows the SDK's `LineraEnvironment` and leaves
+        // an `AccountOwner` rendered as its variant and bytes rather than as an address.
+        // Registry entries are immutable, so pruning here is what repairs those. A name
+        // collision leaves the registry untouched, so this is safe to always apply.
+        let _ = formats.prune_known_primitives();
+        Ok(Formats(formats))
     }
 
     /// Decodes the bytes of an operation into a plain JavaScript value.


### PR DESCRIPTION
## Motivation

`Formats` decodes an application's payloads but cannot hand most of them to
JavaScript in a usable form. Two separate defects, both hit on the first real
payload rather than at the edges.

**Large integers and structs never make it across.** Decoding a real operation
fails outright with

```
10000000000000000000 can't be represented as a JavaScript number
```

because the conversion used the default `serde_wasm_bindgen` settings. Amounts
are `u64`/`u128`, so anything above `Number.MAX_SAFE_INTEGER` is rejected; and
the default also turns every map into a JavaScript `Map`, which
`JSON.stringify` renders as `{}` — so even a payload that decoded would display
as nothing. `linera-explorer` already gets both right, with exactly the settings
this PR adopts:

```rust
pub(crate) const SER: Serializer = serde_wasm_bindgen::Serializer::new()
    .serialize_large_number_types_as_bigints(true)
    .serialize_maps_as_objects(true);
```

**Primitives decode structurally.** `LineraEnvironment` renders the well-known
linera-base primitives canonically — an `AccountOwner` as its address — but only
for names *absent* from the registry being decoded. An application that
published `formats()` rather than `pruned_formats()` defines `AccountOwner`
itself, which shadows the environment, and its owners come out as
`{"Address20": [18, 52, …]}`.

That is not fixable by publishing better formats: registry entries are immutable
per module, so every already-deployed application decodes structurally forever.
It has to be repaired by the reader.

## Proposal

- Route all four decoders through a serializer with both settings.
- Prune the known primitives out of formats as they are read, in
  `Formats::fromBytes`. On a name collision `prune_known_primitives` leaves the
  registry untouched, so this is safe to apply unconditionally.

Pruning was gated behind `#[cfg(not(target_arch = "wasm32"))]`, which is what
kept it out of the one place that needs it at decode time. The gate turns out to
be incidental rather than technical: the code compiles for `wasm32` unchanged
(`cargo check -p linera-sdk --target wasm32-unknown-unknown`), so the gates are
removed. Nothing calls the pruning path from a contract, so it is dead code
there and eliminated.

Note for callers: large integers now arrive as `BigInt`, which `JSON.stringify`
throws on. Rendering a decoded payload needs a replacer — the same obligation
`linera-explorer` already carries in `Json.vue`.

## Test Plan

CI, plus locally on this branch's pinned toolchains:

- `cargo check --lib --target wasm32-unknown-unknown` for `linera-web`, and
  `cargo check -p linera-sdk` both natively and for `wasm32-unknown-unknown`.
- `cargo clippy --lib --target wasm32-unknown-unknown` — no new warnings; the
  ones that remain are all present on `testnet_conway` already.
- `cargo fmt --check` under `nightly-2025-04-03` for both crates.

Found by using these bindings from pm-app's chain explorer against
testnet-conway. Before: decoding a `pm-parimutuel` operation failed with the
error above, and once that was worked around its owners rendered as
`{"Address20": [...]}`. After: the operation decodes, and owners render as
`0x…`.

## Release Plan

- These changes need a new `@linera/client` release to be usable, and should be
  forward-ported to `main`.

## Links

- #6740, which added the bindings
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
