### PR TITLE
[testnet] Keep the project template on an encoding_rs version supporting Rust 1.86

### DIFF
--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -14,6 +14,7 @@ serde_json = {{ version = "1.0" }}
 # TODO(#4742): Remove the pinned versions once the `linera-*` crates work with Rust > 1.86.0.
 allocative_derive = {{ version = ">=0.3, <0.3.5" }}
 darling = {{ version = ">=0.20, <0.23" }}
+encoding_rs = {{ version = ">=0.8, <0.8.40" }}
 icu_collections = {{ version = ">=2, <2.3" }}
 icu_locale_core = {{ version = ">=2, <2.3" }}
 icu_normalizer = {{ version = ">=2, <2.3" }}


### PR DESCRIPTION
## Motivation

CI on `testnet_conway` is red since `ad6ceee1fb` ("prepare release of SDK v0.15.23", #6816), in
three jobs that all fail the same way:

| Workflow / job | Failing test |
|---|---|
| Rust / default-features-and-witty-integration-test | `local::test_project_new` |
| Rust / storage-service-tests | `test_project_publish::storage_service_grpc` |
| ScyllaDB tests / test | `test_project_publish::scylladb_grpc` |

```
error: rustc 1.86.0 is not supported by the following packages:
  encoding_rs@0.8.41 requires rustc 1.88
```

These tests build a project generated from `linera-service/template/Cargo.toml.template`, which has
no lockfile, so Cargo resolves each dependency to its newest version. `encoding_rs` 0.8.40
(2026-09-07) and 0.8.41 (2026-09-09) raised the minimum Rust version to 1.88, while this branch is
pinned to 1.86.0. The last green run predates 0.8.40 by about four hours. The workspace's own
`Cargo.lock` still has 0.8.35, so nothing else is affected.

Since the template ships inside the `linera` binary, `linera project new` also fails for users of
the freshly released SDK v0.15.23.

## Proposal

Cap `encoding_rs` below 0.8.40 in the template, next to the other versions pinned for Rust 1.86.0
under `TODO(#4742)`, as in #6707 and #6356.

## Test Plan

CI, plus a local reproduction: instantiating the template by hand with `linera-sdk` as a path
dependency and running the same command the test runs,
`cargo build --release --target wasm32-unknown-unknown` on Rust 1.86.0.

- without the pin: fails with the error above, identical to CI;
- with the pin: resolves `encoding_rs` to 0.8.35 and builds cleanly, with no other crate reporting
  an incompatible minimum Rust version.

## Release Plan

This PR targets `testnet_conway` directly and should go into the next SDK release from this
branch. `main` is on Rust 1.95 and is not affected.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- #6707, #6356: earlier pins of the same kind
- #4742: tracking issue for removing these pins
