### PR TITLE
Check linera-version's API hash cache in CI and make it regenerable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -271,6 +271,24 @@ jobs:
           exit 1
         fi
 
+  check-outdated-api-hashes:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Check for outdated api-hashes.json
+      run: |
+        if ! diff linera-version/api-hashes.json <(cargo run --locked -p linera-version)
+        then
+          echo '`linera-version/api-hashes.json` differs from the computed API hashes'
+          echo 'Run `cargo run -p linera-version > linera-version/api-hashes.json` to update it.'
+          exit 1
+        fi
+
   benchmark-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'

--- a/linera-version/Cargo.toml
+++ b/linera-version/Cargo.toml
@@ -26,6 +26,9 @@ sha3.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+serde_json.workspace = true
+
 [build-dependencies]
 base64.workspace = true
 cargo_metadata.workspace = true

--- a/linera-version/api-hashes.json
+++ b/linera-version/api-hashes.json
@@ -1,5 +1,5 @@
 {
-    "rpc": "K9p3m/MsIPZL32CYddAqlG6PHKprJvMjei5cIiqFgDY",
-    "graphql": "RmwcE5swpH/HkjbetY/YyD6ebNQFS9oeU6ayEAvDjEQ",
-    "wit": "0X+I4jeHCdpD2M0R+OVodI4pH+dF9rt0K/iHENVcnug"
+  "rpc": "R+hOHa12w3uYcIYh7AW+JXwo97bEOH1Nm0IoAqZshvs",
+  "graphql": "u/1mosg1Nwe2EyvhMVpFVSy7lVNYuKecArYcNK80nw8",
+  "wit": "LBDK3ZORkwFJX1WI+P0neR3xZNtvhufYjvfROgBR3QM"
 }

--- a/linera-version/src/main.rs
+++ b/linera-version/src/main.rs
@@ -5,6 +5,7 @@ use linera_version::VersionInfo;
 
 fn main() -> anyhow::Result<()> {
     serde_json::to_writer_pretty(std::io::stdout(), &VersionInfo::get()?.api_hashes())?;
+    println!();
 
     Ok(())
 }

--- a/linera-version/src/version_info/type.rs
+++ b/linera-version/src/version_info/type.rs
@@ -233,16 +233,13 @@ impl VersionInfo {
         }
         .into();
 
-        let api_hashes: ApiHashes = serde_json::from_reader(fs_err::File::open(api_hashes_path)?)?;
-
         let rpc_hash = get_hash(
             paths,
             &metadata,
             "linera-rpc",
             "tests/snapshots/format__format.yaml.snap",
         )
-        .unwrap_or(api_hashes.rpc)
-        .into();
+        .ok();
 
         let graphql_hash = get_hash(
             paths,
@@ -250,12 +247,30 @@ impl VersionInfo {
             "linera-service-graphql-client",
             "gql/*.graphql",
         )
-        .unwrap_or(api_hashes.graphql)
-        .into();
+        .ok();
 
-        let wit_hash = get_hash(paths, &metadata, "linera-sdk", "wit/*.wit")
-            .unwrap_or(api_hashes.wit)
-            .into();
+        let wit_hash = get_hash(paths, &metadata, "linera-sdk", "wit/*.wit").ok();
+
+        // The cache is a stand-in for the API source files, which a published crate does not
+        // ship; reading it only when a hash is missing keeps it writable from its own output.
+        let (rpc_hash, graphql_hash, wit_hash) = match (rpc_hash, graphql_hash, wit_hash) {
+            (Some(rpc_hash), Some(graphql_hash), Some(wit_hash)) => {
+                (rpc_hash, graphql_hash, wit_hash)
+            }
+            (rpc_hash, graphql_hash, wit_hash) => {
+                let api_hashes: ApiHashes =
+                    serde_json::from_reader(fs_err::File::open(api_hashes_path)?)?;
+                (
+                    rpc_hash.unwrap_or(api_hashes.rpc),
+                    graphql_hash.unwrap_or(api_hashes.graphql),
+                    wit_hash.unwrap_or(api_hashes.wit),
+                )
+            }
+        };
+
+        let rpc_hash = rpc_hash.into();
+        let graphql_hash = graphql_hash.into();
+        let wit_hash = wit_hash.into();
 
         Ok(Self {
             crate_version,

--- a/linera-version/tests/up_to_date.rs
+++ b/linera-version/tests/up_to_date.rs
@@ -1,13 +1,24 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_version::VersionInfo;
+use linera_version::{ApiHashes, VersionInfo};
 
+/// Checks the committed hash cache against the hashes computed from the API source files.
+///
+/// The cache is only read when those files cannot be located, which is the case for a
+/// published crate but not within this repository.
 #[test]
 fn up_to_date() {
+    let cached_path = concat!(env!("CARGO_MANIFEST_DIR"), "/api-hashes.json");
+    let cached: ApiHashes = serde_json::from_str(
+        &std::fs::read_to_string(cached_path)
+            .unwrap_or_else(|error| panic!("failed to read `{cached_path}`: {error}")),
+    )
+    .unwrap_or_else(|error| panic!("failed to parse `{cached_path}`: {error}"));
+
     assert_eq!(
         VersionInfo::get().unwrap().api_hashes(),
-        VersionInfo::default().api_hashes(),
+        cached,
         "`linera-version` API hash cache out of date.\n\
          Please update `linera-version/api-hashes.json` by running:\n\
          $ cargo run -p linera-version > linera-version/api-hashes.json"


### PR DESCRIPTION
## Motivation

`linera-version/api-hashes.json` has not changed since #2347 (2024-08-03), even though the WIT files, the GraphQL schema and the RPC snapshot have all changed since — this branch and `main` ship the same three hashes despite having different WIT files. Two things kept it that way:

- `tests/up_to_date.rs` compares `VersionInfo::get()` against `VersionInfo::default()`. The latter is baked in by `build.rs`, which calls the same `trace_get`, so in a workspace checkout both sides are computed from the live files and the file is never consulted. The test cannot fail.
- The command it recommends, `cargo run -p linera-version > linera-version/api-hashes.json`, truncates the file before the binary starts, and `trace_get` reads it eagerly, so regenerating fails with `JSON error: EOF while parsing a value at line 1 column 0`.

The file is what a published crate reports, since `cargo metadata` resolves it standalone there, without the sibling packages the hashes are computed from. `VersionInfo::is_compatible_with` compares `api_hashes()` before falling back to semver, so stale values let two registry builds with different APIs consider each other compatible.

## Proposal

- Read the file only when a hash cannot be computed, instead of always. That is what it is for, and it makes the file writable from the tool's own output.
- Compare the computed hashes against the file in `tests/up_to_date.rs`.
- Add a `check-outdated-api-hashes` CI job, in the style of `check-outdated-cli-md`.
- Terminate the generated JSON with a newline, and refresh the file with this branch's own hashes.

**Relationship to #6818.** On `main` the mechanism is being removed instead: the hashes become `Option`, absent when they cannot be computed, and the file is deleted — because in the only situation that reads it, the recorded hashes are a constant of the release and therefore carry nothing that `crate_version` does not. That change alters the BCS encoding of `RpcMessage::VersionInfoResponse` and flips the RPC hash, which is not acceptable on a deployed network in a patch release. So this branch keeps the file and only makes it correct and verified; this is the terminal state for the 0.15 line.

## Test Plan

- `cargo test -p linera-version` fails on the stale file before the refresh, reporting all three hashes, and passes after it.
- `cargo run -p linera-version > linera-version/api-hashes.json` now succeeds and is idempotent; before this change it failed on the truncated file.
- The new job's command, `diff linera-version/api-hashes.json <(cargo run --locked -p linera-version)`, exits 0 on this branch.
- No type or wire change: `linera-rpc`'s format snapshot is untouched.
- `cargo fmt` (pinned nightly-2025-04-03), `cargo clippy --all-targets --all-features -p linera-version` and `taplo fmt --check` are clean under Rust 1.86.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6818 removes the mechanism on `main`.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
